### PR TITLE
crypt: optionally registers keying entries with legacy paths

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/snapcore/secboot/internal/luks2"
 	"github.com/snapcore/secboot/internal/luksview"
 )
@@ -172,4 +174,12 @@ func MockHashAlgAvailable() (restore func()) {
 
 func (d *KeyData) DerivePassphraseKeys(passphrase string) (key, iv, auth []byte, err error) {
 	return d.derivePassphraseKeys(passphrase)
+}
+
+func MockUnixStat(f func(devicePath string, st *unix.Stat_t) error) (restore func()) {
+	old := unixStat
+	unixStat = f
+	return func() {
+		unixStat = old
+	}
 }


### PR DESCRIPTION
Snapd has used path of the for
/dev/disk/by-partuuid/deadbeef-dead-dead-dead-deaddeafbeef to activate LUKS2 containers.

`by-partuuid` does not make much sense because it uselessly assumes that it is a partition, where in the future we might have to do something else. It also makes the resolution of the name more complex. We have to resolve the UUID of the LUKS2 header, then query udev for a disk with that UUID, and then ask for the uuid of the partition.

Instead we should either, use a path like
`/dev/disk/by-uuid/deadbeef-dead-dead-dead-deaddeafbeef`, or `UUID=deadbeef-dead-dead-dead-deaddeafbeef`, where the UUID is the one of the LUKS2 header. Or eventually if we do not like symlinks, use `/dev/nodeN`.

Unfortunately, because snap-bootstrap in the initrd might not match exactly, at this point we cannot change the format of the paths. So we need to introduce legacy paths in the activation so that we can make sure that older snapd versions can still work.

We already know that we have to update snap-bootstrap across all our kernels before we release a new snapd. This is because an old snap-bootstrap will not be able to unlock a disk from a new snapd installation.