### PR TITLE
internal/luks2/cryptsetup.go: use --help output to check for --replace-token

### DIFF
--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -111,8 +112,9 @@ func DetectCryptsetupFeatures() Features {
 				}
 			}
 		}
-		if err := cryptsetupCmd(nil, "--test-args", "token", "import", "--token-id", "0",
-			"--token-replace", "/dev/null"); err == nil {
+		cmd = exec.Command("cryptsetup", "--help")
+		out, err = cmd.CombinedOutput()
+		if err == nil && strings.Contains(string(out), "--token-replace") {
 			features |= FeatureTokenReplace
 		}
 	})


### PR DESCRIPTION
Because --replace-token is now required for installation, we need to backport this feature to 20.04. That is on cryptsetup 2.2.2.  However that version of cryptsetup does not support --test-args.  So instead we look at the output of --help.