### PR TITLE
crypt.go: allow renaming keys without cryptsetup features

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -2962,6 +2962,48 @@ func (s *cryptSuite) TestRenameLUKS2ContainerKeyNameInUse(c *C) {
 	c.Check(RenameLUKS2ContainerKey("/dev/sda1", "foo", "bar"), ErrorMatches, "the new name is already in use")
 }
 
+func (s *cryptSuite) TestCopyAndRemoveLUKS2ContainerKey(c *C) {
+	dev := &mockLUKS2Container{
+		tokens: map[int]luks2.Token{
+			0: &luksview.KeyDataToken{
+				TokenBase: luksview.TokenBase{
+					TokenKeyslot: 0,
+					TokenName:    "foo"},
+				Priority: 10,
+				Data:     json.RawMessage("1234567890")},
+			1: &luksview.RecoveryToken{
+				TokenBase: luksview.TokenBase{
+					TokenKeyslot: 1,
+					TokenName:    "default-recovery"}},
+		},
+		keyslots: map[int][]byte{
+			0: nil,
+			1: nil,
+		},
+	}
+	s.luks2.devices["/dev/sda1"] = dev
+
+	c.Check(CopyAndRemoveLUKS2ContainerKey("/dev/sda1", "foo", "bar"), IsNil)
+
+	c.Check(s.luks2.operations, DeepEquals, []string{
+		"newLUKSView(/dev/sda1,0)",
+		"ImportToken(/dev/sda1,<nil>)",
+		"RemoveToken(/dev/sda1,0)",
+	})
+
+	// Expected token is 2 now
+	newToken, ok := dev.tokens[2]
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(newToken, DeepEquals, &luksview.KeyDataToken{
+		TokenBase: luksview.TokenBase{
+			TokenKeyslot: 0,
+			TokenName:    "bar",
+		},
+		Priority: 10,
+		Data:     json.RawMessage("1234567890"),
+	})
+}
+
 type cryptSuiteUnmockedBase struct {
 	snapd_testutil.BaseTest
 	cryptTestBase


### PR DESCRIPTION
Factory reset requires renaming of keyslots. Unfortunately `cryptsetup` on UC 20 and UC 22 do not support `--token-replace`. So we need a way rename without that feature.