### PR TITLE
tpm2: Stop using deprecated go-tpm2 APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/canonical/go-efilib v1.4.1
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
-	github.com/canonical/go-tpm2 v1.10.1
+	github.com/canonical/go-tpm2 v1.11.1
 	github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981
 	github.com/snapcore/snapd v0.0.0-20220714152900-4a1f4c93fc85
 	golang.org/x/crypto v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0/go.mod 
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=
 github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61/go.mod h1:vG41hdbBjV4+/fkubTT1ENBBqSkLwLr7mCeW9Y6kpZY=
-github.com/canonical/go-tpm2 v1.10.1 h1:TtCuiJLX5sU8GNIxEycnc51CzsDd3nXUUkin3/My9gg=
-github.com/canonical/go-tpm2 v1.10.1/go.mod h1:zK+qESVwu78XyX+NPhiBdN+zwPPDoKk4rYlQ7VUsRp4=
+github.com/canonical/go-tpm2 v1.11.1 h1:RivdSXfBWWW+eFaFNYQby5+kVgY4km9eEayot1wX/qU=
+github.com/canonical/go-tpm2 v1.11.1/go.mod h1:zK+qESVwu78XyX+NPhiBdN+zwPPDoKk4rYlQ7VUsRp4=
 github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2/go.mod h1:QoW2apR2tBl6T/4czdND/EHjL1Ia9cCmQnIj9Xe0Kt8=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981 h1:vrUzSfbhl8mzdXPzjxq4jXZPCCNLv18jy6S7aVTS2tI=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981/go.mod h1:ywdPBqUGkuuiitPpVWCfilf2/gq+frhq4CNiNs9KyHU=

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -127,13 +127,13 @@ type PcrPolicyData_v3 = pcrPolicyData_v3
 
 type PcrPolicyParams = pcrPolicyParams
 
-func NewPcrPolicyParams(key secboot.PrimaryKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name, policySequence uint64) *PcrPolicyParams {
+func NewPcrPolicyParams(key secboot.PrimaryKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounter *tpm2.NVPublic, policySequence uint64) *PcrPolicyParams {
 	return &PcrPolicyParams{
-		key:               key,
-		pcrs:              pcrs,
-		pcrDigests:        pcrDigests,
-		policyCounterName: policyCounterName,
-		policySequence:    policySequence,
+		key:            key,
+		pcrs:           pcrs,
+		pcrDigests:     pcrDigests,
+		policyCounter:  policyCounter,
+		policySequence: policySequence,
 	}
 }
 

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -193,7 +193,7 @@ func (k *sealedKeyDataBase) validateData(tpm *tpm2.TPMContext, role string) (*tp
 		return nil, keyDataError{errors.New("sealed key object has the wrong attributes")}
 	}
 
-	srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := tpm.NewResourceContext(tcg.SRKHandle)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
 	}

--- a/tpm2/keydata_v1.go
+++ b/tpm2/keydata_v1.go
@@ -22,11 +22,12 @@ package tpm2
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
-	"github.com/canonical/go-tpm2/util"
+	"github.com/canonical/go-tpm2/policyutil"
 	"github.com/snapcore/secboot"
 
 	"golang.org/x/xerrors"
@@ -75,19 +76,15 @@ func (d *keyData_v1) ValidateData(tpm *tpm2.TPMContext, role []byte) (tpm2.Resou
 
 	// Validate the type and scheme of the dynamic authorization policy signing key.
 	authPublicKey := d.PolicyData.StaticData.AuthPublicKey
-	authKeyName, err := authPublicKey.ComputeName()
-	if err != nil {
-		return nil, keyDataError{xerrors.Errorf("cannot compute name of dynamic authorization policy key: %w", err)}
-	}
 	if authPublicKey.Type != tpm2.ObjectTypeECC {
 		return nil, keyDataError{errors.New("public area of dynamic authorization policy signing key has the wrong type")}
 	}
-	authKeyScheme := authPublicKey.Params.AsymDetail(authPublicKey.Type).Scheme
+	authKeyScheme := authPublicKey.AsymDetail().Scheme
 	if authKeyScheme.Scheme != tpm2.AsymSchemeNull {
 		if authKeyScheme.Scheme != tpm2.AsymSchemeECDSA {
 			return nil, keyDataError{errors.New("dynamic authorization policy signing key has unexpected scheme")}
 		}
-		if authKeyScheme.Details.Any(authKeyScheme.Scheme).HashAlg != authPublicKey.NameAlg {
+		if authKeyScheme.AnyDetails().HashAlg != authPublicKey.NameAlg {
 			return nil, keyDataError{errors.New("dynamic authorization policy signing key algorithm must match name algorithm")}
 		}
 	}
@@ -99,7 +96,8 @@ func (d *keyData_v1) ValidateData(tpm *tpm2.TPMContext, role []byte) (tpm2.Resou
 	case pcrPolicyCounterHandle != tpm2.HandleNull && pcrPolicyCounterHandle.Type() != tpm2.HandleTypeNVIndex:
 		return nil, keyDataError{errors.New("PCR policy counter handle is invalid")}
 	case pcrPolicyCounterHandle != tpm2.HandleNull:
-		pcrPolicyCounter, err = tpm.CreateResourceContextFromTPM(pcrPolicyCounterHandle)
+		var err error
+		pcrPolicyCounter, err = tpm.NewResourceContext(pcrPolicyCounterHandle)
 		if err != nil {
 			if tpm2.IsResourceUnavailableError(err, pcrPolicyCounterHandle) {
 				return nil, keyDataError{errors.New("PCR policy counter is unavailable")}
@@ -112,11 +110,15 @@ func (d *keyData_v1) ValidateData(tpm *tpm2.TPMContext, role []byte) (tpm2.Resou
 	if !d.KeyPublic.NameAlg.Available() {
 		return nil, keyDataError{errors.New("cannot determine if static authorization policy matches sealed key object: algorithm unavailable")}
 	}
-	trial := util.ComputeAuthPolicy(d.KeyPublic.NameAlg)
-	trial.PolicyAuthorize(computeV1PcrPolicyRefFromCounterContext(pcrPolicyCounter), authKeyName)
-	trial.PolicyAuthValue()
+	builder := policyutil.NewPolicyBuilder(d.KeyPublic.NameAlg)
+	builder.RootBranch().PolicyAuthorize(computeV1PcrPolicyRefFromCounterContext(pcrPolicyCounter), authPublicKey)
+	builder.RootBranch().PolicyAuthValue()
+	expectedDigest, err := builder.Digest()
+	if err != nil {
+		return nil, keyDataError{fmt.Errorf("cannot compute expected static authorization policy digest: %w", err)}
+	}
 
-	if !bytes.Equal(trial.GetDigest(), d.KeyPublic.AuthPolicy) {
+	if !bytes.Equal(expectedDigest, d.KeyPublic.AuthPolicy) {
 		return nil, keyDataError{errors.New("the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")}
 	}
 

--- a/tpm2/keydata_v2_test.go
+++ b/tpm2/keydata_v2_test.go
@@ -26,9 +26,8 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
-	"github.com/canonical/go-tpm2/templates"
+	"github.com/canonical/go-tpm2/objectutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
-	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -59,7 +58,8 @@ func (s *keyDataV2Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
 
-	authKeyPublic := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 	mu.MustCopyValue(&authKeyPublic, authKeyPublic)
 
 	// Create a mock PCR policy counter
@@ -110,7 +110,8 @@ func (s *keyDataV2Suite) newMockImportableKeyData(c *C) KeyData {
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
 
-	authKeyPublic := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 	mu.MustCopyValue(&authKeyPublic, authKeyPublic)
 
 	// Create sealed object
@@ -139,7 +140,7 @@ func (s *keyDataV2Suite) newMockImportableKeyData(c *C) KeyData {
 	srkPub, _, _, err := s.TPM().ReadPublic(s.primary)
 	c.Assert(err, IsNil)
 
-	_, priv, symSeed, err := util.CreateDuplicationObject(sensitive, pub, srkPub, nil, nil)
+	_, priv, symSeed, err := objectutil.CreateImportable(testutil.RandReader, sensitive, pub, srkPub, nil, nil)
 	c.Assert(err, IsNil)
 
 	return &KeyData_v2{

--- a/tpm2/pcr_profile.go
+++ b/tpm2/pcr_profile.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
-	"github.com/canonical/go-tpm2/util"
+	"github.com/canonical/go-tpm2/policyutil"
 
 	"golang.org/x/xerrors"
 )
@@ -1132,7 +1132,7 @@ func (p *PCRProtectionProfile) ComputePCRDigests(tpm *tpm2.TPMContext, alg tpm2.
 	// Compute the PCR digests for all branches, making sure that they all contain values for the same sets of PCRs.
 	var pcrDigests tpm2.DigestList
 	for _, v := range values {
-		p, digest, err := util.ComputePCRDigestFromAllValues(alg, v)
+		p, digest, err := policyutil.ComputePCRDigestFromAllValues(alg, v)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("cannot compute PCR digest from values: %w", err)
 		}

--- a/tpm2/pcr_profile_test.go
+++ b/tpm2/pcr_profile_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
+	"github.com/canonical/go-tpm2/policyutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
-	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -51,7 +51,7 @@ func (s *pcrProfileSuite) testPCRProtectionProfile(c *C, data *testPCRProtection
 
 	var expectedDigests tpm2.DigestList
 	for _, v := range data.values {
-		d, _ := util.ComputePCRDigest(data.alg, expectedPcrs, v)
+		d, _ := policyutil.ComputePCRDigest(data.alg, expectedPcrs, v)
 		expectedDigests = append(expectedDigests, d)
 	}
 
@@ -1086,7 +1086,7 @@ func (s *pcrProfileTPMSuite) TestAddValueFromTPM(c *C) {
 	c.Check(pcrs, tpm2_testutil.TPMValueDeepEquals, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{23}}})
 	c.Check(digests, HasLen, 1)
 
-	expectedDigest, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{23}}}, values)
+	expectedDigest, _ := policyutil.ComputePCRDigest(tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{23}}}, values)
 	c.Check(digests[0], DeepEquals, expectedDigest)
 }
 
@@ -1112,7 +1112,7 @@ func (s *pcrProfileTPMSuite) TestAddValueFromTPMAddProfileORPropagatesSelection(
 	})
 	c.Check(digests, HasLen, 1)
 
-	expectedDigest, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{
+	expectedDigest, _ := policyutil.ComputePCRDigest(tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{
 		{Hash: tpm2.HashAlgorithmSHA1, Select: []int{23}},
 		{Hash: tpm2.HashAlgorithmSHA256, Select: []int{23}},
 	}, values)

--- a/tpm2/platform.go
+++ b/tpm2/platform.go
@@ -158,7 +158,7 @@ func (h *platformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, ol
 		return nil, xerrors.Errorf("cannot validate key data: %w", err)
 	}
 
-	srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := tpm.NewResourceContext(tcg.SRKHandle)
 	switch {
 	case tpm2.IsResourceUnavailableError(err, tcg.SRKHandle):
 		return nil, &secboot.PlatformHandlerError{

--- a/tpm2/platform_legacy_test.go
+++ b/tpm2/platform_legacy_test.go
@@ -146,7 +146,7 @@ func (s *platformLegacySuite) TestRecoverKeysErrTPMProvisioning(c *C) {
 		PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Check(err, IsNil)
 
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())

--- a/tpm2/policy_test.go
+++ b/tpm2/policy_test.go
@@ -28,8 +28,8 @@ import (
 	"strconv"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/canonical/go-tpm2/templates"
-	"github.com/canonical/go-tpm2/util"
+	"github.com/canonical/go-tpm2/objectutil"
+	"github.com/canonical/go-tpm2/policyutil"
 
 	. "gopkg.in/check.v1"
 
@@ -43,7 +43,7 @@ type policyOrTreeMixin struct{}
 func (_ policyOrTreeMixin) checkPolicyOrTree(c *C, alg tpm2.HashAlgorithmId, digests tpm2.DigestList, tree *PolicyOrTree) (policy tpm2.Digest, depth int) {
 	// Try a manual walk of the tree for every input digest
 	for i, digest := range digests {
-		trial := util.ComputeAuthPolicy(alg)
+		builder := policyutil.NewPolicyBuilder(alg)
 
 		var node *PolicyOrNode
 		for _, n := range tree.LeafNodes() {
@@ -63,15 +63,19 @@ func (_ policyOrTreeMixin) checkPolicyOrTree(c *C, alg tpm2.HashAlgorithmId, dig
 			if len(digests) == 1 {
 				digests = tpm2.DigestList{digests[0], digests[0]}
 			}
-			trial.PolicyOR(digests)
+			builder.RootBranch().PolicyOR(digests...)
 			node = node.Parent()
 		}
 
 		if i == 0 {
-			policy = trial.GetDigest()
+			var err error
+			policy, err = builder.Digest()
+			c.Assert(err, IsNil)
 			depth = d
 		} else {
-			c.Assert(trial.GetDigest(), DeepEquals, policy)
+			digest, err := builder.Digest()
+			c.Assert(err, IsNil)
+			c.Assert(digest, DeepEquals, policy)
 			c.Assert(d, Equals, depth)
 		}
 	}
@@ -114,12 +118,14 @@ type testNewPolicyOrTreeData struct {
 }
 
 func (s *policySuiteNoTPM) testNewPolicyOrTree(c *C, data *testNewPolicyOrTreeData) {
-	trial := util.ComputeAuthPolicy(data.alg)
-
-	tree, err := NewPolicyOrTree(data.alg, trial, data.digests)
+	tree, rootDigests, err := NewPolicyOrTree(data.alg, data.digests)
 	c.Assert(err, IsNil)
 
-	c.Assert(trial.GetDigest(), DeepEquals, data.expected)
+	builder := policyutil.NewPolicyBuilder(data.alg)
+	builder.RootBranch().PolicyOR(rootDigests...)
+	digest, err := builder.Digest()
+	c.Check(err, IsNil)
+	c.Check(digest, DeepEquals, data.expected)
 
 	policy, depth := s.checkPolicyOrTree(c, data.alg, data.digests, tree)
 	c.Check(policy, DeepEquals, data.expected)
@@ -196,12 +202,12 @@ func (s *policySuiteNoTPM) TestNewPolicyOrTreeDepth4(c *C) {
 }
 
 func (s *policySuiteNoTPM) TestNewPolicyOrTreeNoDigests(c *C) {
-	_, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256), nil)
+	_, _, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, nil)
 	c.Check(err, ErrorMatches, "no digests supplied")
 }
 
 func (s *policySuiteNoTPM) TestNewPolicyOrTreeTooManyDigests(c *C) {
-	_, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256), make(tpm2.DigestList, 5000))
+	_, _, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, make(tpm2.DigestList, 5000))
 	c.Check(err, ErrorMatches, "too many digests")
 }
 
@@ -223,7 +229,8 @@ func (s *policySuiteNoTPM) testNewKeyDataPolicy(c *C, data *testNewKeyDataPolicy
 	c.Assert(err, IsNil)
 	c.Assert(key, testutil.ConvertibleTo, &ecdsa.PublicKey{})
 
-	authKey := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, key.(*ecdsa.PublicKey))
+	authKey, err := objectutil.NewECCPublicKey(key.(*ecdsa.PublicKey))
+	c.Assert(err, IsNil)
 
 	pcrPolicyCounterHandle := tpm2.HandleNull
 	if data.pcrPolicyCounterPub != nil {
@@ -356,7 +363,8 @@ func (s *policySuite) testNewKeyDataPolicyLegacy(c *C, data *testNewKeyDataPolic
 	c.Assert(err, IsNil)
 	c.Assert(key, testutil.ConvertibleTo, &ecdsa.PublicKey{})
 
-	authKey := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, key.(*ecdsa.PublicKey))
+	authKey, err := objectutil.NewECCPublicKey(key.(*ecdsa.PublicKey))
+	c.Assert(err, IsNil)
 
 	pcrPolicyCounterHandle := tpm2.HandleNull
 	if data.pcrPolicyCounterPub != nil {
@@ -438,15 +446,19 @@ xtjPyepMPNg3K7iPmPopFLA5Ap8RjR1Eu9B8LllUHTqYHJY6YQ3o+CP5TQ==
 func (s *policySuite) TestPolicyOrTreeExecuteAssertions(c *C) {
 	var digests tpm2.DigestList
 	for i := 1; i < 201; i++ {
-		trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-		trial.PolicyPCR(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
-		digests = append(digests, trial.GetDigest())
+		builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+		builder.RootBranch().PolicyPCRDigest(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
+		digest, err := builder.Digest()
+		c.Check(err, IsNil)
+		digests = append(digests, digest)
 	}
 
-	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	tree, rootDigests, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, digests)
 	c.Assert(err, IsNil)
-	expectedDigest := trial.GetDigest()
+	builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+	builder.RootBranch().PolicyOR(rootDigests...)
+	expectedDigest, err := builder.Digest()
+	c.Check(err, IsNil)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeTrial, nil, tpm2.HashAlgorithmSHA256)
 
@@ -464,13 +476,14 @@ func (s *policySuite) TestPolicyOrTreeExecuteAssertions(c *C) {
 func (s *policySuite) TestPolicyOrTreeExecuteAssertionsDigestNotFound(c *C) {
 	var digests tpm2.DigestList
 	for i := 1; i < 201; i++ {
-		trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-		trial.PolicyPCR(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
-		digests = append(digests, trial.GetDigest())
+		builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+		builder.RootBranch().PolicyPCRDigest(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
+		digest, err := builder.Digest()
+		c.Check(err, IsNil)
+		digests = append(digests, digest)
 	}
 
-	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	tree, _, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, digests)
 	c.Assert(err, IsNil)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeTrial, nil, tpm2.HashAlgorithmSHA256)
@@ -500,9 +513,11 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9pYAXaeeWBHZZ9TCRXNHClxi6NBB
 	c.Assert(err, IsNil)
 	c.Assert(key, testutil.ConvertibleTo, &ecdsa.PublicKey{})
 
+	authKey, err := objectutil.NewECCPublicKey(key.(*ecdsa.PublicKey))
+	c.Assert(err, IsNil)
+
 	handle := s.NextAvailableHandle(c, 0x0181ff00)
-	pub, count, err := CreatePcrPolicyCounter(s.TPM().TPMContext, handle,
-		util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, key.(*ecdsa.PublicKey)), s.TPM().HmacSession())
+	pub, count, err := CreatePcrPolicyCounter(s.TPM().TPMContext, handle, authKey, s.TPM().HmacSession())
 	c.Assert(err, IsNil)
 	c.Check(pub.Index, Equals, handle)
 	c.Check(pub.Attrs.Type(), Equals, tpm2.NVTypeCounter)
@@ -512,7 +527,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9pYAXaeeWBHZZ9TCRXNHClxi6NBB
 	name, err := pub.ComputeName()
 	c.Check(err, IsNil)
 
-	index, err := s.TPM().CreateResourceContextFromTPM(handle)
+	index, err := s.TPM().NewResourceContext(handle)
 	c.Assert(err, IsNil)
 	c.Check(name, DeepEquals, index.Name())
 }
@@ -578,9 +593,11 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9pYAXaeeWBHZZ9TCRXNHClxi6NBB
 	c.Assert(err, IsNil)
 	c.Assert(key, testutil.ConvertibleTo, &ecdsa.PublicKey{})
 
+	authKey, err := objectutil.NewECCPublicKey(key.(*ecdsa.PublicKey))
+	c.Assert(err, IsNil)
+
 	handle := tpm2.Handle(0x0181ff00)
-	pub, count, err := CreatePcrPolicyCounter(s.TPM().TPMContext, handle,
-		util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, key.(*ecdsa.PublicKey)), s.TPM().HmacSession())
+	pub, count, err := CreatePcrPolicyCounter(s.TPM().TPMContext, handle, authKey, s.TPM().HmacSession())
 	c.Assert(err, IsNil)
 	c.Check(pub.Index, Equals, handle)
 	c.Check(pub.Attrs.Type(), Equals, tpm2.NVTypeCounter)
@@ -590,7 +607,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9pYAXaeeWBHZZ9TCRXNHClxi6NBB
 	name, err := pub.ComputeName()
 	c.Check(err, IsNil)
 
-	index, err := s.TPM().CreateResourceContextFromTPM(handle)
+	index, err := s.TPM().NewResourceContext(handle)
 	c.Assert(err, IsNil)
 	c.Check(name, DeepEquals, index.Name())
 }

--- a/tpm2/policy_v0_test.go
+++ b/tpm2/policy_v0_test.go
@@ -21,6 +21,7 @@ package tpm2_test
 
 import (
 	"crypto"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"strconv"
@@ -28,9 +29,10 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/canonical/go-tpm2/templates"
+	"github.com/canonical/go-tpm2/cryptutil"
+	"github.com/canonical/go-tpm2/objectutil"
+	"github.com/canonical/go-tpm2/policyutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
-	"github.com/canonical/go-tpm2/util"
 
 	"github.com/snapcore/secboot/internal/testutil"
 	"github.com/snapcore/secboot/internal/tpm2test"
@@ -38,8 +40,8 @@ import (
 )
 
 type policyV0Mixin struct {
-	tpmTest       *tpm2_testutil.TPMTest
-	lockIndexName tpm2.Name
+	tpmTest      *tpm2_testutil.TPMTest
+	lockIndexPub *tpm2.NVPublic
 }
 
 func (m *policyV0Mixin) createMockLockIndex(c *C) {
@@ -51,16 +53,17 @@ func (m *policyV0Mixin) createMockLockIndex(c *C) {
 
 	index := m.tpmTest.NVDefineSpace(c, tpm2.HandleOwner, nil, &pub)
 	c.Check(m.tpmTest.TPM.NVWrite(index, index, nil, 0, nil), IsNil)
-	m.lockIndexName = index.Name()
+	pub.Attrs |= tpm2.AttrNVWritten
+	m.lockIndexPub = &pub
 }
 
 func (m *policyV0Mixin) enablePolicyLock(c *C) {
-	index, err := m.tpmTest.TPM.CreateResourceContextFromTPM(LockNVHandle)
+	index, err := m.tpmTest.TPM.NewResourceContext(LockNVHandle)
 	c.Assert(err, IsNil)
 	c.Check(m.tpmTest.TPM.NVReadLock(index, index, nil), IsNil)
 }
 
-func (m *policyV0Mixin) createMockPcrPolicyCounter(c *C, handle tpm2.Handle, authKeyName tpm2.Name) (*tpm2.NVPublic, uint64, tpm2.DigestList) {
+func (m *policyV0Mixin) createMockPcrPolicyCounter(c *C, handle tpm2.Handle, authKey *tpm2.Public) (*tpm2.NVPublic, uint64, tpm2.DigestList) {
 	c.Assert(m.tpmTest, NotNil) // policyV0Mixin.tpmTest must be set!
 
 	pub := &tpm2.NVPublic{
@@ -69,15 +72,21 @@ func (m *policyV0Mixin) createMockPcrPolicyCounter(c *C, handle tpm2.Handle, aut
 		Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVPolicyRead | tpm2.AttrNVNoDA),
 		Size:    8}
 
-	trial := util.ComputeAuthPolicy(pub.NameAlg)
-	trial.PolicyNvWritten(false)
+	builder := policyutil.NewPolicyBuilder(pub.NameAlg)
+	builder.RootBranch().PolicyNvWritten(false)
+	digest, err := builder.Digest()
+	c.Check(err, IsNil)
 
-	policies := tpm2.DigestList{trial.GetDigest()}
-	policies = append(policies, ComputeV0PinNVIndexPostInitAuthPolicies(pub.NameAlg, authKeyName)...)
+	policies := tpm2.DigestList{digest}
+	extraPolicies, err := ComputeV0PinNVIndexPostInitAuthPolicies(pub.NameAlg, authKey)
+	c.Assert(err, IsNil)
+	policies = append(policies, extraPolicies...)
 
-	trial = util.ComputeAuthPolicy(pub.NameAlg)
-	trial.PolicyOR(policies)
-	pub.AuthPolicy = trial.GetDigest()
+	builder = policyutil.NewPolicyBuilder(pub.NameAlg)
+	builder.RootBranch().PolicyOR(policies...)
+	digest, err = builder.Digest()
+	c.Check(err, IsNil)
+	pub.AuthPolicy = digest
 
 	index := m.tpmTest.NVDefineSpace(c, tpm2.HandleOwner, nil, pub)
 
@@ -101,17 +110,19 @@ func (m *policyV0Mixin) createMockPcrPolicyCounter(c *C, handle tpm2.Handle, aut
 func (m *policyV0Mixin) newMockKeyDataPolicy(c *C, alg tpm2.HashAlgorithmId, authKey *tpm2.Public, pcrPolicyCounter *tpm2.NVPublic,
 	pcrPolicyCounterAuthPolicies tpm2.DigestList) (KeyDataPolicy, tpm2.Digest) {
 
-	trial := util.ComputeAuthPolicy(alg)
-	trial.PolicyAuthorize(nil, authKey.Name())
-	trial.PolicySecret(pcrPolicyCounter.Name(), nil)
-	trial.PolicyNV(m.lockIndexName, nil, 0, tpm2.OpEq)
+	builder := policyutil.NewPolicyBuilder(alg)
+	builder.RootBranch().PolicyAuthorize(nil, authKey)
+	builder.RootBranch().PolicySecret(pcrPolicyCounter, nil)
+	builder.RootBranch().PolicyNV(m.lockIndexPub, nil, 0, tpm2.OpEq)
+	policy, err := builder.Digest()
+	c.Assert(err, IsNil)
 
 	return &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{
 			AuthPublicKey:                authKey,
 			PCRPolicyCounterHandle:       pcrPolicyCounter.Index,
 			PCRPolicyCounterAuthPolicies: pcrPolicyCounterAuthPolicies},
-	}, trial.GetDigest()
+	}, policy
 }
 
 type policyV0SuiteNoTPM struct {
@@ -147,8 +158,7 @@ type testPolicyOrTreeSerializationData struct {
 }
 
 func (s *policyV0SuiteNoTPM) testPolicyOrTreeSerialization(c *C, data *testPolicyOrTreeSerializationData) {
-	trial := util.ComputeAuthPolicy(data.alg)
-	tree, err := NewPolicyOrTree(data.alg, trial, data.digests)
+	tree, _, err := NewPolicyOrTree(data.alg, data.digests)
 	c.Assert(err, IsNil)
 
 	serialized := NewPolicyOrDataV0(tree)
@@ -240,8 +250,7 @@ func (s *policyV0SuiteNoTPM) TestPolicyOrTreeResolveError(c *C) {
 		digests = append(digests, make(tpm2.Digest, crypto.SHA256.Size()))
 	}
 
-	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	tree, _, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, digests)
 	c.Assert(err, IsNil)
 
 	serialized := NewPolicyOrDataV0(tree)
@@ -254,15 +263,19 @@ func (s *policyV0SuiteNoTPM) TestPolicyOrTreeResolveError(c *C) {
 func (s *policyV0Suite) TestPolicyOrTreeExecuteAssertions(c *C) {
 	var digests tpm2.DigestList
 	for i := 1; i < 201; i++ {
-		trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-		trial.PolicyPCR(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
-		digests = append(digests, trial.GetDigest())
+		builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+		builder.RootBranch().PolicyPCRDigest(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
+		digest, err := builder.Digest()
+		c.Assert(err, IsNil)
+		digests = append(digests, digest)
 	}
 
-	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	tree, rootDigests, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, digests)
 	c.Assert(err, IsNil)
-	expectedDigest := trial.GetDigest()
+	builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+	builder.RootBranch().PolicyOR(rootDigests...)
+	expectedDigest, err := builder.Digest()
+	c.Assert(err, IsNil)
 
 	serialized := NewPolicyOrDataV0(tree)
 	tree2, err := serialized.Resolve()
@@ -327,12 +340,15 @@ func (s *policyV0SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV0UpdatePCRPoli
 		Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVPolicyRead | tpm2.AttrNVNoDA | tpm2.AttrNVWritten),
 		Size:    8}
 
+	authPublicKey, err := objectutil.NewRSAPublicKey(&key.PublicKey, objectutil.WithNameAlg(data.authKeyNameAlg))
+	c.Assert(err, IsNil)
+
 	var policyData KeyDataPolicy = &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{
-			AuthPublicKey: util.NewExternalRSAPublicKey(data.authKeyNameAlg, templates.KeyUsageSign, nil, &key.PublicKey)},
+			AuthPublicKey: authPublicKey},
 	}
 
-	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(key), data.pcrs, data.pcrDigests, policyCounterPub.Name(), data.initialSeq)
+	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(key), data.pcrs, data.pcrDigests, policyCounterPub, data.initialSeq)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.Selection, tpm2_testutil.TPMValueDeepEquals, data.pcrs)
@@ -341,9 +357,11 @@ func (s *policyV0SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV0UpdatePCRPoli
 	c.Assert(err, IsNil)
 	var digests tpm2.DigestList
 	for _, digest := range data.pcrDigests {
-		trial := util.ComputeAuthPolicy(data.alg)
-		trial.PolicyPCR(digest, data.pcrs)
-		digests = append(digests, trial.GetDigest())
+		builder := policyutil.NewPolicyBuilder(data.alg)
+		builder.RootBranch().PolicyPCRDigest(digest, data.pcrs)
+		digest, err := builder.Digest()
+		c.Assert(err, IsNil)
+		digests = append(digests, digest)
 	}
 	s.checkPolicyOrTree(c, data.alg, digests, orTree)
 
@@ -354,9 +372,8 @@ func (s *policyV0SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV0UpdatePCRPoli
 	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicySignature.SigAlg, Equals, tpm2.SigSchemeAlgRSAPSS)
 	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicySignature.Signature.RSAPSS.Hash, Equals, data.authKeyNameAlg)
 
-	digest, err := util.ComputePolicyAuthorizeDigest(data.authKeyNameAlg, policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicy, nil)
-	c.Check(err, IsNil)
-	ok, err := util.VerifySignature(&key.PublicKey, digest, policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicySignature)
+	digest := policyutil.ComputePolicyAuthorizationTBSDigest(data.authKeyNameAlg.GetHash(), policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicy, nil)
+	ok, err := cryptutil.VerifySignature(&key.PublicKey, digest, policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicySignature)
 	c.Check(err, IsNil)
 	c.Check(ok, testutil.IsTrue)
 }
@@ -467,20 +484,26 @@ func (s *policyV0SuiteNoTPM) TestSetPCRPolicyFrom(c *C) {
 		Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVPolicyRead | tpm2.AttrNVNoDA | tpm2.AttrNVWritten),
 		Size:    8}
 
+	authPublicKey, err := objectutil.NewRSAPublicKey(&key.PublicKey)
+	c.Assert(err, IsNil)
+
 	policyData1 := &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{
-			AuthPublicKey: util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &key.PublicKey)},
+			AuthPublicKey: authPublicKey},
 	}
 
 	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(key),
 		tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		tpm2.DigestList{hash(crypto.SHA256, "1"), hash(crypto.SHA256, "2")},
-		policyCounterPub.Name(), 5000)
+		policyCounterPub, 5000)
 	c.Check(policyData1.UpdatePCRPolicy(tpm2.HashAlgorithmSHA256, params), IsNil)
+
+	authPublicKey, err = objectutil.NewRSAPublicKey(&key.PublicKey)
+	c.Assert(err, IsNil)
 
 	var policyData2 KeyDataPolicy = &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{
-			AuthPublicKey: util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &key.PublicKey)}}
+			AuthPublicKey: authPublicKey}}
 	policyData2.SetPCRPolicyFrom(policyData1)
 
 	c.Check(policyData2.(*KeyDataPolicy_v0).PCRData, DeepEquals, policyData1.PCRData)
@@ -505,19 +528,20 @@ type testV0ExecutePCRPolicyData struct {
 func (s *policyV0Suite) testExecutePCRPolicy(c *C, data *testV0ExecutePCRPolicyData) {
 	authKey, err := rsa.GenerateKey(testutil.RandReader, 2048)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalRSAPublicKey(data.authKeyNameAlg, templates.KeyUsageSign, nil, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewRSAPublicKey(&authKey.PublicKey, objectutil.WithNameAlg(data.authKeyNameAlg))
+	c.Assert(err, IsNil)
 
-	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic.Name())
+	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic)
 
 	policyData, expectedDigest := s.newMockKeyDataPolicy(c, data.alg, authKeyPublic, policyCounterPub, policyCounterPolicies)
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
-		d, _ := util.ComputePCRDigest(data.alg, data.pcrs, v)
+		d, _ := policyutil.ComputePCRDigest(data.alg, data.pcrs, v)
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(authKey), data.pcrs, digests, policyCounterPub.Name(), policyCount)
+	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(authKey), data.pcrs, digests, policyCounterPub, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -814,19 +838,20 @@ type testV0ExecutePCRPolicyErrorHandlingData struct {
 func (s *policyV0Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV0ExecutePCRPolicyErrorHandlingData) error {
 	authKey, err := rsa.GenerateKey(testutil.RandReader, 2048)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalRSAPublicKey(data.authKeyNameAlg, templates.KeyUsageSign, nil, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewRSAPublicKey(&authKey.PublicKey, objectutil.WithNameAlg(data.authKeyNameAlg))
+	c.Assert(err, IsNil)
 
-	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic.Name())
+	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic)
 
 	policyData, expectedDigest := s.newMockKeyDataPolicy(c, data.alg, authKeyPublic, policyCounterPub, policyCounterPolicies)
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
-		d, _ := util.ComputePCRDigest(data.alg, data.pcrs, v)
+		d, _ := policyutil.ComputePCRDigest(data.alg, data.pcrs, v)
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(authKey), data.pcrs, digests, policyCounterPub.Name(), policyCount)
+	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(authKey), data.pcrs, digests, policyCounterPub, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -1095,18 +1120,18 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree4(c *C) {
 			},
 		},
 		fn: func(data *KeyDataPolicy_v0, key *rsa.PrivateKey) {
-			digest, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, data.PCRData.Selection, tpm2.PCRValues{
+			digest, _ := policyutil.ComputePCRDigest(tpm2.HashAlgorithmSHA256, data.PCRData.Selection, tpm2.PCRValues{
 				tpm2.HashAlgorithmSHA256: {
 					16: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1", "bar1"),
 					23: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1", "foo1"),
 				},
 			})
-			trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-			trial.PolicyPCR(digest, data.PCRData.Selection)
-			digest = trial.GetDigest()
+			builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+			builder.RootBranch().PolicyPCRDigest(digest, data.PCRData.Selection)
+			digest, err := builder.Digest()
+			c.Check(err, IsNil)
 
-			trial = util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-			orData, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, tpm2.DigestList{digest})
+			orData, _, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, tpm2.DigestList{digest})
 			c.Assert(err, IsNil)
 
 			data.PCRData.OrData = NewPolicyOrDataV0(orData)
@@ -1361,7 +1386,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 		fn: func(data *KeyDataPolicy_v0, authKey *rsa.PrivateKey) {
 			key := x509.MarshalPKCS1PrivateKey(authKey)
 
-			pub, _, err := s.TPM().NVReadPublic(tpm2.CreatePartialHandleContext(data.StaticData.PCRPolicyCounterHandle))
+			pub, _, err := s.TPM().NVReadPublic(tpm2.NewHandleContext(data.StaticData.PCRPolicyCounterHandle))
 			c.Assert(err, IsNil)
 
 			target := data.PCRData.PolicySequence
@@ -1505,16 +1530,13 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 			key, err := rsa.GenerateKey(testutil.RandReader, 2048)
 			c.Assert(err, IsNil)
 
-			data.StaticData.AuthPublicKey = util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &key.PublicKey)
-
-			scheme := &tpm2.SigScheme{
-				Scheme: tpm2.SigSchemeAlgRSAPSS,
-				Details: &tpm2.SigSchemeU{
-					RSAPSS: &tpm2.SigSchemeRSAPSS{
-						HashAlg: data.StaticData.AuthPublicKey.NameAlg}}}
-			_, signature, err := util.PolicyAuthorize(key, scheme, data.PCRData.AuthorizedPolicy, nil)
+			authPublicKey, err := objectutil.NewRSAPublicKey(&key.PublicKey)
 			c.Assert(err, IsNil)
-			data.PCRData.AuthorizedPolicySignature = signature
+			data.StaticData.AuthPublicKey = authPublicKey
+
+			auth, err := policyutil.SignPolicyAuthorization(rand.Reader, data.PCRData.AuthorizedPolicy, authPublicKey, nil, key, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256})
+			c.Assert(err, IsNil)
+			data.PCRData.AuthorizedPolicySignature = auth.Signature
 		},
 	})
 	c.Check(err, IsNil)
@@ -1553,7 +1575,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingNoLockIndex(c *C) {
 			},
 		},
 		fn: func(_ *KeyDataPolicy_v0, _ *rsa.PrivateKey) {
-			index, err := s.TPM().CreateResourceContextFromTPM(LockNVHandle)
+			index, err := s.TPM().NewResourceContext(LockNVHandle)
 			c.Assert(err, IsNil)
 			c.Check(s.TPM().NVUndefineSpace(s.TPM().OwnerHandleContext(), index, nil), IsNil)
 		},
@@ -1565,9 +1587,10 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingNoLockIndex(c *C) {
 func (s *policyV0Suite) TestPolicyCounterContextGet(c *C) {
 	authKey, err := rsa.GenerateKey(testutil.RandReader, 2048)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewRSAPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
-	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, 0x01800000), authKeyPublic.Name())
+	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, 0x01800000), authKeyPublic)
 
 	data := &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{
@@ -1586,9 +1609,10 @@ func (s *policyV0Suite) TestPolicyCounterContextGet(c *C) {
 func (s *policyV0Suite) TestPolicyCounterContextIncrement(c *C) {
 	authKey, err := rsa.GenerateKey(testutil.RandReader, 2048)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewRSAPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
-	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, 0x01800000), authKeyPublic.Name())
+	policyCounterPub, policyCount, policyCounterPolicies := s.createMockPcrPolicyCounter(c, s.NextAvailableHandle(c, 0x01800000), authKeyPublic)
 
 	data := &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{
@@ -1609,7 +1633,8 @@ func (s *policyV0Suite) TestPolicyCounterContextIncrement(c *C) {
 func (s *policyV0SuiteNoTPM) TestValidateAuthKey(c *C) {
 	authKey, err := rsa.GenerateKey(testutil.RandReader, 2048)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewRSAPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
 	data := &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{
@@ -1620,7 +1645,8 @@ func (s *policyV0SuiteNoTPM) TestValidateAuthKey(c *C) {
 func (s *policyV0SuiteNoTPM) TestValidateAuthKeyWrongKey(c *C) {
 	authKey, err := rsa.GenerateKey(testutil.RandReader, 2048)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewRSAPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
 	data := &KeyDataPolicy_v0{
 		StaticData: &StaticPolicyData_v0{

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -21,13 +21,13 @@ package tpm2
 
 import (
 	"crypto/ecdsa"
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/canonical/go-tpm2/mu"
-	"github.com/canonical/go-tpm2/util"
+	"github.com/canonical/go-tpm2/policyutil"
 
 	"golang.org/x/xerrors"
 
@@ -36,8 +36,12 @@ import (
 
 // computeV1PcrPolicyCounterAuthPolicies computes the authorization policy digests passed to
 // TPM2_PolicyOR for a PCR policy counter that can be updated with the key associated with
-// updateKeyName.
-func computeV1PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) tpm2.DigestList {
+// updateKey.
+func computeV1PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKey *tpm2.Public) (tpm2.DigestList, error) {
+	if !alg.Available() {
+		return nil, errors.New("digest algorithm is not available")
+	}
+
 	// The NV index requires 2 policies:
 	// - A policy to initialize the index with no authorization
 	// - A policy for updating the index to revoke old PCR policies using a signed assertion. This isn't done for security
@@ -48,23 +52,23 @@ func computeV1PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyNa
 	// authorization value, but it is always empty and this policy doesn't allow it to be changed).
 	var authPolicies tpm2.DigestList
 
-	if !updateKeyName.IsValid() {
-		// avoid a panic if updateKeyName is invalid. Note that this will
-		// produce invalid policies - callers should take steps to ensure that
-		// updateKeyName is valid.
-		// TODO: Use tpm2.MakeHandleName here
-		updateKeyName = tpm2.Name(mu.MustMarshalToBytes(tpm2.HandleUnassigned))
+	builder := policyutil.NewPolicyBuilder(alg)
+	builder.RootBranch().PolicyNvWritten(false)
+	digest, err := builder.Digest()
+	if err != nil {
+		return nil, err
 	}
+	authPolicies = append(authPolicies, digest)
 
-	trial := util.ComputeAuthPolicy(alg)
-	trial.PolicyNvWritten(false)
-	authPolicies = append(authPolicies, trial.GetDigest())
+	builder = policyutil.NewPolicyBuilder(alg)
+	builder.RootBranch().PolicySigned(updateKey, nil)
+	digest, err = builder.Digest()
+	if err != nil {
+		return nil, err
+	}
+	authPolicies = append(authPolicies, digest)
 
-	trial = util.ComputeAuthPolicy(alg)
-	trial.PolicySigned(updateKeyName, nil)
-	authPolicies = append(authPolicies, trial.GetDigest())
-
-	return authPolicies
+	return authPolicies, nil
 }
 
 // computeV1PcrPolicyRefFromCounterName computes the reference used for authorization of signed
@@ -141,13 +145,15 @@ func (p *keyDataPolicy_v1) PCRPolicySequence() uint64 {
 func (p *keyDataPolicy_v1) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcrPolicyParams) error {
 	pcrData := new(pcrPolicyData_v1)
 
-	trial := util.ComputeAuthPolicy(alg)
-	if err := pcrData.addPcrAssertions(alg, trial, params.pcrs, params.pcrDigests); err != nil {
+	builder, err := pcrData.addPcrAssertions(alg, params.pcrs, params.pcrDigests)
+	if err != nil {
 		return xerrors.Errorf("cannot compute base PCR policy: %w", err)
 	}
 
-	if params.policyCounterName != nil {
-		pcrData.addRevocationCheck(trial, params.policyCounterName, params.policySequence)
+	var policyCounterName tpm2.Name
+	if params.policyCounter != nil {
+		pcrData.addRevocationCheck(builder, params.policyCounter, params.policySequence)
+		policyCounterName = params.policyCounter.Name()
 	}
 
 	key, err := createECDSAPrivateKeyFromTPM(p.StaticData.AuthPublicKey, tpm2.ECCParameter(params.key))
@@ -155,12 +161,11 @@ func (p *keyDataPolicy_v1) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcr
 		return xerrors.Errorf("cannot create auth key: %w", err)
 	}
 
-	scheme := &tpm2.SigScheme{
-		Scheme: tpm2.SigSchemeAlgECDSA,
-		Details: &tpm2.SigSchemeU{
-			ECDSA: &tpm2.SigSchemeECDSA{
-				HashAlg: p.StaticData.AuthPublicKey.NameAlg}}}
-	if err := pcrData.authorizePolicy(key, scheme, trial.GetDigest(), computeV1PcrPolicyRefFromCounterName(params.policyCounterName)); err != nil {
+	approvedPolicy, err := builder.Digest()
+	if err != nil {
+		return fmt.Errorf("cannot compute approved policy: %w", err)
+	}
+	if err := pcrData.authorizePolicy(approvedPolicy, p.StaticData.AuthPublicKey, computeV1PcrPolicyRefFromCounterName(policyCounterName), key, p.StaticData.AuthPublicKey.NameAlg); err != nil {
 		return xerrors.Errorf("cannot authorize policy: %w", err)
 	}
 
@@ -185,7 +190,7 @@ func (p *keyDataPolicy_v1) ExecutePCRPolicy(tpm *tpm2.TPMContext, policySession,
 	var pcrPolicyCounter tpm2.ResourceContext
 	if pcrPolicyCounterHandle != tpm2.HandleNull {
 		var err error
-		pcrPolicyCounter, err = tpm.CreateResourceContextFromTPM(pcrPolicyCounterHandle)
+		pcrPolicyCounter, err = tpm.NewResourceContext(pcrPolicyCounterHandle)
 		switch {
 		case tpm2.IsResourceUnavailableError(err, pcrPolicyCounterHandle):
 			// If there is no NV index at the expected handle then the key file is invalid and must be recreated.
@@ -212,10 +217,10 @@ func (p *keyDataPolicy_v1) ExecutePCRPolicy(tpm *tpm2.TPMContext, policySession,
 
 	pcrPolicyRef := computeV1PcrPolicyRefFromCounterContext(pcrPolicyCounter)
 
-	pcrPolicyDigest, err := util.ComputePolicyAuthorizeDigest(authPublicKey.NameAlg, p.PCRData.AuthorizedPolicy, pcrPolicyRef)
-	if err != nil {
-		return policyDataError{xerrors.Errorf("cannot compute PCR policy digest: %w", err)}
+	if !authPublicKey.NameAlg.Available() {
+		return policyDataError{errors.New("name algorithm for auth public key is not available")}
 	}
+	pcrPolicyDigest := policyutil.ComputePolicyAuthorizationTBSDigest(authPublicKey.NameAlg.GetHash(), p.PCRData.AuthorizedPolicy, pcrPolicyRef)
 
 	authorizeTicket, err := tpm.VerifySignature(authorizeKey, pcrPolicyDigest, p.PCRData.AuthorizedPolicySignature)
 	if err != nil {
@@ -280,20 +285,19 @@ func (c *pcrPolicyCounterContext_v1) Increment(key secboot.PrimaryKey) error {
 	defer c.tpm.FlushContext(keyLoaded)
 
 	// Create a signed authorization. keyData.validate checks that this scheme is compatible with the key
-	scheme := tpm2.SigScheme{
-		Scheme: tpm2.SigSchemeAlgECDSA,
-		Details: &tpm2.SigSchemeU{
-			ECDSA: &tpm2.SigSchemeECDSA{
-				HashAlg: c.updateKey.NameAlg}}}
-	signature, err := util.SignPolicyAuthorization(ecdsaKey, &scheme, policySession.NonceTPM(), nil, nil, 0)
+	params := &policyutil.PolicySignedParams{NonceTPM: policySession.State().NonceTPM}
+	auth, err := policyutil.SignPolicySignedAuthorization(rand.Reader, params, c.updateKey, nil, ecdsaKey, c.updateKey.NameAlg)
 	if err != nil {
 		return xerrors.Errorf("cannot sign authorization: %w", err)
 	}
 
-	if _, _, err := c.tpm.PolicySigned(keyLoaded, policySession, true, nil, nil, 0, signature); err != nil {
+	if _, _, err := c.tpm.PolicySigned(keyLoaded, policySession, true, nil, nil, 0, auth.Signature); err != nil {
 		return err
 	}
-	authPolicies := computeV1PcrPolicyCounterAuthPolicies(c.index.Name().Algorithm(), c.updateKey.Name())
+	authPolicies, err := computeV1PcrPolicyCounterAuthPolicies(c.index.Name().Algorithm(), c.updateKey)
+	if err != nil {
+		return fmt.Errorf("cannot compute OR policies for index: %w", err)
+	}
 	if err := c.tpm.PolicyOR(policySession, authPolicies); err != nil {
 		return err
 	}
@@ -307,7 +311,7 @@ func (p *keyDataPolicy_v1) PCRPolicyCounterContext(tpm *tpm2.TPMContext, pub *tp
 		return nil, errors.New("NV index public area is inconsistent with metadata")
 	}
 
-	index, err := tpm2.CreateNVIndexResourceContextFromPublic(pub)
+	index, err := tpm2.NewNVIndexResourceContextFromPub(pub)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create context for NV index: %w", err)
 	}

--- a/tpm2/policy_v1_test.go
+++ b/tpm2/policy_v1_test.go
@@ -26,9 +26,10 @@ import (
 	"strconv"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/canonical/go-tpm2/templates"
+	"github.com/canonical/go-tpm2/cryptutil"
+	"github.com/canonical/go-tpm2/objectutil"
+	"github.com/canonical/go-tpm2/policyutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
-	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -103,12 +104,15 @@ func (s *policyV1SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV1UpdatePCRPoli
 		policyCounterName = policyCounterPub.Name()
 	}
 
+	authPublicKey, err := objectutil.NewECCPublicKey(&key.PublicKey, objectutil.WithNameAlg(data.authKeyNameAlg))
+	c.Assert(err, IsNil)
+
 	var policyData KeyDataPolicy = &KeyDataPolicy_v1{
 		StaticData: &StaticPolicyData_v1{
-			AuthPublicKey: util.NewExternalECCPublicKey(data.authKeyNameAlg, templates.KeyUsageSign, nil, &key.PublicKey)},
+			AuthPublicKey: authPublicKey},
 	}
 
-	params := NewPcrPolicyParams(key.D.Bytes(), data.pcrs, data.pcrDigests, policyCounterName, data.initialSeq)
+	params := NewPcrPolicyParams(key.D.Bytes(), data.pcrs, data.pcrDigests, policyCounterPub, data.initialSeq)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	c.Check(policyData.(*KeyDataPolicy_v1).PCRData.Selection, tpm2_testutil.TPMValueDeepEquals, data.pcrs)
@@ -117,9 +121,11 @@ func (s *policyV1SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV1UpdatePCRPoli
 	c.Assert(err, IsNil)
 	var digests tpm2.DigestList
 	for _, digest := range data.pcrDigests {
-		trial := util.ComputeAuthPolicy(data.alg)
-		trial.PolicyPCR(digest, data.pcrs)
-		digests = append(digests, trial.GetDigest())
+		builder := policyutil.NewPolicyBuilder(data.alg)
+		builder.RootBranch().PolicyPCRDigest(digest, data.pcrs)
+		digest, err := builder.Digest()
+		c.Assert(err, IsNil)
+		digests = append(digests, digest)
 	}
 	s.checkPolicyOrTree(c, data.alg, digests, orTree)
 
@@ -134,11 +140,11 @@ func (s *policyV1SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV1UpdatePCRPoli
 	c.Check(policyData.(*KeyDataPolicy_v1).PCRData.AuthorizedPolicySignature.SigAlg, Equals, tpm2.SigSchemeAlgECDSA)
 	c.Check(policyData.(*KeyDataPolicy_v1).PCRData.AuthorizedPolicySignature.Signature.ECDSA.Hash, Equals, data.authKeyNameAlg)
 
-	digest, err := util.ComputePolicyAuthorizeDigest(data.authKeyNameAlg,
+	digest := policyutil.ComputePolicyAuthorizationTBSDigest(data.authKeyNameAlg.GetHash(),
 		policyData.(*KeyDataPolicy_v1).PCRData.AuthorizedPolicy,
 		ComputeV1PcrPolicyRefFromCounterName(policyCounterName))
 	c.Check(err, IsNil)
-	ok, err := util.VerifySignature(&key.PublicKey, digest, policyData.(*KeyDataPolicy_v1).PCRData.AuthorizedPolicySignature)
+	ok, err := cryptutil.VerifySignature(&key.PublicKey, digest, policyData.(*KeyDataPolicy_v1).PCRData.AuthorizedPolicySignature)
 	c.Check(err, IsNil)
 	c.Check(ok, testutil.IsTrue)
 }
@@ -260,20 +266,26 @@ func (s *policyV1SuiteNoTPM) TestSetPCRPolicyFrom(c *C) {
 		Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVPolicyRead | tpm2.AttrNVNoDA | tpm2.AttrNVWritten),
 		Size:    8}
 
+	authPublicKey, err := objectutil.NewECCPublicKey(&key.PublicKey)
+	c.Assert(err, IsNil)
+
 	policyData1 := &KeyDataPolicy_v1{
 		StaticData: &StaticPolicyData_v1{
-			AuthPublicKey: util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &key.PublicKey)},
+			AuthPublicKey: authPublicKey},
 	}
 
 	params := NewPcrPolicyParams(key.D.Bytes(),
 		tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		tpm2.DigestList{hash(crypto.SHA256, "1"), hash(crypto.SHA256, "2")},
-		policyCounterPub.Name(), 5000)
+		policyCounterPub, 5000)
 	c.Check(policyData1.UpdatePCRPolicy(tpm2.HashAlgorithmSHA256, params), IsNil)
+
+	authPublicKey, err = objectutil.NewECCPublicKey(&key.PublicKey)
+	c.Assert(err, IsNil)
 
 	var policyData2 KeyDataPolicy = &KeyDataPolicy_v1{
 		StaticData: &StaticPolicyData_v1{
-			AuthPublicKey: util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &key.PublicKey)}}
+			AuthPublicKey: authPublicKey}}
 	policyData2.SetPCRPolicyFrom(policyData1)
 
 	c.Check(policyData2.(*KeyDataPolicy_v1).PCRData, DeepEquals, policyData1.PCRData)
@@ -293,15 +305,14 @@ type testV1ExecutePCRPolicyData struct {
 func (s *policyV1Suite) testExecutePCRPolicy(c *C, data *testV1ExecutePCRPolicyData) {
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalECCPublicKey(data.authKeyNameAlg, templates.KeyUsageSign, nil, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey, objectutil.WithNameAlg(data.authKeyNameAlg))
+	c.Assert(err, IsNil)
 
 	var policyCounterPub *tpm2.NVPublic
 	var policyCount uint64
-	var policyCounterName tpm2.Name
 	if data.policyCounterHandle != tpm2.HandleNull {
 		policyCounterPub, policyCount, err = CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
 		c.Assert(err, IsNil)
-		policyCounterName = policyCounterPub.Name()
 	}
 
 	policyData, expectedDigest, err := NewKeyDataPolicyLegacy(data.alg, authKeyPublic, policyCounterPub, policyCount)
@@ -310,11 +321,11 @@ func (s *policyV1Suite) testExecutePCRPolicy(c *C, data *testV1ExecutePCRPolicyD
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
-		d, _ := util.ComputePCRDigest(data.alg, data.pcrs, v)
+		d, _ := policyutil.ComputePCRDigest(data.alg, data.pcrs, v)
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(authKey.D.Bytes(), data.pcrs, digests, policyCounterName, policyCount)
+	params := NewPcrPolicyParams(authKey.D.Bytes(), data.pcrs, digests, policyCounterPub, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -646,15 +657,14 @@ type testV1ExecutePCRPolicyErrorHandlingData struct {
 func (s *policyV1Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV1ExecutePCRPolicyErrorHandlingData) error {
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalECCPublicKey(data.authKeyNameAlg, templates.KeyUsageSign, nil, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey, objectutil.WithNameAlg(data.authKeyNameAlg))
+	c.Assert(err, IsNil)
 
 	var policyCounterPub *tpm2.NVPublic
 	var policyCount uint64
-	var policyCounterName tpm2.Name
 	if data.policyCounterHandle != tpm2.HandleNull {
 		policyCounterPub, policyCount, err = CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
 		c.Assert(err, IsNil)
-		policyCounterName = policyCounterPub.Name()
 	}
 
 	policyData, expectedDigest, err := NewKeyDataPolicyLegacy(data.alg, authKeyPublic, policyCounterPub, policyCount)
@@ -663,11 +673,11 @@ func (s *policyV1Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV1Exec
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
-		d, _ := util.ComputePCRDigest(data.alg, data.pcrs, v)
+		d, _ := policyutil.ComputePCRDigest(data.alg, data.pcrs, v)
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(authKey.D.Bytes(), data.pcrs, digests, policyCounterName, policyCount)
+	params := NewPcrPolicyParams(authKey.D.Bytes(), data.pcrs, digests, policyCounterPub, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -936,18 +946,19 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree4(c *C) {
 			},
 		},
 		fn: func(data *KeyDataPolicy_v1, key *ecdsa.PrivateKey) {
-			digest, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, data.PCRData.Selection, tpm2.PCRValues{
+			digest, _ := policyutil.ComputePCRDigest(tpm2.HashAlgorithmSHA256, data.PCRData.Selection, tpm2.PCRValues{
 				tpm2.HashAlgorithmSHA256: {
 					16: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1", "bar1"),
 					23: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1", "foo1"),
 				},
 			})
-			trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-			trial.PolicyPCR(digest, data.PCRData.Selection)
-			digest = trial.GetDigest()
 
-			trial = util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-			orData, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, tpm2.DigestList{digest})
+			builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+			builder.RootBranch().PolicyPCRDigest(digest, data.PCRData.Selection)
+			digest, err := builder.Digest()
+			c.Check(err, IsNil)
+
+			orData, _, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, tpm2.DigestList{digest})
 			c.Assert(err, IsNil)
 
 			data.PCRData.OrData = NewPolicyOrDataV0(orData)
@@ -1202,7 +1213,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 			},
 		},
 		fn: func(data *KeyDataPolicy_v1, authKey *ecdsa.PrivateKey) {
-			pub, _, err := s.TPM().NVReadPublic(tpm2.CreatePartialHandleContext(data.StaticData.PCRPolicyCounterHandle))
+			pub, _, err := s.TPM().NVReadPublic(tpm2.NewHandleContext(data.StaticData.PCRPolicyCounterHandle))
 			c.Assert(err, IsNil)
 
 			target := data.PCRData.PolicySequence
@@ -1346,16 +1357,13 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 			key, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 			c.Assert(err, IsNil)
 
-			data.StaticData.AuthPublicKey = util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &key.PublicKey)
-
-			scheme := &tpm2.SigScheme{
-				Scheme: tpm2.SigSchemeAlgECDSA,
-				Details: &tpm2.SigSchemeU{
-					ECDSA: &tpm2.SigSchemeECDSA{
-						HashAlg: data.StaticData.AuthPublicKey.NameAlg}}}
-			_, signature, err := util.PolicyAuthorize(key, scheme, data.PCRData.AuthorizedPolicy, ComputeV1PcrPolicyRefFromCounterName(nil))
+			authPublicKey, err := objectutil.NewECCPublicKey(&key.PublicKey)
 			c.Assert(err, IsNil)
-			data.PCRData.AuthorizedPolicySignature = signature
+			data.StaticData.AuthPublicKey = authPublicKey
+
+			auth, err := policyutil.SignPolicyAuthorization(testutil.RandReader, data.PCRData.AuthorizedPolicy, authPublicKey, ComputeV1PcrPolicyRefFromCounterName(nil), key, tpm2.HashAlgorithmSHA256)
+			c.Assert(err, IsNil)
+			data.PCRData.AuthorizedPolicySignature = auth.Signature
 		},
 	})
 	c.Check(err, IsNil)
@@ -1364,7 +1372,8 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 func (s *policyV1Suite) TestPolicyCounterContextGet(c *C) {
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
 	policyCounterPub, policyCount, err := CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, 0x01800000), authKeyPublic, s.TPM().HmacSession())
 	c.Assert(err, IsNil)
@@ -1385,7 +1394,8 @@ func (s *policyV1Suite) TestPolicyCounterContextGet(c *C) {
 func (s *policyV1Suite) TestPolicyCounterContextIncrement(c *C) {
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
 	policyCounterPub, policyCount, err := CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, 0x01800000), authKeyPublic, s.TPM().HmacSession())
 	c.Assert(err, IsNil)
@@ -1408,7 +1418,8 @@ func (s *policyV1Suite) TestPolicyCounterContextIncrement(c *C) {
 func (s *policyV1SuiteNoTPM) TestValidateAuthKey(c *C) {
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
 	data := &KeyDataPolicy_v1{
 		StaticData: &StaticPolicyData_v1{
@@ -1419,7 +1430,8 @@ func (s *policyV1SuiteNoTPM) TestValidateAuthKey(c *C) {
 func (s *policyV1SuiteNoTPM) TestValidateAuthKeyWrongKey(c *C) {
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
-	authKeyPublic := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
+	authKeyPublic, err := objectutil.NewECCPublicKey(&authKey.PublicKey)
+	c.Assert(err, IsNil)
 
 	data := &KeyDataPolicy_v1{
 		StaticData: &StaticPolicyData_v1{

--- a/tpm2/policy_v2.go
+++ b/tpm2/policy_v2.go
@@ -23,8 +23,8 @@ import (
 	"github.com/canonical/go-tpm2"
 )
 
-func computeV2PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) tpm2.DigestList {
-	return computeV1PcrPolicyCounterAuthPolicies(alg, updateKeyName)
+func computeV2PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKey *tpm2.Public) (tpm2.DigestList, error) {
+	return computeV1PcrPolicyCounterAuthPolicies(alg, updateKey)
 }
 
 func computeV2PcrPolicyRefFromCounterName(name tpm2.Name) tpm2.Nonce {

--- a/tpm2/policy_v3_test.go
+++ b/tpm2/policy_v3_test.go
@@ -27,9 +27,10 @@ import (
 	"strconv"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/canonical/go-tpm2/templates"
+	"github.com/canonical/go-tpm2/cryptutil"
+	"github.com/canonical/go-tpm2/objectutil"
+	"github.com/canonical/go-tpm2/policyutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
-	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -45,7 +46,9 @@ func (_ policyV3Mixin) newPolicyAuthPublicKey(c *C, nameAlg tpm2.HashAlgorithmId
 	ecdsaKey, err := DeriveV3PolicyAuthKey(nameAlg.GetHash(), key)
 	c.Assert(err, IsNil)
 
-	return util.NewExternalECCPublicKey(nameAlg, templates.KeyUsageSign, nil, &ecdsaKey.PublicKey)
+	pubKey, err := objectutil.NewECCPublicKey(&ecdsaKey.PublicKey, objectutil.WithNameAlg(nameAlg))
+	c.Assert(err, IsNil)
+	return pubKey
 }
 
 type policyV3SuiteNoTPM struct {
@@ -128,14 +131,12 @@ func (s *policyV3SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV3UpdatePCRPoli
 	authPublicKey := s.newPolicyAuthPublicKey(c, data.authKeyNameAlg, key)
 
 	var policyCounterPub *tpm2.NVPublic
-	var policyCounterName tpm2.Name
 	if data.policyCounterHandle != tpm2.HandleNull {
 		policyCounterPub = &tpm2.NVPublic{
 			Index:   data.policyCounterHandle,
 			NameAlg: tpm2.HashAlgorithmSHA256,
 			Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVPolicyRead | tpm2.AttrNVNoDA | tpm2.AttrNVWritten),
 			Size:    8}
-		policyCounterName = policyCounterPub.Name()
 	}
 
 	var policyData KeyDataPolicy = &KeyDataPolicy_v3{
@@ -143,7 +144,7 @@ func (s *policyV3SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV3UpdatePCRPoli
 			AuthPublicKey: authPublicKey},
 	}
 
-	params := NewPcrPolicyParams(key, data.pcrs, data.pcrDigests, policyCounterName, 1)
+	params := NewPcrPolicyParams(key, data.pcrs, data.pcrDigests, policyCounterPub, 1)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	c.Check(policyData.(*KeyDataPolicy_v3).PCRData.Selection, tpm2_testutil.TPMValueDeepEquals, data.pcrs)
@@ -152,9 +153,11 @@ func (s *policyV3SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV3UpdatePCRPoli
 	c.Assert(err, IsNil)
 	var digests tpm2.DigestList
 	for _, digest := range data.pcrDigests {
-		trial := util.ComputeAuthPolicy(data.alg)
-		trial.PolicyPCR(digest, data.pcrs)
-		digests = append(digests, trial.GetDigest())
+		builder := policyutil.NewPolicyBuilder(data.alg)
+		builder.RootBranch().PolicyPCRDigest(digest, data.pcrs)
+		policy, err := builder.Digest()
+		c.Check(err, IsNil)
+		digests = append(digests, policy)
 	}
 	s.checkPolicyOrTree(c, data.alg, digests, orTree)
 
@@ -165,11 +168,11 @@ func (s *policyV3SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV3UpdatePCRPoli
 	c.Check(policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicySignature.SigAlg, Equals, tpm2.SigSchemeAlgECDSA)
 	c.Check(policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicySignature.Signature.ECDSA.Hash, Equals, data.authKeyNameAlg)
 
-	digest, err := util.ComputePolicyAuthorizeDigest(data.authKeyNameAlg,
+	digest := policyutil.ComputePolicyAuthorizationTBSDigest(data.authKeyNameAlg.GetHash(),
 		policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicy,
 		policyData.(*KeyDataPolicy_v3).StaticData.PCRPolicyRef)
 	c.Check(err, IsNil)
-	ok, err := util.VerifySignature(authPublicKey.Public(), digest, policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicySignature)
+	ok, err := cryptutil.VerifySignature(authPublicKey.Public(), digest, policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicySignature)
 	c.Check(err, IsNil)
 	c.Check(ok, testutil.IsTrue)
 }
@@ -299,7 +302,7 @@ func (s *policyV3SuiteNoTPM) TestSetPCRPolicyFrom(c *C) {
 	params := NewPcrPolicyParams(key,
 		tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		tpm2.DigestList{hash(crypto.SHA256, "1"), hash(crypto.SHA256, "2")},
-		policyCounterPub.Name(), 5000)
+		policyCounterPub, 5000)
 	c.Check(policyData1.UpdatePCRPolicy(tpm2.HashAlgorithmSHA256, params), IsNil)
 
 	var policyData2 KeyDataPolicy = &KeyDataPolicy_v3{
@@ -328,12 +331,10 @@ func (s *policyV3Suite) testExecutePCRPolicy(c *C, data *testV3ExecutePCRPolicyD
 	authKeyPublic := s.newPolicyAuthPublicKey(c, data.authKeyNameAlg, primaryKey)
 
 	var policyCounterPub *tpm2.NVPublic
-	var policyCounterName tpm2.Name
 	if data.policyCounterHandle != tpm2.HandleNull {
 		var err error
 		policyCounterPub, err = EnsurePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
 		c.Assert(err, IsNil)
-		policyCounterName = policyCounterPub.Name()
 	}
 
 	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, "", policyCounterPub, false)
@@ -351,11 +352,11 @@ func (s *policyV3Suite) testExecutePCRPolicy(c *C, data *testV3ExecutePCRPolicyD
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
-		d, _ := util.ComputePCRDigest(data.alg, data.pcrs, v)
+		d, _ := policyutil.ComputePCRDigest(data.alg, data.pcrs, v)
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(primaryKey, data.pcrs, digests, policyCounterName, policyCount)
+	params := NewPcrPolicyParams(primaryKey, data.pcrs, digests, policyCounterPub, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -691,12 +692,10 @@ func (s *policyV3Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV3Exec
 	authKeyPublic := s.newPolicyAuthPublicKey(c, data.authKeyNameAlg, primaryKey)
 
 	var policyCounterPub *tpm2.NVPublic
-	var policyCounterName tpm2.Name
 	if data.policyCounterHandle != tpm2.HandleNull {
 		var err error
 		policyCounterPub, err = EnsurePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
 		c.Assert(err, IsNil)
-		policyCounterName = policyCounterPub.Name()
 	}
 
 	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, "", policyCounterPub, false)
@@ -714,11 +713,11 @@ func (s *policyV3Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV3Exec
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
-		d, _ := util.ComputePCRDigest(data.alg, data.pcrs, v)
+		d, _ := policyutil.ComputePCRDigest(data.alg, data.pcrs, v)
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(primaryKey, data.pcrs, digests, policyCounterName, policyCount)
+	params := NewPcrPolicyParams(primaryKey, data.pcrs, digests, policyCounterPub, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -987,18 +986,18 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree4(c *C) {
 			},
 		},
 		fn: func(data *KeyDataPolicy_v3, _ secboot.PrimaryKey) {
-			digest, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, data.PCRData.Selection, tpm2.PCRValues{
+			digest, _ := policyutil.ComputePCRDigest(tpm2.HashAlgorithmSHA256, data.PCRData.Selection, tpm2.PCRValues{
 				tpm2.HashAlgorithmSHA256: {
 					16: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1", "bar1"),
 					23: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1", "foo1"),
 				},
 			})
-			trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-			trial.PolicyPCR(digest, data.PCRData.Selection)
-			digest = trial.GetDigest()
+			builder := policyutil.NewPolicyBuilder(tpm2.HashAlgorithmSHA256)
+			builder.RootBranch().PolicyPCRDigest(digest, data.PCRData.Selection)
+			digest, err := builder.Digest()
+			c.Check(err, IsNil)
 
-			trial = util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-			orData, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, tpm2.DigestList{digest})
+			orData, _, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, tpm2.DigestList{digest})
 			c.Assert(err, IsNil)
 
 			data.PCRData.OrData = NewPolicyOrDataV0(orData)
@@ -1234,7 +1233,7 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 
 	var digests tpm2.DigestList
 	for _, v := range pcrValues {
-		d, _ := util.ComputePCRDigest(alg, pcrs, v)
+		d, _ := policyutil.ComputePCRDigest(alg, pcrs, v)
 		digests = append(digests, d)
 	}
 
@@ -1263,7 +1262,7 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 			},
 		},
 		fn: func(data *KeyDataPolicy_v3, primaryKey secboot.PrimaryKey) {
-			pub, _, err := s.TPM().NVReadPublic(tpm2.CreatePartialHandleContext(data.StaticData.PCRPolicyCounterHandle))
+			pub, _, err := s.TPM().NVReadPublic(tpm2.NewHandleContext(data.StaticData.PCRPolicyCounterHandle))
 			c.Assert(err, IsNil)
 
 			target := data.PCRData.PolicySequence
@@ -1271,9 +1270,8 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 			authKeyPublic := s.newPolicyAuthPublicKey(c, alg, primaryKey)
 			policyCounterPub, err := EnsurePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, 0x01800000), authKeyPublic, s.TPM().HmacSession())
 			c.Assert(err, IsNil)
-			policyCounterName := policyCounterPub.Name()
 
-			params := NewPcrPolicyParams(primaryKey, pcrs, digests, policyCounterName, target+1)
+			params := NewPcrPolicyParams(primaryKey, pcrs, digests, policyCounterPub, target+1)
 			data.UpdatePCRPolicy(alg, params)
 
 			context, err := data.PCRPolicyCounterContext(s.TPM().TPMContext, pub)
@@ -1415,16 +1413,13 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 			key, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 			c.Assert(err, IsNil)
 
-			data.StaticData.AuthPublicKey = util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, &key.PublicKey)
-
-			scheme := &tpm2.SigScheme{
-				Scheme: tpm2.SigSchemeAlgECDSA,
-				Details: &tpm2.SigSchemeU{
-					ECDSA: &tpm2.SigSchemeECDSA{
-						HashAlg: data.StaticData.AuthPublicKey.NameAlg}}}
-			_, signature, err := util.PolicyAuthorize(key, scheme, data.PCRData.AuthorizedPolicy, ComputeV3PcrPolicyRef(tpm2.HashAlgorithmSHA256, []byte(""), nil))
+			authPublicKey, err := objectutil.NewECCPublicKey(&key.PublicKey)
 			c.Assert(err, IsNil)
-			data.PCRData.AuthorizedPolicySignature = signature
+			data.StaticData.AuthPublicKey = authPublicKey
+
+			auth, err := policyutil.SignPolicyAuthorization(testutil.RandReader, data.PCRData.AuthorizedPolicy, authPublicKey, ComputeV3PcrPolicyRef(tpm2.HashAlgorithmSHA256, []byte(""), nil), key, tpm2.HashAlgorithmSHA256)
+			c.Assert(err, IsNil)
+			data.PCRData.AuthorizedPolicySignature = auth.Signature
 		},
 	})
 	c.Check(err, IsNil)

--- a/tpm2/provisioning.go
+++ b/tpm2/provisioning.go
@@ -73,7 +73,7 @@ const (
 // attribute set, and is used for authenticating with the relevant hierarchies to avoid sending the
 // authorization value in the clear.
 func provisionPrimaryKey(tpm *tpm2.TPMContext, hierarchy tpm2.ResourceContext, template *tpm2.Public, handle tpm2.Handle, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
-	obj, err := tpm.CreateResourceContextFromTPM(handle)
+	obj, err := tpm.NewResourceContext(handle)
 	switch {
 	case err != nil && !tpm2.IsResourceUnavailableError(err, handle):
 		// Unexpected error
@@ -107,7 +107,7 @@ func provisionPrimaryKey(tpm *tpm2.TPMContext, hierarchy tpm2.ResourceContext, t
 // the authorization value in the clear.
 // XXX: The NV index should be created with the TPMA_NV_AUTHREAD attribute to avoid this entirely.
 func selectSrkTemplate(tpm *tpm2.TPMContext, session tpm2.SessionContext) *tpm2.Public {
-	nv, err := tpm.CreateResourceContextFromTPM(srkTemplateHandle)
+	nv, err := tpm.NewResourceContext(srkTemplateHandle)
 	if err != nil {
 		return tcg.SRKTemplate
 	}
@@ -176,7 +176,7 @@ func storeSrkTemplate(tpm *tpm2.TPMContext, template *tpm2.Public, session tpm2.
 // is one. If a session is supplied, it must be a HMAC session and is used for authenticating
 // with the storage hierarchy to avoid sending the authorization value in the clear.
 func removeStoredSrkTemplate(tpm *tpm2.TPMContext, session tpm2.SessionContext) error {
-	nv, err := tpm.CreateResourceContextFromTPM(srkTemplateHandle)
+	nv, err := tpm.NewResourceContext(srkTemplateHandle)
 	switch {
 	case err != nil && !tpm2.IsResourceUnavailableError(err, srkTemplateHandle):
 		// Unexpected error

--- a/tpm2/provisioning_test.go
+++ b/tpm2/provisioning_test.go
@@ -44,7 +44,7 @@ func (m *primaryKeyMixin) validatePrimaryKeyAgainstTemplate(c *C, hierarchy, han
 	expected := m.tpmTest.CreatePrimary(c, hierarchy, template)
 	defer m.tpmTest.TPM.FlushContext(expected)
 
-	key, err := m.tpmTest.TPM.CreateResourceContextFromTPM(handle)
+	key, err := m.tpmTest.TPM.NewResourceContext(handle)
 	c.Assert(err, IsNil)
 	c.Check(key.Name(), DeepEquals, expected.Name())
 }
@@ -297,7 +297,7 @@ func (s *provisioningSuite) testProvisionRecreateEK(c *C, mode ProvisionMode) {
 
 	origHmacSession := s.TPM().HmacSession()
 
-	ek, err := s.TPM().CreateResourceContextFromTPM(tcg.EKHandle)
+	ek, err := s.TPM().NewResourceContext(tcg.EKHandle)
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, ek, ek.Handle())
 
@@ -331,7 +331,7 @@ func (s *provisioningSuite) testProvisionRecreateSRK(c *C, mode ProvisionMode) {
 		s.HierarchyChangeAuth(c, tpm2.HandleLockout, nil)
 	})
 
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 	expectedName := srk.Name()
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
@@ -341,7 +341,7 @@ func (s *provisioningSuite) testProvisionRecreateSRK(c *C, mode ProvisionMode) {
 	s.validateEK(c)
 	s.validateSRK(c)
 
-	srk, err = s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err = s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 	c.Check(srk.Name(), DeepEquals, expectedName)
 }
@@ -393,7 +393,7 @@ func (s *provisioningSuite) testProvisionWithCustomSRKTemplate(c *C, mode Provis
 
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, &template)
 
-	nv, err := s.TPM().CreateResourceContextFromTPM(0x01810001)
+	nv, err := s.TPM().NewResourceContext(0x01810001)
 	c.Assert(err, IsNil)
 
 	nvPub, _, err := s.TPM().NVReadPublic(nv)
@@ -457,7 +457,7 @@ func (s *provisioningSuite) testProvisionDefaultPreservesCustomSRKTemplate(c *C,
 		s.HierarchyChangeAuth(c, tpm2.HandleLockout, nil)
 	})
 
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
@@ -532,7 +532,7 @@ func (s *provisioningSuite) TestProvisionWithCustomSRKTemplateOverwritesExisting
 	c.Check(s.TPM().EnsureProvisionedWithCustomSRK(ProvisionModeFull, nil, &template2), IsNil)
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, &template2)
 
-	nv, err := s.TPM().CreateResourceContextFromTPM(0x01810001)
+	nv, err := s.TPM().NewResourceContext(0x01810001)
 	c.Assert(err, IsNil)
 
 	nvPub, _, err := s.TPM().NVReadPublic(nv)

--- a/tpm2/seal_legacy_test.go
+++ b/tpm2/seal_legacy_test.go
@@ -123,7 +123,7 @@ func (s *sealLegacySuite) TestSealKeyToTPMWithNewConnection(c *C) {
 
 func (s *sealLegacySuite) TestSealKeyToTPMMissingSRK(c *C) {
 	// Ensure that calling SealKeyToTPM recreates the SRK with the standard template
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
@@ -139,7 +139,7 @@ func (s *sealLegacySuite) TestSealKeyToTPMMissingSRK(c *C) {
 func (s *sealLegacySuite) TestSealKeyToTPMMissingCustomSRK(c *C) {
 	// Ensure that calling SealKeyToTPM recreates the SRK with the custom
 	// template originally supplied during provisioning
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
@@ -180,7 +180,7 @@ func (s *sealLegacySuite) TestSealKeyToTPMMissingSRKWithInvalidCustomTemplate(c 
 	// Ensure that calling SealKeyToTPM recreates the SRK with the standard
 	// template if the NV index we use to store custom templates has invalid
 	// contents - if the contents are invalid then we didn't create it.
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
@@ -332,7 +332,7 @@ func (s *sealLegacySuite) TestSealKeyToTPMMultipleWithNewConnection(c *C) {
 func (s *sealLegacySuite) TestSealKeyToTPMMultipleMissingSRK(c *C) {
 	// Ensure that calling SealKeyToTPMMultiple recreates the SRK with the standard
 	// template
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
@@ -377,7 +377,7 @@ func (s *sealLegacySuite) testSealKeyToTPMErrorHandling(c *C, params *KeyCreatio
 	var origCounter tpm2.ResourceContext
 	if params != nil && params.PCRPolicyCounterHandle != tpm2.HandleNull {
 		var err error
-		origCounter, err = s.TPM().CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
+		origCounter, err = s.TPM().NewResourceContext(params.PCRPolicyCounterHandle)
 		if tpm2.IsResourceUnavailableError(err, params.PCRPolicyCounterHandle) {
 			err = nil
 		}
@@ -398,7 +398,7 @@ func (s *sealLegacySuite) testSealKeyToTPMErrorHandling(c *C, params *KeyCreatio
 	var counter tpm2.ResourceContext
 	if params != nil && params.PCRPolicyCounterHandle != tpm2.HandleNull {
 		var err error
-		counter, err = s.TPM().CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
+		counter, err = s.TPM().NewResourceContext(params.PCRPolicyCounterHandle)
 		if tpm2.IsResourceUnavailableError(err, params.PCRPolicyCounterHandle) {
 			err = nil
 		}
@@ -476,7 +476,7 @@ func (s *sealLegacySuite) TestSealKeyToTPMErrorHandlingWrongCurve(c *C) {
 }
 
 func (s *sealLegacySuite) testSealKeyToExternalTPMStorageKey(c *C, params *KeyCreationParams) {
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 
 	srkPub, _, _, err := s.TPM().ReadPublic(srk)
@@ -540,7 +540,7 @@ func (s *sealLegacySuite) TestSealKeyToExternalTPMStorageKeyWithProvidedAuthKey(
 }
 
 func (s *sealLegacySuite) testSealKeyToExternalTPMStorageKeyErrorHandling(c *C, params *KeyCreationParams) error {
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 
 	srkPub, _, _, err := s.TPM().ReadPublic(srk)

--- a/tpm2/snapmodel_policy_test.go
+++ b/tpm2/snapmodel_policy_test.go
@@ -23,8 +23,8 @@ import (
 	"encoding/binary"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/policyutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
-	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -61,7 +61,7 @@ func (s *snapModelProfileSuite) testAddSnapModelProfile(c *C, data *testAddSnapM
 	expectedPcrs = expectedPcrs.MustMerge(tpm2.PCRSelectionList{{Hash: data.params.PCRAlgorithm, Select: []int{data.params.PCRIndex}}})
 	var expectedDigests tpm2.DigestList
 	for _, v := range data.values {
-		d, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
+		d, _ := policyutil.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
 		expectedDigests = append(expectedDigests, d)
 	}
 

--- a/tpm2/tpm.go
+++ b/tpm2/tpm.go
@@ -89,7 +89,7 @@ func (t *Connection) init() (err error) {
 	}
 	t.provisionedSrk = nil
 
-	ek, err := t.CreateResourceContextFromTPM(tcg.EKHandle)
+	ek, err := t.NewResourceContext(tcg.EKHandle)
 	switch {
 	case tpm2.IsResourceUnavailableError(err, tcg.EKHandle):
 		// ok

--- a/tpm2/tpm_test.go
+++ b/tpm2/tpm_test.go
@@ -23,7 +23,7 @@ import (
 	"crypto/x509"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/canonical/go-tpm2/templates"
+	"github.com/canonical/go-tpm2/objectutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 
 	. "gopkg.in/check.v1"
@@ -144,7 +144,7 @@ func (s *tpmSuite) TestConnectToDefaultTPMProvisioned(c *C) {
 }
 
 func (s *tpmSuite) TestConnectToDefaultTPMInvalidEK(c *C) {
-	primary := s.CreatePrimary(c, tpm2.HandleOwner, tpm2_testutil.NewRSAKeyTemplate(templates.KeyUsageDecrypt, nil))
+	primary := s.CreatePrimary(c, tpm2.HandleOwner, tpm2_testutil.NewRSAKeyTemplate(objectutil.UsageDecrypt, nil))
 	s.EvictControl(c, tpm2.HandleOwner, primary, tcg.EKHandle)
 	s.testConnectToDefaultTPM(c, false)
 }

--- a/tpm2/unseal.go
+++ b/tpm2/unseal.go
@@ -57,7 +57,7 @@ func (k *sealedKeyDataBase) loadForUnseal(tpm *tpm2.TPMContext, session tpm2.Ses
 		var srk tpm2.ResourceContext
 		var thisErr error
 		if try == tryPersistentSRK {
-			srk, thisErr = tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+			srk, thisErr = tpm.NewResourceContext(tcg.SRKHandle)
 			if tpm2.IsResourceUnavailableError(thisErr, tcg.SRKHandle) {
 				// No SRK - save the error and try creating a transient
 				err = ErrTPMProvisioning

--- a/tpm2/unseal_legacy_test.go
+++ b/tpm2/unseal_legacy_test.go
@@ -114,7 +114,7 @@ func (s *unsealSuite) testUnsealFromTPMNoValidSRK(c *C, prepareSrk func()) {
 
 func (s *unsealSuite) TestUnsealFromTPMMissingSRK(c *C) {
 	s.testUnsealFromTPMNoValidSRK(c, func() {
-		srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+		srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 		c.Assert(err, IsNil)
 		s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 	})
@@ -122,7 +122,7 @@ func (s *unsealSuite) TestUnsealFromTPMMissingSRK(c *C) {
 
 func (s *unsealSuite) TestUnsealFromTPMWrongSRK(c *C) {
 	s.testUnsealFromTPMNoValidSRK(c, func() {
-		srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+		srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 		c.Assert(err, IsNil)
 		s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
@@ -134,7 +134,7 @@ func (s *unsealSuite) TestUnsealFromTPMWrongSRK(c *C) {
 }
 
 func (s *unsealSuite) testUnsealImportableFromTPM(c *C, params *KeyCreationParams) {
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	srk, err := s.TPM().NewResourceContext(tcg.SRKHandle)
 	c.Assert(err, IsNil)
 
 	srkPub, _, _, err := s.TPM().ReadPublic(srk)


### PR DESCRIPTION
PR #357 migrated the tpm2 code to using the new tpm2.TPMDevice abstraction for opening TPM connections.

The go-tpm2 package contains some other deprecated APIs, and in some cases, entire sub-packages have been deprecated (crypto, templates, util). These have been replaced by alternative APIs, and the util package, which was a bit of a dumping ground for APIs that had nowhere else to go, has been split into more focused packages.

This ports secboot to using updated APIs. It's just a straight port for now - we may want to refactor some code to make better use of these APIs in future PRs - particularly those in the `policyutil` sub-package, something that will allow us to create keys with arbitrary policies without having to change the key data format for tpm2 keys (see issue #350).