### PR TITLE
internal/efi: Use internal/tpm2_device package

### DIFF
--- a/internal/efi/env.go
+++ b/internal/efi/env.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/tcglog-parser"
+	"github.com/snapcore/secboot/internal/tpm2_device"
 )
 
 // XXX: Some of the interfaces here are really public, but they are here because they are shared by
@@ -97,7 +98,7 @@ const VirtModeNone = "none"
 var (
 	// ErrNoTPM2Device is returned from HostEnvironment.TPMDevice if no TPM2
 	// device is available.
-	ErrNoTPM2Device = errors.New("no TPM2 device is available")
+	ErrNoTPM2Device = tpm2_device.ErrNoTPM2Device
 
 	// ErrNoDeviceAttribute is returned from SysfsDevice.Attribute if the supplied attribute
 	// does not exist.

--- a/internal/efi/export_test.go
+++ b/internal/efi/export_test.go
@@ -20,8 +20,7 @@
 package efi
 
 import (
-	"github.com/canonical/go-tpm2/linux"
-	. "gopkg.in/check.v1"
+	"github.com/snapcore/secboot/internal/tpm2_device"
 )
 
 func MockEventLogPath(path string) (restore func()) {
@@ -32,24 +31,11 @@ func MockEventLogPath(path string) (restore func()) {
 	}
 }
 
-func MockLinuxDefaultTPM2Device(dev *linux.RawDevice, err error) (restore func()) {
-	orig := linuxDefaultTPM2Device
-	linuxDefaultTPM2Device = func() (*linux.RawDevice, error) {
-		return dev, err
-	}
+func MockDefaultTPM2Device(fn func(tpm2_device.DeviceMode) (tpm2_device.TPMDevice, error)) (restore func()) {
+	orig := tpm2_deviceDefaultDevice
+	tpm2_deviceDefaultDevice = fn
 	return func() {
-		linuxDefaultTPM2Device = orig
-	}
-}
-
-func MockLinuxRawDeviceResourceManagedDevice(c *C, expectedDev *linux.RawDevice, dev *linux.RMDevice, err error) (restore func()) {
-	orig := linuxRawDeviceResourceManagedDevice
-	linuxRawDeviceResourceManagedDevice = func(device *linux.RawDevice) (*linux.RMDevice, error) {
-		c.Check(device, Equals, expectedDev)
-		return dev, err
-	}
-	return func() {
-		linuxRawDeviceResourceManagedDevice = orig
+		tpm2_deviceDefaultDevice = orig
 	}
 }
 


### PR DESCRIPTION
Other code in secboot makes use of this recently introduced package,
so the code in internal/efi should use it too.