### PR TITLE
tpm2: Avoid attempting to open duplicate TPM connections

### DIFF
--- a/bootscope/keydata_test.go
+++ b/bootscope/keydata_test.go
@@ -968,7 +968,7 @@ func (h *mockPlatformKeyDataHandler) RecoverKeysWithAuthKey(data *PlatformKeyDat
 	return h.recoverKeys(handle, encryptedPayload)
 }
 
-func (h *mockPlatformKeyDataHandler) ChangeAuthKey(data *PlatformKeyData, old, new []byte) ([]byte, error) {
+func (h *mockPlatformKeyDataHandler) ChangeAuthKey(data *PlatformKeyData, old, new []byte, context any) ([]byte, error) {
 	if err := h.checkState(); err != nil {
 		return nil, err
 	}

--- a/hooks/platform.go
+++ b/hooks/platform.go
@@ -126,7 +126,7 @@ func (*hooksPlatform) RecoverKeysWithAuthKey(data *secboot.PlatformKeyData, encr
 	return nil, errors.New("unsupported action")
 }
 
-func (*hooksPlatform) ChangeAuthKey(data *secboot.PlatformKeyData, old, new []byte) ([]byte, error) {
+func (*hooksPlatform) ChangeAuthKey(data *secboot.PlatformKeyData, old, new []byte, context any) ([]byte, error) {
 	return nil, errors.New("unsupported action")
 }
 

--- a/keydata.go
+++ b/keydata.go
@@ -533,6 +533,7 @@ func (d *KeyData) platformKeyData() *PlatformKeyData {
 	return &PlatformKeyData{
 		Generation:    d.Generation(),
 		EncodedHandle: d.data.PlatformHandle,
+		Role:          d.data.Role,
 		KDFAlg:        crypto.Hash(d.data.KDFAlg),
 		AuthMode:      d.AuthMode(),
 	}

--- a/plainkey/platform.go
+++ b/plainkey/platform.go
@@ -137,7 +137,7 @@ func (*platformKeyDataHandler) RecoverKeysWithAuthKey(data *secboot.PlatformKeyD
 	return nil, errors.New("unsupported action")
 }
 
-func (*platformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, old, new []byte) ([]byte, error) {
+func (*platformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, old, new []byte, context any) ([]byte, error) {
 	return nil, errors.New("unsupported action")
 }
 

--- a/platform.go
+++ b/platform.go
@@ -97,8 +97,11 @@ type PlatformKeyDataHandler interface {
 	// keys. Either value can be nil if passphrase authentication is being enabled (
 	// where old will be nil) or disabled (where new will be nil).
 	//
+	// The use of the context argument isn't defined here - it's passed during
+	// key construction and the platform is free to use it however it likes.
+	//
 	// On success, it should return an updated handle.
-	ChangeAuthKey(data *PlatformKeyData, old, new []byte) ([]byte, error)
+	ChangeAuthKey(data *PlatformKeyData, old, new []byte, context any) ([]byte, error)
 }
 
 var handlers = make(map[string]PlatformKeyDataHandler)

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -116,7 +116,7 @@ func (h *legacyPlatformKeyDataHandler) RecoverKeysWithAuthKey(data *secboot.Plat
 	return nil, fmt.Errorf("passphrase authentication is not supported for the %s platform", legacyPlatformName)
 }
 
-func (h *legacyPlatformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, old, new []byte) ([]byte, error) {
+func (h *legacyPlatformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, old, new []byte, context any) ([]byte, error) {
 	return nil, fmt.Errorf("passphrase authentication is not supported for the %s platform", legacyPlatformName)
 }
 

--- a/tpm2/platform_legacy_test.go
+++ b/tpm2/platform_legacy_test.go
@@ -64,6 +64,8 @@ func (s *platformLegacySuite) TestRecoverKeys(c *C) {
 		PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Check(err, IsNil)
 
+	s.AddCleanup(s.CloseMockConnection(c))
+
 	k, err := NewKeyDataFromSealedKeyObjectFile(keyFile)
 	c.Assert(err, IsNil)
 
@@ -108,6 +110,8 @@ func (s *platformLegacySuite) TestRecoverKeysInvalidPCRPolicy(c *C) {
 	_, err = s.TPM().PCREvent(s.TPM().PCRHandleContext(7), tpm2.Event("foo"), nil)
 	c.Check(err, IsNil)
 
+	s.AddCleanup(s.CloseMockConnection(c))
+
 	k, err := NewKeyDataFromSealedKeyObjectFile(keyFile)
 	c.Assert(err, IsNil)
 
@@ -128,6 +132,8 @@ func (s *platformLegacySuite) TestRecoverKeysTPMLockout(c *C) {
 
 	// Put the TPM in DA lockout mode
 	c.Check(s.TPM().DictionaryAttackParameters(s.TPM().LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	k, err := NewKeyDataFromSealedKeyObjectFile(keyFile)
 	c.Assert(err, IsNil)
@@ -151,6 +157,8 @@ func (s *platformLegacySuite) TestRecoverKeysErrTPMProvisioning(c *C) {
 
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 	s.HierarchyChangeAuth(c, tpm2.HandleOwner, []byte("foo"))
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	k, err := NewKeyDataFromSealedKeyObjectFile(keyFile)
 	c.Assert(err, IsNil)

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -563,7 +563,7 @@ func (s *platformSuite) TestRecoverKeysWithAuthKey(c *C) {
 	}
 
 	var handler PlatformKeyDataHandler
-	newHandle, err := handler.ChangeAuthKey(platformKeyData, nil, []byte{1, 2, 3, 4})
+	newHandle, err := handler.ChangeAuthKey(platformKeyData, nil, []byte{1, 2, 3, 4}, nil)
 	c.Check(err, IsNil)
 
 	newPlatformKeyData := &secboot.PlatformKeyData{
@@ -648,7 +648,7 @@ func (s *platformSuite) TestRecoverKeysWithIncorrectAuthKey(c *C) {
 	}
 
 	var handler PlatformKeyDataHandler
-	newHandle, err := handler.ChangeAuthKey(platformKeyData, nil, []byte{1, 2, 3, 4})
+	newHandle, err := handler.ChangeAuthKey(platformKeyData, nil, []byte{1, 2, 3, 4}, nil)
 	c.Check(err, IsNil)
 
 	newPlatformKeyData := &secboot.PlatformKeyData{
@@ -728,7 +728,7 @@ func (s *platformSuite) TestChangeAuthKeyWithIncorrectAuthKey(c *C) {
 	}
 
 	var handler PlatformKeyDataHandler
-	newHandle, err := handler.ChangeAuthKey(platformKeyData, nil, []byte{1, 2, 3, 4})
+	newHandle, err := handler.ChangeAuthKey(platformKeyData, nil, []byte{1, 2, 3, 4}, nil)
 	c.Check(err, IsNil)
 
 	newPlatformKeyData := &secboot.PlatformKeyData{
@@ -738,7 +738,7 @@ func (s *platformSuite) TestChangeAuthKeyWithIncorrectAuthKey(c *C) {
 		AuthMode:      k.AuthMode(),
 	}
 
-	_, err = handler.ChangeAuthKey(newPlatformKeyData, nil, []byte{5, 6, 7, 8})
+	_, err = handler.ChangeAuthKey(newPlatformKeyData, nil, []byte{5, 6, 7, 8}, nil)
 	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
 	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorInvalidAuthKey)
 	c.Check(err, ErrorMatches, "TPM returned an error for session 1 whilst executing command TPM_CC_ObjectChangeAuth: "+

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -82,6 +82,8 @@ func (s *platformSuite) TestRecoverKeysIntegrated(c *C) {
 	k, primaryKey, unlockKey, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
 
+	s.AddCleanup(s.CloseMockConnection(c))
+
 	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeys()
 	c.Check(err, IsNil)
 	c.Check(unlockKeyUnsealed, DeepEquals, unlockKey)
@@ -101,6 +103,8 @@ func (s *platformSuite) TestRecoverKeysWithPassphraseIntegrated(c *C) {
 
 	k, primaryKey, unlockKey, err := NewTPMPassphraseProtectedKey(s.TPM(), passphraseParams, "passphrase")
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeysWithPassphrase("passphrase")
 	c.Check(err, IsNil)
@@ -122,6 +126,8 @@ func (s *platformSuite) TestRecoverKeysWithPassphraseIntegratedPBKDF2(c *C) {
 
 	k, primaryKey, unlockKey, err := NewTPMPassphraseProtectedKey(s.TPM(), passphraseParams, "passphrase")
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeysWithPassphrase("passphrase")
 	c.Check(err, IsNil)
@@ -146,6 +152,8 @@ func (s *platformSuite) TestRecoverKeysWithBadPassphraseIntegrated(c *C) {
 	k, _, _, err := NewTPMPassphraseProtectedKey(s.TPM(), passphraseParams, "passphrase")
 	c.Assert(err, IsNil)
 
+	s.AddCleanup(s.CloseMockConnection(c))
+
 	_, _, err = k.RecoverKeysWithPassphrase("1234")
 	c.Check(err, Equals, secboot.ErrInvalidPassphrase)
 }
@@ -163,6 +171,8 @@ func (s *platformSuite) TestChangePassphraseIntegrated(c *C) {
 
 	k, primaryKey, unlockKey, err := NewTPMPassphraseProtectedKey(s.TPM(), passphraseParams, "passphrase")
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	c.Check(k.ChangePassphrase("passphrase", "1234"), IsNil)
 
@@ -185,6 +195,8 @@ func (s *platformSuite) TestChangePassphraseWithBadPassphraseIntegrated(c *C) {
 
 	k, primaryKey, unlockKey, err := NewTPMPassphraseProtectedKey(s.TPM(), passphraseParams, "passphrase")
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	c.Check(k.ChangePassphrase("1234", "1234"), Equals, secboot.ErrInvalidPassphrase)
 
@@ -210,6 +222,8 @@ func (s *platformSuite) verifyASN1(c *C, data []byte) (primaryKey, unique []byte
 func (s *platformSuite) testRecoverKeys(c *C, params *ProtectKeyParams) {
 	k, primaryKey, unlockKey, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
@@ -277,6 +291,8 @@ func (s *platformSuite) testRecoverKeysNoValidSRK(c *C, prepareSrk func()) {
 
 	prepareSrk()
 
+	s.AddCleanup(s.CloseMockConnection(c))
+
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
 
@@ -330,6 +346,8 @@ func (s *platformSuite) testRecoverKeysImportable(c *C, params *ProtectKeyParams
 
 	k, primaryKey, unlockKey, err := NewExternalTPMProtectedKey(srkPub, params)
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
@@ -404,6 +422,8 @@ func (s *platformSuite) testRecoverKeysUnsealErrorHandling(c *C, prepare func(*s
 	c.Assert(err, IsNil)
 
 	prepare(k, primaryKey)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
@@ -530,6 +550,8 @@ func (s *platformSuite) TestRecoverKeysWithAuthKey(c *C) {
 	k, primaryKey, unlockKey, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
 
+	s.AddCleanup(s.CloseMockConnection(c))
+
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
 
@@ -613,6 +635,8 @@ func (s *platformSuite) TestRecoverKeysWithIncorrectAuthKey(c *C) {
 	k, _, _, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
 
+	s.AddCleanup(s.CloseMockConnection(c))
+
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
 
@@ -690,6 +714,8 @@ func (s *platformSuite) TestChangeAuthKeyWithIncorrectAuthKey(c *C) {
 
 	k, _, _, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
@@ -770,6 +796,8 @@ func (s *platformSuite) TestRecoverKeysWithAuthKeyTPMLockout(c *C) {
 
 	k, _, _, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	var platformHandle json.RawMessage
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -85,13 +85,27 @@ func (s *sealSuite) SetUpTest(c *C) {
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
 	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+	origKdf := secboot.SetArgon2KDF(&testutil.MockArgon2KDF{})
+	s.AddCleanup(func() { secboot.SetArgon2KDF(origKdf) })
 }
 
 var _ = Suite(&sealSuite{})
 
 func (s *sealSuite) testProtectKeyWithTPM(c *C, params *ProtectKeyParams) {
+	s.AddCleanup(MockSecbootNewKeyData(func(keyParams *secboot.KeyParams) (*secboot.KeyData, error) {
+		c.Check(keyParams.Role, Equals, params.Role)
+		c.Check(keyParams.PlatformName, Equals, "tpm2")
+		c.Check(keyParams.KDFAlg, Equals, crypto.SHA256)
+
+		// TODO: Check EncryptedPayload and Handle fields
+
+		return secboot.NewKeyData(keyParams)
+	}))
+
 	k, primaryKey, unlockKey, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
+
+	c.Check(k.AuthMode(), Equals, secboot.AuthModeNone)
 
 	skd, err := NewSealedKeyData(k)
 	c.Assert(err, IsNil)
@@ -117,12 +131,15 @@ func (s *sealSuite) testProtectKeyWithTPM(c *C, params *ProtectKeyParams) {
 	c.Assert(err, IsNil)
 
 	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
+	c.Check(skd.Data().Public().Attrs, Equals, tpm2.AttrFixedTPM|tpm2.AttrFixedParent|tpm2.AttrNoDA)
 	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
 	c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
 
 	if params.PrimaryKey != nil {
 		c.Check(primaryKey, DeepEquals, params.PrimaryKey)
 	}
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeys()
 	c.Check(err, IsNil)
@@ -367,6 +384,129 @@ func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingInvalidPCRProfileSelection
 	c.Check(err, ErrorMatches, "cannot set initial PCR policy: PCR protection profile contains digests for unsupported PCRs")
 }
 
+func (s *sealSuite) testPassphraseProtectKeyWithTPM(c *C, params *PassphraseProtectKeyParams, passphrase string) {
+	s.AddCleanup(MockSecbootNewKeyDataWithPassphrase(func(keyParams *secboot.KeyWithPassphraseParams, keyPassphrase string) (*secboot.KeyData, error) {
+		c.Check(keyParams.Role, Equals, params.Role)
+		c.Check(keyParams.PlatformName, Equals, "tpm2")
+		c.Check(keyParams.KDFAlg, Equals, crypto.SHA256)
+		c.Check(keyParams.KDFOptions, DeepEquals, params.KDFOptions)
+		c.Check(keyParams.AuthKeySize, Equals, 32)
+		c.Check(keyPassphrase, Equals, passphrase)
+
+		// TODO: Check EncryptedPayload and Handle fields
+
+		return secboot.NewKeyDataWithPassphrase(keyParams, keyPassphrase)
+	}))
+
+	k, primaryKey, unlockKey, err := NewTPMPassphraseProtectedKey(s.TPM(), params, passphrase)
+	c.Assert(err, IsNil)
+
+	c.Check(k.AuthMode(), Equals, secboot.AuthModePassphrase)
+
+	skd, err := NewSealedKeyData(k)
+	c.Assert(err, IsNil)
+	c.Check(skd.Validate(s.TPM().TPMContext, primaryKey), IsNil)
+
+	c.Check(skd.Version(), Equals, uint32(3))
+	c.Check(skd.PCRPolicyCounterHandle(), Equals, params.PCRPolicyCounterHandle)
+
+	policyAuthPublicKey, err := NewPolicyAuthPublicKey(primaryKey)
+	c.Assert(err, IsNil)
+
+	var pcrPolicyCounterPub *tpm2.NVPublic
+	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		index, err := s.TPM().CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
+		c.Assert(err, IsNil)
+
+		pcrPolicyCounterPub, _, err = s.TPM().NVReadPublic(index)
+		c.Check(err, IsNil)
+
+	}
+
+	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, params.Role, pcrPolicyCounterPub, true)
+	c.Assert(err, IsNil)
+
+	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
+	c.Check(skd.Data().Public().Attrs, Equals, tpm2.AttrFixedTPM|tpm2.AttrFixedParent)
+	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
+	c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
+
+	if params.PrimaryKey != nil {
+		c.Check(primaryKey, DeepEquals, params.PrimaryKey)
+	}
+
+	s.AddCleanup(s.CloseMockConnection(c))
+
+	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeysWithPassphrase(passphrase)
+	c.Check(err, IsNil)
+	c.Check(unlockKeyUnsealed, DeepEquals, unlockKey)
+	c.Check(primaryKeyUnsealed, DeepEquals, primaryKey)
+
+	if params.PCRProfile != nil {
+		// Verify that the key is sealed with the supplied PCR profile by changing
+		// the PCR values.
+		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
+		c.Check(err, IsNil)
+		_, _, err = k.RecoverKeysWithPassphrase(passphrase)
+		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
+	}
+
+	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		c.Check(s.TPM().DoesHandleExist(params.PCRPolicyCounterHandle), testutil.IsTrue)
+	}
+}
+
+func (s *sealSuite) TestPassphraseProtectKeyWithTPM(c *C) {
+	s.testPassphraseProtectKeyWithTPM(c, &PassphraseProtectKeyParams{
+		ProtectKeyParams: ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			Role:                   "foo",
+		},
+	}, "Jg4zg4GF9WGL")
+}
+
+func (s *sealSuite) TestPassphraseProtectKeyWithTPMSuppliedKDFOptions(c *C) {
+	s.testPassphraseProtectKeyWithTPM(c, &PassphraseProtectKeyParams{
+		ProtectKeyParams: ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			Role:                   "foo",
+		},
+		KDFOptions: &secboot.Argon2Options{
+			Mode:            secboot.Argon2id,
+			MemoryKiB:       32 * 1024,
+			ForceIterations: 4,
+			Parallel:        4,
+		},
+	}, "Jg4zg4GF9WGL")
+}
+
+func (s *sealSuite) TestPassphraseProtectKeyWithTPMDifferentSuppliedKDFOptions(c *C) {
+	s.testPassphraseProtectKeyWithTPM(c, &PassphraseProtectKeyParams{
+		ProtectKeyParams: ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			Role:                   "foo",
+		},
+		KDFOptions: &secboot.PBKDF2Options{
+			ForceIterations: 100000,
+			HashAlg:         crypto.SHA256,
+		},
+	}, "Jg4zg4GF9WGL")
+}
+
+func (s *sealSuite) TestPassphraseProtectKeyWithTPMDifferentPassphrase(c *C) {
+	s.testPassphraseProtectKeyWithTPM(c, &PassphraseProtectKeyParams{
+		ProtectKeyParams: ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			Role:                   "foo",
+		},
+	}, "uWjzz3MURKUS")
+}
+
 func (s *sealSuite) testProtectKeyWithExternalStorageKey(c *C, params *ProtectKeyParams) {
 	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
 	c.Assert(err, IsNil)
@@ -400,6 +540,8 @@ func (s *sealSuite) testProtectKeyWithExternalStorageKey(c *C, params *ProtectKe
 	if params.PrimaryKey != nil {
 		c.Check(primaryKey, DeepEquals, params.PrimaryKey)
 	}
+
+	s.AddCleanup(s.CloseMockConnection(c))
 
 	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeys()
 	c.Check(err, IsNil)

--- a/tpm2/tpm_test.go
+++ b/tpm2/tpm_test.go
@@ -134,18 +134,21 @@ func (s *tpmSuiteCommon) testConnectToDefaultTPM(c *C, hasEncryption bool) {
 }
 
 func (s *tpmSuiteSimulator) TestConnectToDefaultTPMUnprovisioned(c *C) {
+	s.AddCleanup(s.CloseMockConnection(c))
 	s.testConnectToDefaultTPM(c, false)
 }
 
 func (s *tpmSuite) TestConnectToDefaultTPMProvisioned(c *C) {
 	c.Check(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+	s.AddCleanup(s.CloseMockConnection(c))
 	s.testConnectToDefaultTPM(c, true)
 }
 
 func (s *tpmSuite) TestConnectToDefaultTPMInvalidEK(c *C) {
 	primary := s.CreatePrimary(c, tpm2.HandleOwner, tpm2_testutil.NewRSAKeyTemplate(templates.KeyUsageDecrypt, nil))
 	s.EvictControl(c, tpm2.HandleOwner, primary, tcg.EKHandle)
+	s.AddCleanup(s.CloseMockConnection(c))
 	s.testConnectToDefaultTPM(c, false)
 }
 


### PR DESCRIPTION
When using `NewTPMPassphraseProtectedKey`, it is passed an already open
connection. But the core secboot package calls back into the platform
handler to set the user auth value, which opens a second connection.
When using the direct device (/dev/tpm0), this doesn't work.

This updates the test suite to make sure that this scenario is caught
and results in an error. It also fixes the problem by providing a way to
pass the open TPM connection to the singleton tpm2 platform handler
via a new field on the `secboot.KeyWithPassphraseParams` struct which
can be set to any value and is passed to the `ChangeAuthKey` implementation
when setting the initial auth value. The tpm2 platform handler
implementation uses this connection if passed rather than trying to open a
new connection. If the `ChangeAuthKey` implementation is called via
`KeyData.ChangePassphrase`, then the new argument will be nil and the
tpm2 implementation will open a new TPM connection as required.

This also identified a bug that the core secboot package was not passing
the role value to the platform handler, which only seemed to be caught
by adding tests that created passphrase protected TPM keys with a role.

This addresses issue #353