### PR TITLE
internal/testutil: Update import for KBKDF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/canonical/cpuid v0.0.0-20220614022739-219e067757cb
 	github.com/canonical/go-efilib v1.4.1
-	github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0
+	github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
 	github.com/canonical/go-tpm2 v1.11.1
 	github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981
@@ -19,7 +19,6 @@ require (
 )
 
 require (
-	github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/kr/pretty v0.2.2-0.20200810074440-814ac30b4b18 // indirect
 	github.com/kr/text v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/canonical/go-efilib v1.4.1/go.mod h1:n0Ttsy1JuHAvqaFbZBs6PAzoiiJdfkHs
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9 h1:Twk1ZSTWRClfGShP16ePf2JIiayqWS4ix1rkAR6baag=
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9/go.mod h1:IneQ5/yQcfPXrGekEXpR6yeea55ZD24N5+kHzeDseOM=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
-github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0 h1:ZE2XMRFHcwlib3uU9is37+pKkkMloVoEPWmgQ6GK1yo=
-github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=
 github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61/go.mod h1:vG41hdbBjV4+/fkubTT1ENBBqSkLwLr7mCeW9Y6kpZY=

--- a/internal/testutil/argon2.go
+++ b/internal/testutil/argon2.go
@@ -20,14 +20,13 @@
 package testutil
 
 import (
-	"crypto"
 	_ "crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"time"
 
-	kdf "github.com/canonical/go-sp800.108-kdf"
-
+	"github.com/canonical/go-kbkdf"
+	"github.com/canonical/go-kbkdf/hmac_prf"
 	"github.com/snapcore/secboot"
 )
 
@@ -57,7 +56,7 @@ func (_ *MockArgon2KDF) Derive(passphrase string, salt []byte, mode secboot.Argo
 	binary.LittleEndian.PutUint32(context[len(salt)+5:], params.MemoryKiB)
 	context[len(salt)+9] = params.Threads
 
-	return kdf.CounterModeKey(kdf.NewHMACPRF(crypto.SHA256), []byte(passphrase), nil, context, keyLen*8), nil
+	return kbkdf.CounterModeKey(hmac_prf.SHA256, []byte(passphrase), nil, context, keyLen*8), nil
 }
 
 // Time implements secboot.KDF.Time and returns a time that is linearly


### PR DESCRIPTION
The previous import was github.com/canonical/go-sp800.108-kdf. I've since moved it to github.com/canonical/go-kbkdf and renamed the module accordingly, following the naming convention for this KDF on openssl.

The package is largely the same, just with the HMAC implementation of the PRF split into its own sub-package. This package has global variables for pre-defined PRFs for each supported SHA2 algorithm.