### PR TITLE
Fix plumbing of the role via the PlatformKeyDataHandler interface

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -421,7 +421,6 @@ func (s *cryptSuite) TearDownSuite(c *C) {
 
 func (s *cryptSuite) SetUpTest(c *C) {
 	s.AddCleanup(MockUnixStat(func(devicePath string, st *unix.Stat_t) error {
-		fmt.Printf("Called mock for %s\n", devicePath)
 		s.requestedStats = append(s.requestedStats, devicePath)
 		foundSt, hasSt := s.deviceStats[devicePath]
 		if !hasSt {
@@ -433,11 +432,11 @@ func (s *cryptSuite) SetUpTest(c *C) {
 
 	s.deviceStats = map[string]unix.Stat_t{
 		"/dev/sda1": unix.Stat_t{
-			Mode: 0600|unix.S_IFBLK,
+			Mode: 0600 | unix.S_IFBLK,
 			Rdev: unix.Mkdev(8, 1),
 		},
 		"/dev/vda2": unix.Stat_t{
-			Mode: 0600|unix.S_IFBLK,
+			Mode: 0600 | unix.S_IFBLK,
 			Rdev: unix.Mkdev(9, 2),
 		},
 	}
@@ -520,7 +519,7 @@ func (s *cryptSuite) checkKeyDataKeysInKeyring(c *C, prefix, path string, expect
 func (s *cryptSuite) newMultipleNamedKeyData(c *C, names ...string) (keyData []*KeyData, keys []DiskUnlockKey, primaryKeys []PrimaryKey) {
 	for _, name := range names {
 		primaryKey := s.newPrimaryKey(c, 32)
-		protected, unlockKey := s.mockProtectKeys(c, primaryKey, crypto.SHA256, crypto.SHA256)
+		protected, unlockKey := s.mockProtectKeys(c, primaryKey, "foo", crypto.SHA256)
 
 		kd, err := NewKeyData(protected)
 		c.Assert(err, IsNil)
@@ -548,7 +547,7 @@ func (s *cryptSuite) newNamedKeyData(c *C, name string) (*KeyData, DiskUnlockKey
 func (s *cryptSuite) newMultipleNamedKeyDataWithPassphrases(c *C, passphrases []string, names ...string) (keyData []*KeyData, keys []DiskUnlockKey, primaryKeys []PrimaryKey) {
 	for i, name := range names {
 		primaryKey := s.newPrimaryKey(c, 32)
-		protected, unlockKey := s.mockProtectKeysWithPassphrase(c, primaryKey, nil, 32, crypto.SHA256, crypto.SHA256)
+		protected, unlockKey := s.mockProtectKeysWithPassphrase(c, primaryKey, "foo", nil, 32, crypto.SHA256)
 
 		kd, err := NewKeyDataWithPassphrase(protected, passphrases[i])
 		c.Assert(err, IsNil)
@@ -791,7 +790,7 @@ func (s *cryptSuite) testActivateVolumeWithRecoveryKeyErrorHandling(c *C, data *
 	defer MockUnixStat(func(devicePath string, st *unix.Stat_t) error {
 		c.Check(devicePath, Equals, "/dev/sda1")
 		*st = unix.Stat_t{
-			Mode: 0600|unix.S_IFBLK,
+			Mode: 0600 | unix.S_IFBLK,
 			Rdev: unix.Mkdev(8, 1),
 		}
 		return nil
@@ -3945,11 +3944,11 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleLegacyKeyDataErrorHandling15(
 func (s *cryptSuite) TestActivateVolumeWithLegacyPaths(c *C) {
 	s.deviceStats = map[string]unix.Stat_t{
 		"/dev/some/path": unix.Stat_t{
-			Mode: 0600|unix.S_IFBLK,
+			Mode: 0600 | unix.S_IFBLK,
 			Rdev: unix.Mkdev(8, 1),
 		},
 		"/dev/some/legacy/path": unix.Stat_t{
-			Mode: 0600|unix.S_IFBLK,
+			Mode: 0600 | unix.S_IFBLK,
 			Rdev: unix.Mkdev(8, 1),
 		},
 	}
@@ -3967,11 +3966,11 @@ func (s *cryptSuite) TestActivateVolumeWithLegacyPaths(c *C) {
 func (s *cryptSuite) TestActivateVolumeWithLegacyPathsError(c *C) {
 	s.deviceStats = map[string]unix.Stat_t{
 		"/dev/some/path": unix.Stat_t{
-			Mode: 0600|unix.S_IFBLK,
+			Mode: 0600 | unix.S_IFBLK,
 			Rdev: unix.Mkdev(8, 1),
 		},
 		"/dev/some/legacy/path": unix.Stat_t{
-			Mode: 0600|unix.S_IFBLK,
+			Mode: 0600 | unix.S_IFBLK,
 			// different node
 			Rdev: unix.Mkdev(8, 2),
 		},

--- a/keydata.go
+++ b/keydata.go
@@ -533,6 +533,7 @@ func (d *KeyData) platformKeyData() *PlatformKeyData {
 	return &PlatformKeyData{
 		Generation:    d.Generation(),
 		EncodedHandle: d.data.PlatformHandle,
+		Role:          d.data.Role,
 		KDFAlg:        crypto.Hash(d.data.KDFAlg),
 		AuthMode:      d.AuthMode(),
 	}

--- a/keydata_file_test.go
+++ b/keydata_file_test.go
@@ -46,7 +46,7 @@ var _ = Suite(&keyDataFileSuite{})
 
 func (s *keyDataFileSuite) TestWriter(c *C) {
 	primaryKey := s.newPrimaryKey(c, 32)
-	protected, _ := s.mockProtectKeys(c, primaryKey, crypto.SHA256, crypto.SHA256)
+	protected, _ := s.mockProtectKeys(c, primaryKey, "foo", crypto.SHA256)
 
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
@@ -64,12 +64,12 @@ func (s *keyDataFileSuite) TestWriter(c *C) {
 	d := json.NewDecoder(f)
 	c.Check(d.Decode(&j), IsNil)
 
-	s.checkKeyDataJSONDecodedAuthModeNone(c, j, protected, 0)
+	s.checkKeyDataJSONDecodedAuthModeNone(c, j, protected)
 }
 
 func (s *keyDataFileSuite) TestWriterIsAtomic(c *C) {
 	primaryKey := s.newPrimaryKey(c, 32)
-	protected, _ := s.mockProtectKeys(c, primaryKey, crypto.SHA256, crypto.SHA256)
+	protected, _ := s.mockProtectKeys(c, primaryKey, "foo", crypto.SHA256)
 
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
@@ -93,7 +93,7 @@ func (s *keyDataFileSuite) TestWriterIsAtomic(c *C) {
 
 func (s *keyDataFileSuite) TestReader(c *C) {
 	primaryKey := s.newPrimaryKey(c, 32)
-	protected, unlockKey := s.mockProtectKeys(c, primaryKey, crypto.SHA256, crypto.SHA256)
+	protected, unlockKey := s.mockProtectKeys(c, primaryKey, "foo", crypto.SHA256)
 
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
@@ -117,6 +117,8 @@ func (s *keyDataFileSuite) TestReader(c *C) {
 	id, err := keyData.UniqueID()
 	c.Check(err, IsNil)
 	c.Check(id, DeepEquals, expectedId)
+
+	c.Check(keyData.Role(), Equals, "foo")
 
 	recoveredUnlockKey, recoveredPrimaryKey, err := keyData.RecoverKeys()
 	c.Check(err, IsNil)

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -76,7 +76,7 @@ func (s *platformSuite) TestRecoverKeysIntegrated(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "foo",
 	}
 
 	k, primaryKey, unlockKey, err := NewTPMProtectedKey(s.TPM(), params)
@@ -92,7 +92,7 @@ func (s *platformSuite) TestRecoverKeysWithPassphraseIntegrated(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "bar",
 	}
 
 	passphraseParams := &PassphraseProtectKeyParams{
@@ -112,7 +112,7 @@ func (s *platformSuite) TestRecoverKeysWithPassphraseIntegratedPBKDF2(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "foo",
 	}
 
 	passphraseParams := &PassphraseProtectKeyParams{
@@ -136,7 +136,7 @@ func (s *platformSuite) TestRecoverKeysWithBadPassphraseIntegrated(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "foo",
 	}
 
 	passphraseParams := &PassphraseProtectKeyParams{
@@ -154,7 +154,7 @@ func (s *platformSuite) TestChangePassphraseIntegrated(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "foo",
 	}
 
 	passphraseParams := &PassphraseProtectKeyParams{
@@ -176,7 +176,7 @@ func (s *platformSuite) TestChangePassphraseWithBadPassphraseIntegrated(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "foo",
 	}
 
 	passphraseParams := &PassphraseProtectKeyParams{
@@ -217,6 +217,7 @@ func (s *platformSuite) testRecoverKeys(c *C, params *ProtectKeyParams) {
 	platformKeyData := &secboot.PlatformKeyData{
 		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
+		Role:          params.Role,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),
 	}
@@ -239,19 +240,31 @@ func (s *platformSuite) TestRecoverKeysSimplePCRProfile(c *C) {
 	s.testRecoverKeys(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "foo",
 	})
 }
 
 func (s *platformSuite) TestRecoverKeysNilPCRProfile(c *C) {
 	s.testRecoverKeys(c, &ProtectKeyParams{
-		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0)})
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
+		Role:                   "foo",
+	})
 }
 
 func (s *platformSuite) TestRecoverKeysNoPCRPolicyCounter(c *C) {
 	s.testRecoverKeys(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
-		PCRPolicyCounterHandle: tpm2.HandleNull})
+		PCRPolicyCounterHandle: tpm2.HandleNull,
+		Role:                   "foo",
+	})
+}
+
+func (s *platformSuite) TestRecoverKeysDifferentRole(c *C) {
+	s.testRecoverKeys(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
+		Role:                   "bar",
+	})
 }
 
 func (s *platformSuite) TestRecoverKeysTPMLockout(c *C) {
@@ -412,7 +425,7 @@ func (s *platformSuite) testRecoverKeysUnsealErrorHandling(c *C, prepare func(*s
 	_, err = handler.RecoverKeys(&secboot.PlatformKeyData{
 		Generation:    k.Generation(),
 		AuthMode:      secboot.AuthModeNone,
-		Role:          "",
+		Role:          "foo",
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		EncodedHandle: platformHandle},
 		s.lastEncryptedPayload)
@@ -525,7 +538,7 @@ func (s *platformSuite) TestRecoverKeysWithAuthKey(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		Role:                   "",
+		Role:                   "foo",
 	}
 
 	k, primaryKey, unlockKey, err := NewTPMProtectedKey(s.TPM(), params)
@@ -537,6 +550,7 @@ func (s *platformSuite) TestRecoverKeysWithAuthKey(c *C) {
 	platformKeyData := &secboot.PlatformKeyData{
 		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
+		Role:          "foo",
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),
 	}

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -68,7 +68,8 @@ func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRPro
 	params := &ProtectKeyParams{
 		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
 		PCRPolicyCounterHandle: data.pcrPolicyCounterHandle,
-		PrimaryKey:             data.primaryKey}
+		PrimaryKey:             data.primaryKey,
+		Role:                   "foo"}
 	k, primaryKey, _, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
 
@@ -170,7 +171,9 @@ func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy(c *C) {
 	params := &ProtectKeyParams{
 		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		PrimaryKey:             primaryKey}
+		PrimaryKey:             primaryKey,
+		Role:                   "bar",
+	}
 
 	var keys []*secboot.KeyData
 	for i := 0; i < 2; i++ {


### PR DESCRIPTION
PR #361 addressed the issue that most tpm2 tests were being performed with an empty role, which isn't realistic. It turns out that I missed a few places, particularly in some of the platform tests, that if I had fixed in the previous PR, would have noticed that the role parameter isn't being passed through the platform interface (this would get picked up when changing a password because key validation would fail).

This addresses this, and fixes tests in the top-level package to catch it as well.

Note that I'm using the same value in most tests - my normal approach to unit testing is to test each input with at least more than one value, but the tests in the top-level secboot package and the tpm2 sub-package are getting a bit complicated with a lot of inconsistencies in their approach to testing. I have issues #329 and #330 open to refactor the tests so they are structured in a more consistent way, like the tests for the recently added plainkey platform are.