### PR TITLE
tpm2: Directly authenticate the role field of the metadata.

### DIFF
--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -87,7 +87,7 @@ type keyData interface {
 
 	// Decrypt performs authenticated decryption of the encrypted payload and the associated data.
 	// This is relevant only for keydata versions 3 and later.
-	Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error)
+	Decrypt(key, payload []byte, generation uint32, role []byte, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error)
 }
 
 func readKeyData(r io.Reader, version uint32) (keyData, error) {

--- a/tpm2/keydata_v0.go
+++ b/tpm2/keydata_v0.go
@@ -209,6 +209,6 @@ func (d *keyData_v0) Policy() keyDataPolicy {
 	return d.PolicyData
 }
 
-func (d *keyData_v0) Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+func (d *keyData_v0) Decrypt(key, payload []byte, generation uint32, role []byte, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
 	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v1.go
+++ b/tpm2/keydata_v1.go
@@ -134,6 +134,6 @@ func (d *keyData_v1) Policy() keyDataPolicy {
 	return d.PolicyData
 }
 
-func (d *keyData_v1) Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+func (d *keyData_v1) Decrypt(key, payload []byte, generation uint32, role []byte, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
 	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v2.go
+++ b/tpm2/keydata_v2.go
@@ -112,6 +112,6 @@ func (d *keyData_v2) Policy() keyDataPolicy {
 	return d.PolicyData
 }
 
-func (d *keyData_v2) Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+func (d *keyData_v2) Decrypt(key, payload []byte, baseVersion uint32, role []byte, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
 	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v3.go
+++ b/tpm2/keydata_v3.go
@@ -37,6 +37,7 @@ import (
 
 type additionalData_v3 struct {
 	Generation uint32
+	Role       []byte
 	KDFAlg     tpm2.HashAlgorithmId
 	AuthMode   secboot.AuthMode
 }
@@ -44,7 +45,7 @@ type additionalData_v3 struct {
 func (d additionalData_v3) Marshal(w io.Writer) error {
 	_, err := mu.MarshalToWriter(w,
 		uint32(3), // The TPM2 platform keydata version
-		d.Generation, d.KDFAlg, d.AuthMode)
+		d.Generation, d.Role, d.KDFAlg, d.AuthMode)
 	return err
 }
 
@@ -172,7 +173,7 @@ func (d *keyData_v3) Policy() keyDataPolicy {
 	return d.PolicyData
 }
 
-func (d *keyData_v3) Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+func (d *keyData_v3) Decrypt(key, payload []byte, generation uint32, role []byte, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
 	// We only support AES-256-GCM with a 12-byte nonce, so we expect 44 bytes here
 	if len(key) != 32+12 {
 		return nil, errors.New("invalid symmetric key size")
@@ -180,6 +181,7 @@ func (d *keyData_v3) Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2
 
 	aad, err := mu.MarshalToBytes(&additionalData_v3{
 		Generation: generation,
+		Role:       role,
 		KDFAlg:     kdfAlg,
 		AuthMode:   authMode,
 	})

--- a/tpm2/platform.go
+++ b/tpm2/platform.go
@@ -102,7 +102,7 @@ func (h *platformKeyDataHandler) recoverKeysCommon(data *secboot.PlatformKeyData
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
 	}
 
-	payload, err := k.data.Decrypt(symKey, encryptedPayload, uint32(data.Generation), kdfAlg, data.AuthMode)
+	payload, err := k.data.Decrypt(symKey, encryptedPayload, uint32(data.Generation), []byte(data.Role), kdfAlg, data.AuthMode)
 	if err != nil {
 		return nil, &secboot.PlatformHandlerError{
 			Type: secboot.PlatformHandlerErrorInvalidData,

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -194,6 +194,7 @@ var makeSealedKeyData = func(tpm *tpm2.TPMContext, params *makeSealedKeyDataPara
 	// already bound to the sealed object via its authorization policy.
 	aad, err := mu.MarshalToBytes(&additionalData_v3{
 		Generation: uint32(secboot.KeyDataGeneration),
+		Role:       []byte(params.Role),
 		KDFAlg:     tpm2.HashAlgorithmSHA256,
 		AuthMode:   params.AuthMode,
 	})

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -672,6 +672,7 @@ func (s *sealSuiteNoTPM) testMakeSealedKeyData(c *C, data *testMakeSealedKeyData
 
 	aad, err := mu.MarshalToBytes(&AdditionalData_v3{
 		Generation: uint32(kd.Generation()),
+		Role:       []byte(data.Role),
 		KDFAlg:     tpm2.HashAlgorithmSHA256,
 		AuthMode:   kd.AuthMode(),
 	})


### PR DESCRIPTION
The role field currently isn't authenticated directly becuase it's used to generate the policyRef for the `TPM2_PolicyAuthorize` command. However, the polcyRef is stored in the metadata, and so modifications to the role field of a keyslot metadata will only be detected by calling a method of `SealedKeyData` that calls in to `keyData.ValidateData`. In this sense, it is authenticated indirectly.

However, we might make security decisions based on the role of a key used for unlocking, so the current approach isn't sufficient - it needs to be authenticated directly during unlocking.