### PR TITLE
Add a flags argument associated with registered PlatformKeyDataHandlers

### DIFF
--- a/bootscope/keydata_test.go
+++ b/bootscope/keydata_test.go
@@ -995,7 +995,7 @@ type keyDataScopeSuite struct {
 
 func (s *keyDataScopeSuite) SetUpTest(c *C) {
 	s.handler = &mockPlatformKeyDataHandler{}
-	RegisterPlatformKeyDataHandler("mock-scope", s.handler)
+	RegisterPlatformKeyDataHandler("mock-scope", s.handler, 0)
 	s.handler.scopes = nil
 }
 

--- a/hooks/platform.go
+++ b/hooks/platform.go
@@ -154,5 +154,7 @@ func (nullKeyRevealer) RevealKey(handle, ciphertext, aad []byte) (plaintext []by
 }
 
 func init() {
-	secboot.RegisterPlatformKeyDataHandler(platformName, new(hooksPlatform))
+	// Just use the flags to describe the current version of this platform.
+	flags := secboot.PlatformKeyDataHandlerFlags(0).AddPlatformFlags(3)
+	secboot.RegisterPlatformKeyDataHandler(platformName, new(hooksPlatform), flags)
 }

--- a/keydata.go
+++ b/keydata.go
@@ -478,8 +478,8 @@ func (d *KeyData) derivePassphraseKeys(passphrase string) (key, iv, auth []byte,
 }
 
 func (d *KeyData) updatePassphrase(payload, oldAuthKey []byte, passphrase string, platformContext any) error {
-	handler := handlers[d.data.PlatformName]
-	if handler == nil {
+	handlerInfo, exists := handlers[d.data.PlatformName]
+	if !exists {
 		return ErrNoPlatformHandlerRegistered
 	}
 
@@ -493,7 +493,7 @@ func (d *KeyData) updatePassphrase(payload, oldAuthKey []byte, passphrase string
 		return fmt.Errorf("unexpected encryption algorithm \"%s\"", d.data.PassphraseParams.Encryption)
 	}
 
-	handle, err := handler.ChangeAuthKey(d.platformKeyData(), oldAuthKey, authKey, platformContext)
+	handle, err := handlerInfo.handler.ChangeAuthKey(d.platformKeyData(), oldAuthKey, authKey, platformContext)
 	if err != nil {
 		return err
 	}
@@ -658,12 +658,12 @@ func (d *KeyData) RecoverKeys() (DiskUnlockKey, PrimaryKey, error) {
 		return nil, nil, errors.New("cannot recover key without authorization")
 	}
 
-	handler := handlers[d.data.PlatformName]
-	if handler == nil {
+	handlerInfo, exists := handlers[d.data.PlatformName]
+	if !exists {
 		return nil, nil, ErrNoPlatformHandlerRegistered
 	}
 
-	c, err := handler.RecoverKeys(d.platformKeyData(), d.data.EncryptedPayload)
+	c, err := handlerInfo.handler.RecoverKeys(d.platformKeyData(), d.data.EncryptedPayload)
 	if err != nil {
 		return nil, nil, processPlatformHandlerError(err)
 	}
@@ -676,8 +676,8 @@ func (d *KeyData) RecoverKeysWithPassphrase(passphrase string) (DiskUnlockKey, P
 		return nil, nil, errors.New("cannot recover key with passphrase")
 	}
 
-	handler := handlers[d.data.PlatformName]
-	if handler == nil {
+	handlerInfo, exists := handlers[d.data.PlatformName]
+	if !exists {
 		return nil, nil, ErrNoPlatformHandlerRegistered
 	}
 
@@ -686,7 +686,7 @@ func (d *KeyData) RecoverKeysWithPassphrase(passphrase string) (DiskUnlockKey, P
 		return nil, nil, err
 	}
 
-	c, err := handler.RecoverKeysWithAuthKey(d.platformKeyData(), payload, key)
+	c, err := handlerInfo.handler.RecoverKeysWithAuthKey(d.platformKeyData(), payload, key)
 	if err != nil {
 		return nil, nil, processPlatformHandlerError(err)
 	}

--- a/keydata_legacy_test.go
+++ b/keydata_legacy_test.go
@@ -34,7 +34,7 @@ var _ = Suite(&keyDataLegacySuite{})
 func (s *keyDataLegacySuite) SetUpSuite(c *C) {
 	s.handler = &mockPlatformKeyDataHandler{}
 	s.mockPlatformName = "mock-legacy"
-	RegisterPlatformKeyDataHandler(s.mockPlatformName, s.handler)
+	RegisterPlatformKeyDataHandler(s.mockPlatformName, s.handler, 0)
 }
 
 func (s *keyDataLegacySuite) SetUpTest(c *C) {
@@ -43,7 +43,7 @@ func (s *keyDataLegacySuite) SetUpTest(c *C) {
 }
 
 func (s *keyDataLegacySuite) TearDownSuite(c *C) {
-	RegisterPlatformKeyDataHandler(s.mockPlatformName, nil)
+	RegisterPlatformKeyDataHandler(s.mockPlatformName, nil, 0)
 }
 
 func (s *keyDataLegacySuite) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKey, PrimaryKey) {

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -281,7 +281,7 @@ type keyDataTestBase struct {
 func (s *keyDataTestBase) SetUpSuite(c *C) {
 	s.handler = &mockPlatformKeyDataHandler{}
 	s.mockPlatformName = "mock"
-	RegisterPlatformKeyDataHandler(s.mockPlatformName, s.handler)
+	RegisterPlatformKeyDataHandler(s.mockPlatformName, s.handler, 0)
 }
 
 func (s *keyDataTestBase) SetUpTest(c *C) {
@@ -303,7 +303,7 @@ func (s *keyDataTestBase) TearDownTest(c *C) {
 }
 
 func (s *keyDataTestBase) TearDownSuite(c *C) {
-	RegisterPlatformKeyDataHandler(s.mockPlatformName, nil)
+	RegisterPlatformKeyDataHandler(s.mockPlatformName, nil, 0)
 }
 
 func (s *keyDataTestBase) newPrimaryKey(c *C, sz1 int) PrimaryKey {

--- a/plainkey/platform.go
+++ b/plainkey/platform.go
@@ -142,5 +142,7 @@ func (*platformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, old,
 }
 
 func init() {
-	secboot.RegisterPlatformKeyDataHandler(platformName, &platformKeyDataHandler{})
+	// Just use the flags to describe the current version of this platform.
+	flags := secboot.PlatformKeyDataHandlerFlags(0).AddPlatformFlags(1)
+	secboot.RegisterPlatformKeyDataHandler(platformName, &platformKeyDataHandler{}, flags)
 }

--- a/platform_test.go
+++ b/platform_test.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	. "github.com/snapcore/secboot"
+
+	. "gopkg.in/check.v1"
+)
+
+type platformSuite struct{}
+
+var _ = Suite(&platformSuite{})
+
+func (s *platformSuite) TestPlatformKeyDataHandlerFlagsAddPlatformFlagsGood1(c *C) {
+	flags := PlatformKeyDataHandlerFlags(0x080000000000)
+	flags = flags.AddPlatformFlags(50)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(0x080000000032))
+}
+
+func (s *platformSuite) TestPlatformKeyDataHandlerFlagsAddPlatformFlagsGood2(c *C) {
+	flags := PlatformKeyDataHandlerFlags(0x480000000000)
+	flags = flags.AddPlatformFlags(0xffffffffff)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(0x48ffffffffff))
+}
+
+func (s *platformSuite) TestPlatformKeyDataHandlerFlagsAddPlatformFlagsBad(c *C) {
+	flags := PlatformKeyDataHandlerFlags(0x080000000000)
+	c.Check(func() { flags.AddPlatformFlags(0x090000000000) }, PanicMatches, `platform is using flag bits reserved for common flags: 0x90000000000`)
+}
+
+func (s *platformSuite) TestRegisterPlatformKeyDataHandler(c *C) {
+	handler := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("mock", handler, 50)
+	handler2, flags, err := RegisteredPlatformKeyDataHandler("mock")
+	c.Assert(err, IsNil)
+	c.Check(handler2, Equals, handler)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(50))
+}
+
+func (s *platformSuite) TestRegisterPlatformKeyDataHandlerDifferentName(c *C) {
+	handler := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("foo", handler, 50)
+	handler2, flags, err := RegisteredPlatformKeyDataHandler("foo")
+	c.Assert(err, IsNil)
+	c.Check(handler2, Equals, handler)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(50))
+}
+
+func (s *platformSuite) TestRegisterPlatformKeyDataHandlerDifferentFlags(c *C) {
+	handler := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("mock", handler, 0xffffffffff)
+	handler2, flags, err := RegisteredPlatformKeyDataHandler("mock")
+	c.Assert(err, IsNil)
+	c.Check(handler2, Equals, handler)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(0xffffffffff))
+}
+
+func (s *platformSuite) TestUnregisterPlatformKeyDataHandler(c *C) {
+	RegisterPlatformKeyDataHandler("mock", new(mockPlatformKeyDataHandler), 50)
+	RegisterPlatformKeyDataHandler("mock", nil, 0)
+	_, _, err := RegisteredPlatformKeyDataHandler("mock")
+	c.Check(err, Equals, ErrNoPlatformHandlerRegistered)
+}
+
+func (s *platformSuite) TestReRegisterPlatformKeyDataHandler(c *C) {
+	handler1 := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("mock", handler1, 50)
+	handler2 := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("mock", handler2, 0xffffffffff)
+	handler3, flags, err := RegisteredPlatformKeyDataHandler("mock")
+	c.Assert(err, IsNil)
+	c.Check(handler3, Equals, handler2)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(0xffffffffff))
+}
+
+func (s *platformSuite) TestRegisterMultiplePlatformKeyDataHandler(c *C) {
+	handler1 := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("mock", handler1, 50)
+	handler2 := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("foo", handler2, 0xffffffffff)
+
+	handler3, flags, err := RegisteredPlatformKeyDataHandler("mock")
+	c.Assert(err, IsNil)
+	c.Check(handler3, Equals, handler1)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(50))
+
+	handler3, flags, err = RegisteredPlatformKeyDataHandler("foo")
+	c.Assert(err, IsNil)
+	c.Check(handler3, Equals, handler2)
+	c.Check(flags, Equals, PlatformKeyDataHandlerFlags(0xffffffffff))
+}
+
+func (s *platformSuite) TestListRegisteredKeyDataPlatforms(c *C) {
+	handler1 := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("mock", handler1, 50)
+	handler2 := new(mockPlatformKeyDataHandler)
+	RegisterPlatformKeyDataHandler("foo", handler2, 0xffffffffff)
+
+	c.Check(ListRegisteredKeyDataPlatforms(), DeepEquals, []string{"foo", "mock"})
+}

--- a/tpm2/platform.go
+++ b/tpm2/platform.go
@@ -240,5 +240,7 @@ func (h *platformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, ol
 }
 
 func init() {
-	secboot.RegisterPlatformKeyDataHandler(platformName, new(platformKeyDataHandler))
+	// Just use the flags to describe the current version of this platform.
+	flags := secboot.PlatformKeyDataHandlerFlags(0).AddPlatformFlags(3)
+	secboot.RegisterPlatformKeyDataHandler(platformName, new(platformKeyDataHandler), flags)
 }

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -157,5 +157,7 @@ func NewKeyDataFromSealedKeyObjectFile(path string) (*secboot.KeyData, error) {
 }
 
 func init() {
-	secboot.RegisterPlatformKeyDataHandler(legacyPlatformName, &legacyPlatformKeyDataHandler{})
+	// Just use the flags to describe the current version of this platform.
+	flags := secboot.PlatformKeyDataHandlerFlags(0).AddPlatformFlags(2)
+	secboot.RegisterPlatformKeyDataHandler(legacyPlatformName, &legacyPlatformKeyDataHandler{}, flags)
 }


### PR DESCRIPTION
When adding features to key metadata, we need to be sure that we have kernels that contain a snap-bootstrap based on a new enough version of secboot before those features can be used. Given that other requirements mean that we will be passing information from early boot to snapd, we may as well pass information about the secboot packages compiled into snap-bootstrap as part of that information.

In order to do this, I've added a way for each platform that registers a handler to be able to specify a set of flags. Each platform has 40-bits which they can use however they choose. The remaining 24-bits may be used for common flags in the future (eg, we could have a common flag to allow a platform to indicate that it supports user auth rather than doing what we do today - we just call into the platform's `RecoverKeysWithAuthKey` and `ChangeAuthKey` methods and expect them to return an error).

The existing platforms are just using the lower bis of the flags to indicate the platform version / generation for now, but the 40-bits should be sufficient to allow a platform to define a mix of version / generation and / or feature flags, should there be a need to in the future.

The stateful API for activation will capture these flags for all registered platforms.