### PR TITLE
efi/preinstall: Add missing test for expected CheckResultFlags

### DIFF
--- a/efi/preinstall/checks_test.go
+++ b/efi/preinstall/checks_test.go
@@ -113,6 +113,7 @@ func (s *runChecksSuite) testRunChecks(c *C, params *testRunChecksParams) (warni
 	for i, ca := range result.UsedSecureBootCAs {
 		c.Check(ca, DeepEquals, params.expectedUsedSecureBootCAs[i])
 	}
+	c.Check(result.Flags, Equals, params.expectedFlags)
 
 	dev, err := params.env.TPMDevice()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The unit tests were supplying expected flags but the tests were not
actually testing that the returned value matches.