### PR TITLE
efi/preinstall: Include crypto/sha1 package

### DIFF
--- a/efi/preinstall/check_tcglog.go
+++ b/efi/preinstall/check_tcglog.go
@@ -21,6 +21,7 @@ package preinstall
 
 import (
 	"bytes"
+	_ "crypto/sha1"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	"encoding/binary"


### PR DESCRIPTION
As SHA1 is a PCR algorithm that this package can choose (with the `PermitWeakPCRBanks` flag enabled), this package should include the `crypto/sha1` package so that the behaviour is consistent with other algorithms where we already include those packages for supported algorithms.