### PR TITLE
tests: Use the stable channel for the TPM simulator

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,12 @@ jobs:
       matrix:
         goversion:
           - 1.18
-          - stable
+# The unit tests currently fail against the new stable go
+# version (1.24). This needs investigating and resolving,
+# but in the meantime, we'll do tests against 1.23.
+# See https://github.com/canonical/secboot/issues/383
+#         - stable
+          - 1.23
     steps:
     - name: Set up Go ${{ matrix.goversion }}
       uses: actions/setup-go@v4
@@ -24,7 +29,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y sbsigntool
           sudo snap install core core18
-          sudo snap install --edge tpm2-simulator-chrisccoulson
+          sudo snap install tpm2-simulator-chrisccoulson
     - name: Build
       run: go build -v
     - name: Test


### PR DESCRIPTION
I'm in the process of updating the TPM simulator to the one based on
v1.83 of the reference library. Although the default reference build
still keeps SHA1 as a supported algorithm, it only enables the SHA256
and SHA384 PCR banks by default, which is likely to break some tests
where we assume that we have SHA1 banks (as we are able to with the
version of the simulator we've been using for the previous ~2 years).

In order to make the transition smoother, I've copied the previous
version of the TPM simulator to stable, and this updates the workflow
to pull in the simulator from latest/stable. I'll probably need to do
some work in secboot in order to get the tests working in the absence
of the SHA1 bank by default, after which, the new simulator based on
v1.83 of the reference library can be promoted to stable for use in
secboot testing.

Note that whilst I was making this change, it became apparent that the
unrelated tests have begun to fail against the latest stable go version
(1.24 was released a week ago). I've verified that I get the same failures
locally as well. As a temporary workaround, I've disabled the tests against
stable and hard-coded go 1.23.

See https://github.com/canonical/secboot/issues/383 to track the investigation of this.