### PR TITLE
efi/preinstall: Add some more TPM tests

### DIFF
--- a/efi/preinstall/check_tpm.go
+++ b/efi/preinstall/check_tpm.go
@@ -83,7 +83,8 @@ func openAndCheckTPM2Device(env internal_efi.HostEnvironment, flags checkTPM2Dev
 	// testing - the important detail is that this statement only applies to full self-tests, which
 	// we aren't requesting here (and don't want to - we only want to test functionality that hasn't
 	// been tested yet). For now, we'll assume that the same statement applies also to
-	// TPM2_SelfTest(NO) and only support the case where it runs the tests synchronously - we can
+	// TPM2_SelfTest(NO) (there's no good reason why an implementation would implement both cases
+	// differently) and only support the case where it runs the tests synchronously - we can
 	// uncomment the other path later on if we come across implementations that need it, perhaps
 	// with some sort of timeout.
 	err = tpm.SelfTest(false)

--- a/efi/preinstall/check_tpm_test.go
+++ b/efi/preinstall/check_tpm_test.go
@@ -57,7 +57,7 @@ func (m *tpmPropertyModifierMixin) addTPMPropertyModifiers(c *C, overrides map[t
 		}
 
 		// Unpack the response
-		rc, rpBytes, rAuthArea, err := tpm2.ReadResponsePacket(rsp, nil)
+		rc, rpBytes, _, err := tpm2.ReadResponsePacket(bytes.NewReader(rsp.Bytes()), nil)
 		c.Assert(err, IsNil)
 		if rc != tpm2.ResponseSuccess {
 			// Do nothing if the TPM didn't return success
@@ -85,7 +85,7 @@ func (m *tpmPropertyModifierMixin) addTPMPropertyModifiers(c *C, overrides map[t
 
 		// Repack the response
 		rsp.Reset()
-		c.Check(tpm2.WriteResponsePacket(rsp, rc, nil, rpBytes, rAuthArea), IsNil)
+		c.Check(tpm2.WriteResponsePacket(rsp, rc, nil, rpBytes, nil), IsNil)
 	}
 }
 
@@ -102,6 +102,8 @@ func (s *tpmSuite) SetUpTest(c *C) {
 var _ = Suite(&tpmSuite{})
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersDiscreteTPM(c *C) {
+	// Test the good case for pre-install on bare-metal with a discrete TPM and
+	// infinite NV counters.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     0,
 		tpm2.PropertyPSFamilyIndicator: 1,
@@ -121,6 +123,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersD
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersFWTPM(c *C) {
+	// Test the good case for pre-install on bare-metal with a firmware TPM and infinite
+	// NV counters.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     0,
 		tpm2.PropertyPSFamilyIndicator: 1,
@@ -140,6 +144,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersF
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMFiniteCountersDiscreteTPM(c *C) {
+	// Test the good case for pre-install on bare-metal with a discrete TPM, and a
+	// finite but sufficient number of NV counters.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     6,
 		tpm2.PropertyNVCounters:        4,
@@ -160,6 +166,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMFiniteCountersDis
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMCountersCheckSkippedDiscreteTPM(c *C) {
+	// Test the good case for post-install on bare-metal with a discrete TPM, and make
+	// sure we skip the NV counter index check.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     6,
 		tpm2.PropertyNVCounters:        5,
@@ -179,26 +187,55 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMCountersCheckSki
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCounters(c *C) {
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSkippedDiscreteTPM(c *C) {
+	// Test the good case for post-install on bare-metal with a discrete TPM, and make
+	// sure we skip the hierarchy ownership check.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyNVCountersMax:     0,
 		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerMSFT),
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
 	})
+
+	// Set the lockout hierarchy auth value.
+	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsFalse)
+	c.Check(discreteTPM, testutil.IsTrue)
+	c.Check(dev.NumberOpen(), Equals, int(1))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSkippedDiscreteTPM_2(c *C) {
+	// Test the good case for post-install on bare-metal with a discrete TPM, and make
+	// sure we skip the hierarchy ownership check where we test for hierarchy policies.
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
+	})
+
+	// Set the owner hierarchy auth policy.
+	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), make([]byte, 32), tpm2.HashAlgorithmSHA256, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	c.Check(err, IsNil)
+	c.Assert(tpm, NotNil)
+	var tmpl tpm2_testutil.TransportWrapper
+	c.Assert(tpm.Transport(), Implements, &tmpl)
+	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
+	c.Check(discreteTPM, testutil.IsTrue)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMLockoutCheckSkipped(c *C) {
+	// Test the good case for post-install on bare-metal with a firmware TPM, and make
+	// sure we skip the lockout status check.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     6,
 		tpm2.PropertyNVCounters:        4,
@@ -221,19 +258,18 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMLockoutCheckSkip
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMLockoutOwnedCheckSkipped(c *C) {
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCounters(c *C) {
+	// Test the good case for pre-install on a VM with a swtpm that has
+	// infinite NV counters.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     0,
 		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerMSFT),
 	})
-
-	// Set the lockout hierarchy auth value.
-	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
@@ -243,19 +279,21 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMLockoutOwnedChec
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnerOwnedCheckSkipped(c *C) {
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCountersWithSWTPMWorkaround(c *C) {
+	// Test the good case for pre-install on a VM with a swtpm that has
+	// infinite NV counters, using the workaround for invalid TPM_PT_PS_FAMILY_INDICATOR.
+
+	family, err := s.TPM.GetCapabilityTPMProperty(tpm2.PropertyFamilyIndicator)
+	c.Check(err, IsNil)
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     0,
-		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		tpm2.PropertyPSFamilyIndicator: family,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerMSFT),
 	})
-
-	// Set the owner hierarchy auth value.
-	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.OwnerHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
@@ -265,35 +303,186 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnerOwnedCheckS
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMEndorsmentOwnedCheckSkipped(c *C) {
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersDiscreteTPMWithBackgroundSelfTest(c *C) {
+	// Test the good case for pre-install on bare-metal with a discrete TPM and
+	// infinite NV counters, mocking a TPM that performs self tests in the
+	// background.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     0,
 		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
 	})
 
-	// Set the endorsement hierarchy auth value.
-	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.EndorsementHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
+	// The above call relies on this.
+	origIntercept := s.Transport.ResponseIntercept
+	getTestResultLooped := false
+	s.Transport.ResponseIntercept = func(cmdCode tpm2.CommandCode, cmdHandles tpm2.HandleList, cmdAuthArea []tpm2.AuthCommand, cpBytes []byte, rsp *bytes.Buffer) {
+		switch cmdCode {
+		case tpm2.CommandSelfTest:
+			// Unpack the response
+			rc, _, _, err := tpm2.ReadResponsePacket(bytes.NewReader(rsp.Bytes()), nil)
+			c.Assert(err, IsNil)
+			if rc != tpm2.ResponseSuccess {
+				// Do nothing if the TPM didn't return success
+				return
+			}
+
+			// Return a response indicating that the tests are running in the background.
+			rsp.Reset()
+			c.Check(tpm2.WriteResponsePacket(rsp, tpm2.ResponseTesting, nil, nil, nil), IsNil)
+
+		case tpm2.CommandGetTestResult:
+			// Unpack the response
+			rc, rpBytes, _, err := tpm2.ReadResponsePacket(bytes.NewReader(rsp.Bytes()), nil)
+			c.Assert(err, IsNil)
+			if rc != tpm2.ResponseSuccess {
+				// Do nothing if the TPM didn't return success
+				return
+			}
+
+			var outData tpm2.MaxBuffer
+			var testResult tpm2.ResponseCode
+			_, err = mu.UnmarshalFromBytes(rpBytes, &outData, &testResult)
+			if testResult != tpm2.ResponseSuccess {
+				// Do nothing if the tests actully failed
+				return
+			}
+
+			testResult = tpm2.ResponseSuccess
+			if !getTestResultLooped {
+				testResult = tpm2.ResponseTesting
+				getTestResultLooped = true
+			}
+
+			rsp.Reset()
+			rpBytes = mu.MustMarshalToBytes(outData, testResult)
+			c.Check(tpm2.WriteResponsePacket(rsp, tpm2.ResponseSuccess, nil, rpBytes, nil), IsNil)
+
+		default:
+			origIntercept(cmdCode, cmdHandles, cmdAuthArea, cpBytes, rsp)
+		}
+	}
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsFalse)
+	c.Check(discreteTPM, testutil.IsTrue)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
+
+// Error cases begin here.
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceNoTPM(c *C) {
+	// Test the case where there isn't a TPM2 device.
 	env := efitest.NewMockHostEnvironmentWithOpts()
 	_, _, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, Equals, ErrNoTPM2Device)
 }
 
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceFailureMode(c *C) {
+	// Test the case where the TPM is in failure mode.
+	s.Mssim(c).TestFailureMode()
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrTPMFailure)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceFailureModeBackgroundTest(c *C) {
+	// Test the case where the TPM is in failure mode, and it performs self-tests
+	// in the background (we have to mock this behaviour because the simulator
+	// doesn't work like this).
+	getTestResultLooped := false
+	s.Transport.ResponseIntercept = func(cmdCode tpm2.CommandCode, cmdHandles tpm2.HandleList, cmdAuthArea []tpm2.AuthCommand, cpBytes []byte, rsp *bytes.Buffer) {
+		switch cmdCode {
+		case tpm2.CommandSelfTest:
+			// Unpack the response
+			rc, _, _, err := tpm2.ReadResponsePacket(rsp, nil)
+			c.Assert(err, IsNil)
+			if rc != tpm2.ResponseSuccess {
+				// Do nothing if the TPM didn't return success
+				return
+			}
+
+			// Return a response indicating that the tests are running in the background.
+			rsp.Reset()
+			c.Check(tpm2.WriteResponsePacket(rsp, tpm2.ResponseTesting, nil, nil, nil), IsNil)
+
+		case tpm2.CommandGetTestResult:
+			// Unpack the response
+			rc, rpBytes, _, err := tpm2.ReadResponsePacket(rsp, nil)
+			c.Assert(err, IsNil)
+			if rc != tpm2.ResponseSuccess {
+				// Do nothing if the TPM didn't return success
+				return
+			}
+
+			var outData tpm2.MaxBuffer
+			var testResult tpm2.ResponseCode
+			_, err = mu.UnmarshalFromBytes(rpBytes, &outData, &testResult)
+			if testResult != tpm2.ResponseSuccess {
+				// Do nothing if the tests actully failed
+				return
+			}
+
+			testResult = tpm2.ResponseFailure
+			if !getTestResultLooped {
+				testResult = tpm2.ResponseTesting
+				getTestResultLooped = true
+			}
+
+			rsp.Reset()
+			rpBytes = mu.MustMarshalToBytes(outData, testResult)
+			c.Check(tpm2.WriteResponsePacket(rsp, tpm2.ResponseSuccess, nil, rpBytes, nil), IsNil)
+		}
+	}
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrTPMFailure)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClient(c *C) {
+	// Test for not having a PC Client TPM2 device.
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 2, // This is defined as PDA in the reference library specs
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrNoPCClientTPM)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClientWithSWTPMWorkaround(c *C) {
+	// Test for not having a PC Client TPM2 device, when running in a VM, which
+	// has a workaround for the swtpm.
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 2, // This is defined as PDA in the reference library specs
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
+	c.Check(err, Equals, ErrNoPCClientTPM)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceDisabled(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+	})
+
 	// Disable owner and endorsement hierarchies
 	c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
 	c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
@@ -302,6 +491,144 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceDisabled(c *C) {
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
 	_, _, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, Equals, ErrTPMDisabled)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockout(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+	})
+
+	// Set the lockout hierarchy auth value so we get an error indicating that the TPM is already owned.
+	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
+- TPM_RH_LOCKOUT has an authorization value
+`)
+
+	var e *TPM2OwnedHierarchiesError
+	c.Check(errors.As(err, &e), testutil.IsTrue)
+	c.Check(e.WithAuthValue, DeepEquals, tpm2.HandleList{tpm2.HandleLockout})
+	c.Check(e.WithAuthPolicy, HasLen, 0)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwner(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+	})
+
+	// Set the owner hierarchy auth value so we get an error indicating that the TPM is already owned.
+	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.OwnerHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
+- TPM_RH_OWNER has an authorization value
+`)
+
+	var e *TPM2OwnedHierarchiesError
+	c.Check(errors.As(err, &e), testutil.IsTrue)
+	c.Check(e.WithAuthValue, DeepEquals, tpm2.HandleList{tpm2.HandleOwner})
+	c.Check(e.WithAuthPolicy, HasLen, 0)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsement(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+	})
+
+	// Set the endorsement hierarchy auth value so we get an error indicating that the TPM is already owned.
+	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.EndorsementHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
+- TPM_RH_ENDORSEMENT has an authorization value
+`)
+
+	var e *TPM2OwnedHierarchiesError
+	c.Check(errors.As(err, &e), testutil.IsTrue)
+	c.Check(e.WithAuthValue, DeepEquals, tpm2.HandleList{tpm2.HandleEndorsement})
+	c.Check(e.WithAuthPolicy, HasLen, 0)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockoutWithPolicy(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+	})
+
+	// Set an authorization policy and test that we get the appropriate error.
+	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.LockoutHandleContext(), testutil.DecodeHexString(c, "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"), tpm2.HashAlgorithmSHA256, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
+- TPM_RH_LOCKOUT has an authorization policy
+`)
+
+	var e *TPM2OwnedHierarchiesError
+	c.Check(errors.As(err, &e), testutil.IsTrue)
+	c.Check(e.WithAuthValue, HasLen, 0)
+	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleLockout})
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwnerWithPolicy(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+	})
+
+	// Set an authorization policy and test that we get the appropriate error.
+	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), testutil.DecodeHexString(c, "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"), tpm2.HashAlgorithmSHA256, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
+- TPM_RH_OWNER has an authorization policy
+`)
+
+	var e *TPM2OwnedHierarchiesError
+	c.Check(errors.As(err, &e), testutil.IsTrue)
+	c.Check(e.WithAuthValue, HasLen, 0)
+	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleOwner})
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsementWithPolicy(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+	})
+
+	// Set an authorization policy and test that we get the appropriate error.
+	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.EndorsementHandleContext(), testutil.DecodeHexString(c, "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"), tpm2.HashAlgorithmSHA256, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
+- TPM_RH_ENDORSEMENT has an authorization policy
+`)
+
+	var e *TPM2OwnedHierarchiesError
+	c.Check(errors.As(err, &e), testutil.IsTrue)
+	c.Check(e.WithAuthValue, HasLen, 0)
+	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleEndorsement})
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
 
@@ -321,81 +648,23 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceLockout(c *C) {
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockout(c *C) {
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceHierarchyOwnershipHasPriorityOverLockout(c *C) {
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyPSFamilyIndicator: 1,
 		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 	})
 
-	// Set the lockout hierarchy auth value so we get an error indicating that the TPM is already owned.
-	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
+	s.HierarchyChangeAuth(c, tpm2.HandleOwner, []byte("1234"))
+
+	// Trip the DA logic by setting newMaxTries to 0
+	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
 	_, _, err := OpenAndCheckTPM2Device(env, 0)
-	c.Check(err, ErrorMatches, `TPM lockout hierarchy is currently owned`)
-	var he *TPM2HierarchyOwnedError
-	c.Check(errors.As(err, &he), testutil.IsTrue)
-	c.Check(dev.NumberOpen(), Equals, int(0))
-}
-
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwner(c *C) {
-	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-	})
-
-	// Set the owner hierarchy auth value so we get an error indicating that the TPM is already owned.
-	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.OwnerHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
-
-	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
-	c.Check(err, ErrorMatches, `TPM owner hierarchy is currently owned`)
-	var he *TPM2HierarchyOwnedError
-	c.Check(errors.As(err, &he), testutil.IsTrue)
-	c.Check(dev.NumberOpen(), Equals, int(0))
-}
-
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsement(c *C) {
-	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-	})
-
-	// Set the endorsement hierarchy auth value so we get an error indicating that the TPM is already owned.
-	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.EndorsementHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
-
-	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
-	c.Check(err, ErrorMatches, `TPM endorsement hierarchy is currently owned`)
-	var he *TPM2HierarchyOwnedError
-	c.Check(errors.As(err, &he), testutil.IsTrue)
-	c.Check(dev.NumberOpen(), Equals, int(0))
-}
-
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClient(c *C) {
-	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyPSFamilyIndicator: 2, // This is defined as PDA in the reference library specs
-	})
-
-	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
-	c.Check(err, Equals, ErrNoPCClientTPM)
-	c.Check(dev.NumberOpen(), Equals, int(0))
-}
-
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClientWithSWTPMWorkaround(c *C) {
-	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyPSFamilyIndicator: 2, // This is defined as PDA in the reference library specs
-	})
-
-	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
-	c.Check(err, Equals, ErrNoPCClientTPM)
+	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
+- TPM_RH_OWNER has an authorization value
+`)
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
 
@@ -404,6 +673,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceInsufficientNVCountersPreInstall(c 
 		tpm2.PropertyNVCountersMax:     6,
 		tpm2.PropertyNVCounters:        5,
 		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
 	})
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/canonical/go-efilib v1.4.1
 	github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
-	github.com/canonical/go-tpm2 v1.11.1
+	github.com/canonical/go-tpm2 v1.12.2
 	github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981
 	github.com/snapcore/snapd v0.0.0-20220714152900-4a1f4c93fc85
 	golang.org/x/crypto v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod 
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=
 github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61/go.mod h1:vG41hdbBjV4+/fkubTT1ENBBqSkLwLr7mCeW9Y6kpZY=
-github.com/canonical/go-tpm2 v1.11.1 h1:RivdSXfBWWW+eFaFNYQby5+kVgY4km9eEayot1wX/qU=
-github.com/canonical/go-tpm2 v1.11.1/go.mod h1:zK+qESVwu78XyX+NPhiBdN+zwPPDoKk4rYlQ7VUsRp4=
+github.com/canonical/go-tpm2 v1.12.2 h1:7sWef6xVlWwBAn7hsY+3j62ANzoAO+GZvrltMHXq9RQ=
+github.com/canonical/go-tpm2 v1.12.2/go.mod h1:zK+qESVwu78XyX+NPhiBdN+zwPPDoKk4rYlQ7VUsRp4=
 github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2/go.mod h1:QoW2apR2tBl6T/4czdND/EHjL1Ia9cCmQnIj9Xe0Kt8=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981 h1:vrUzSfbhl8mzdXPzjxq4jXZPCCNLv18jy6S7aVTS2tI=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981/go.mod h1:ywdPBqUGkuuiitPpVWCfilf2/gq+frhq4CNiNs9KyHU=


### PR DESCRIPTION
This adds 2 more TPM tests:
- That no hierarchy has an authorization policy set.
- That the TPM is not in failure mode.

It also moves the lockout check until after we've checked that all of
the hierarchies are unowned. This is because it simplifies potential
options for rectifying this failure later.

Also, the hierarchy ownership checks are rolled into a new error
(TPM2OwnedHierarchiesError) which can capture multiple hierarchies in a
single error, which is a bit more useful.