### PR TITLE
efi/preinstall Add initial RunChecksContext API

### DIFF
--- a/efi/preinstall/actions.go
+++ b/efi/preinstall/actions.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+// Action describes an Action to resolve a detected error. Some [ErrorKind]s may
+// be associated with one or more Actions that can be taken in order to resolve
+// the error. The code that calls [RunChecksContext.Run] can respond with one of
+// these actions.
+//
+// An installer UI may offer some of these actions in response to detected errors,
+// although note that it doesn't have to offer all actions associated with an error,
+// and the documentation for some actions provide hints as to whether they are
+// inappropriate for an installer UI. In some cases, it may be appropriate for snapd
+// to choose an action as opposed to exposing it to the installer UI.
+//
+// TODO: Add some meaningful actions here later on.
+type Action string
+
+const (
+	// ActionNone corresponds to no action.
+	ActionNone Action = ""
+
+	// ActionReboot corresponds to rebooting the device. Note that this is a
+	// pseudo-action. It cannot be performed by this package - the caller
+	// should trigger the reboot.
+	ActionReboot Action = "reboot"
+
+	// ActionShutdown corresponds to shutting down the device. Note that this
+	// is a pseudo-action. It cannot be performed by this package - the caller
+	// should trigger the shutdown.
+	ActionShutdown Action = "shutdown"
+
+	// ActionRebootToFWSettings corresponds to rebooting the device to the firmware
+	// settings in order to resolve a problem manually. Note that this is a
+	// pseudo-action. It cannot be performed by this package - the caller should
+	// trigger the reboot to FW settings.
+	//
+	// TODO: How do we improve this by offering a hint of what needs to change
+	// from entering the firmware settings UI?
+	ActionRebootToFWSettings Action = "reboot-to-fw-settings"
+
+	// ActionContactOEM is a hint that the user should contact the OEM for the
+	// device because of a bug in the platform. It is a pseudo-action and cannnot
+	// be performed by this package.
+	ActionContactOEM Action = "contact-oem"
+
+	// ActionContactOSVendor is a hint that the user should contact the OS vendor
+	// because of a bug in the OS. It is a pseudo-action and cannnot be performed
+	// by this package.
+	ActionContactOSVendor Action = "contact-os-vendor"
+)
+
+// IsPseudoAction will return true if the action cannot actually be executed by
+// [RunChecksContext.Run], but the action is expected to be performed by the caller
+// (eg, snapd or the installer) instead.
+//
+// TODO: Add extra actions that can be performed by this package by passing the
+// action to [RunChecksContext.Run].
+func (a Action) IsPseudoAction() bool {
+	switch a {
+	case ActionReboot, ActionShutdown, ActionRebootToFWSettings, ActionContactOEM, ActionContactOSVendor:
+		return true
+	default:
+		return false
+	}
+}

--- a/efi/preinstall/actions.go
+++ b/efi/preinstall/actions.go
@@ -67,13 +67,13 @@ const (
 	ActionContactOSVendor Action = "contact-os-vendor"
 )
 
-// IsPseudoAction will return true if the action cannot actually be executed by
+// IsExternalAction will return true if the action cannot actually be executed by
 // [RunChecksContext.Run], but the action is expected to be performed by the caller
 // (eg, snapd or the installer) instead.
 //
 // TODO: Add extra actions that can be performed by this package by passing the
 // action to [RunChecksContext.Run].
-func (a Action) IsPseudoAction() bool {
+func (a Action) IsExternalAction() bool {
 	switch a {
 	case ActionReboot, ActionShutdown, ActionRebootToFWSettings, ActionContactOEM, ActionContactOSVendor:
 		return true

--- a/efi/preinstall/check_tpm_test.go
+++ b/efi/preinstall/check_tpm_test.go
@@ -766,10 +766,11 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceLockout(c *C) {
 	c.Assert(err, Implements, &tmpl)
 	c.Assert(err.(CompoundError).Unwrap(), HasLen, 1)
 
+	c.Check(err.(CompoundError).Unwrap()[0], Equals, ErrTPMLockout)
+
 	c.Check(tpm, NotNil)
 	c.Check(discreteTPM, testutil.IsFalse)
 
-	c.Check(err.(CompoundError).Unwrap()[0], Equals, ErrTPMLockout)
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
 

--- a/efi/preinstall/checks.go
+++ b/efi/preinstall/checks.go
@@ -29,10 +29,14 @@ import (
 	internal_efi "github.com/snapcore/secboot/internal/efi"
 )
 
-// CheckFlags can be used to customize the behaviour or [RunChecks].
+// CheckFlags can be used to customize the behaviour or [RunChecks] and [NewRunChecksContext].
 type CheckFlags int
 
 const (
+	// CheckFlagsDefault is the default flags for RunChecks and
+	// NewRunChecksContext if no other flags are supplied.
+	CheckFlagsDefault CheckFlags = 0
+
 	// PlatformFirmwareProfileSupportRequired indicates that support for
 	// [secboot_efi.WithPlatformFirmwareProfile] to generate profiles for
 	// PCR 0 is not optional.

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -31,6 +31,9 @@ import (
 	internal_efi "github.com/snapcore/secboot/internal/efi"
 )
 
+// errorKindToActions maps an error kinds to one or more possible actions. The
+// slice of actions is an OR in the sense that any one of these actions can
+// be eecuted to attempt to resolve the associated error kind.
 var errorKindToActions map[ErrorKind][]Action
 
 func init() {

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -175,7 +175,6 @@ func NewRunChecksContext(initialFlags CheckFlags, loadedImages []secboot_efi.Ima
 			ActionContactOEM:         true,
 			ActionContactOSVendor:    true,
 		},
-		expectedActions: []Action{ActionNone},
 	}
 }
 
@@ -217,6 +216,10 @@ func (c *RunChecksContext) filterUnavailableActions(actions []Action) (out []Act
 // isActionExpected determines if the supplied action is an expected
 // response to the last call to [RunChecksContext.Run].
 func (c *RunChecksContext) isActionExpected(action Action) bool {
+	if action == ActionNone {
+		// ActionNone is always expected.
+		return true
+	}
 	for _, expected := range c.expectedActions {
 		if expected == action {
 			return true
@@ -483,7 +486,7 @@ func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) 
 		return nil, err
 	}
 
-	c.expectedActions = []Action{ActionNone}
+	c.expectedActions = nil
 	var errs []error
 	for {
 		result, err := RunChecks(ctx, c.flags, c.loadedImages)

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -437,6 +437,7 @@ func (c *RunChecksContext) runAction(action Action, args ...any) error {
 	if !c.isActionExpected(action) {
 		return &WithKindAndActionsError{
 			Kind: ErrorKindUnexpectedAction,
+			Args: []byte("null"),
 			err:  errors.New("specified action is not expected"),
 		}
 	}
@@ -444,6 +445,7 @@ func (c *RunChecksContext) runAction(action Action, args ...any) error {
 	if action.IsExternalAction() {
 		return &WithKindAndActionsError{
 			Kind: ErrorKindUnexpectedAction,
+			Args: []byte("null"),
 			err:  errors.New("specified action is not implemented directly by this package"),
 		}
 	}
@@ -455,6 +457,7 @@ func (c *RunChecksContext) runAction(action Action, args ...any) error {
 	default:
 		return &WithKindAndActionsError{
 			Kind: ErrorKindUnexpectedAction,
+			Args: []byte("null"),
 			err:  errors.New("specified action is invalid"),
 		}
 	}
@@ -487,6 +490,8 @@ func (c *RunChecksContext) Result() *CheckResult {
 // to ask permission from the user to perform an action.
 func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) (*CheckResult, error) {
 	if err := c.runAction(action, args...); err != nil {
+		c.lastErr = err
+		c.errs = append(c.errs, err)
 		return nil, err
 	}
 
@@ -522,6 +527,7 @@ func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) 
 				if err != nil {
 					return nil, &WithKindAndActionsError{
 						Kind: ErrorKindInternal,
+						Args: []byte("null"),
 						err:  fmt.Errorf("cannot classify error %v: %w", e, err),
 					}
 				}
@@ -529,6 +535,7 @@ func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) 
 				if err != nil {
 					return nil, &WithKindAndActionsError{
 						Kind: ErrorKindInternal,
+						Args: []byte("null"),
 						err:  fmt.Errorf("cannot serialize error arguments: %w", err),
 					}
 				}
@@ -537,6 +544,7 @@ func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) 
 				if err != nil {
 					return nil, &WithKindAndActionsError{
 						Kind: ErrorKindInternal,
+						Args: []byte("null"),
 						err:  fmt.Errorf("cannot filter unavailable actions: %w", err),
 					}
 				}

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -431,7 +431,7 @@ func (c *RunChecksContext) runAction(action Action, args ...any) error {
 		}
 	}
 
-	if action.IsPseudoAction() {
+	if action.IsExternalAction() {
 		return &WithKindAndActionsError{
 			Kind: ErrorKindUnexpectedAction,
 			err:  errors.New("specified action is not implemented directly by this package"),

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -1,0 +1,585 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/canonical/go-tpm2"
+	secboot_efi "github.com/snapcore/secboot/efi"
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+var errorKindToActions map[ErrorKind][]Action
+
+func init() {
+	errorKindToActions = map[ErrorKind][]Action{
+		ErrorKindShutdownRequired: []Action{
+			ActionShutdown,
+		},
+		ErrorKindRebootRequired: []Action{
+			ActionReboot,
+		},
+		ErrorKindRunningInVM: []Action{
+			// TODO: Add action to add PermitVirtualMachine to CheckFlags
+		},
+		ErrorKindTPMDeviceFailure: []Action{
+			ActionReboot,
+			ActionContactOEM,
+		},
+		ErrorKindTPMDeviceDisabled: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to enable the TPM
+			// TODO: Add actions to enable the TPM via the PPI
+		},
+		ErrorKindTPMHierarchiesOwned: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to clear the TPM
+			// TODO: Add actions to clear the TPM, either directly if possible or via the PPI
+			// TODO: Add action to clear the authorization values / policies
+		},
+		ErrorKindTPMDeviceLockout: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to clear the TPM
+			// TODO: Add actions to clear the TPM, either directly if possible or via the PPI
+			// TODO: Add action to clear the lockout.
+		},
+		ErrorKindInsufficientTPMStorage: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to clear the TPM
+			// TODO: Add actions to clear the TPM, either directly if possible or via the PPI
+		},
+		ErrorKindNoSuitablePCRBank: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to enable other PCR banks
+			ActionContactOEM,         // suggest contacting the OEM because of a firmware bug
+			// TODO: Add an action to reconfigure PCR banks via the PPI.
+		},
+		ErrorKindEmptyPCRBanks: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to disable the empty PCR bank
+			ActionContactOEM,         // suggest contacting the OEM because of a firmware bug
+			// TODO: Add an action to reconfigure PCR banks via the PPI
+			// TODO: Add an action to add PermitEmptyPCRBanks to CheckFlags if the user is ok with accepting this.
+		},
+		ErrorKindUEFIDebuggingEnabled: []Action{
+			ActionContactOEM, // suggest contacting the OEM because of a firmware bug
+		},
+		ErrorKindInsufficientDMAProtection: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to enable DMA protection.
+		},
+		ErrorKindNoKernelIOMMU: []Action{
+			ActionContactOSVendor, // suggest contacting the OS vendor to supply a kernel with this feature enabled.
+		},
+		ErrorKindTPMStartupLocalityNotProtected: []Action{
+			// TODO: Add an action to add PermitNoDiscreteTPMResetMitigation to CheckFlags
+		},
+		ErrorKindHostSecurity: []Action{
+			ActionContactOEM, // suggest contacting the OEM because of a firmware bug or misconfigured root-of-trust
+		},
+		ErrorKindPCRUnusable: []Action{
+			ActionContactOEM, // suggest contacting the OEM because of a firmware bug
+		},
+		ErrorKindVARSuppliedDriversPresent: []Action{
+			// TODO: Add action to add PermitVARSuppliedDrivers to CheckFlags if they're necessary - this gives the
+			// user the chance to be aware of their existence.
+			// TODO: If the drivers are being loaded from BDS using DriverOrder and DriverXXXX variables, add action to delete these
+		},
+		ErrorKindSysPrepApplicationsPresent: []Action{
+			// TODO: Add action to add PermitSysPrepApplications to CheckFlags if the user wants to keep them -
+			// this gives the user the chance to be aware of their existence.
+			// TODO: Add an action to just disable these by erasing the SysPrepOrder and SysPrepXXXX variables
+		},
+		ErrorKindAbsolutePresent: []Action{
+			ActionContactOEM,         // suggest contacting the OEM if there's no way to disable it.
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to disable it.
+			// TODO: Add action to add PermitAbsoluteComputrace to CheckFlags if the user doesn't want to
+			// or can't disable it. This gives the user the chance to be aware of their existence.
+			// TODO: Add an action to just disable this automatically on supported platforms (eg, Dell via the WMI interface)
+		},
+		ErrorKindInvalidSecureBootMode: []Action{
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to properly configure secure boot
+			// TODO: Add action to add PCRProfileOptionPermitNoSecureBootPolicyProfile to the PCRProfileOptionsFlags,
+			//  noting that this flag will need to be subsequently passed to WithAutoTCGPCRProfile.
+		},
+		ErrorKindWeakSecureBootAlgorithmsDetected: []Action{
+			// TODO: Add action to add PermitWeakSecureBootAlgorithms to CheckFlags.
+		},
+		ErrorKindPreOSDigestVerificationDetected: []Action{
+			// TODO: Add action to add PermitPreOSVerificationUsingDigests to CheckFlags.
+		},
+	}
+}
+
+// RunChecksContext maintains context for multiple invocations of [RunChecks] to permit the
+// install process to iterate and resolve detected issues where possible. It also reduces
+// the burden of selecting an initial set of [CheckFlags].
+type RunChecksContext struct {
+	env          internal_efi.HostEnvironment
+	flags        CheckFlags
+	loadedImages []secboot_efi.Image
+	profileOpts  PCRProfileOptionsFlags
+
+	errs    []error
+	lastErr error
+	result  *CheckResult
+
+	availableActions map[Action]bool
+	expectedActions  []Action
+}
+
+// NewRunChecksContext returns a new RunChecksContext instance with the initial flags for [RunChecks]
+// and the supplied list of boot components for the current boot (see the documentation for [RunChecks].
+// The supplied [PCRProfileOptionsFlags] represent the preferred flags for [WithAutoTCGPCRProfile] and
+// should match the flags later passed to this function when creating a PCR profile. The PCRs that are
+// determined to be required to build the profile using [WithAutoTCGPCRProfile] will be made mandatory
+// automatically by this function by passing the relevant flags to [RunChecks].
+//
+// As [PCRProfileOptionsFlags] is intended to provide some limited amount of user customisation, this
+// API [RunChecksContext] should be executed again with the new set of flags, should the user wish to
+// change them. In this case, the caller should pass the PostInstallChecks flag as an initial flag.
+//
+// There is no need for the caller to supply any of these *SupportRequired flags as the initial flags,
+// and this may have the effect of limiting the number of devices which pass the checks.
+func NewRunChecksContext(initialFlags CheckFlags, loadedImages []secboot_efi.Image, profileOpts PCRProfileOptionsFlags) *RunChecksContext {
+	return &RunChecksContext{
+		env:          runChecksEnv,
+		flags:        initialFlags,
+		loadedImages: loadedImages,
+		profileOpts:  profileOpts,
+		// Populate actions that are always available or available by default
+		// unless we discover that they aren't later on.
+		availableActions: map[Action]bool{
+			ActionNone:               true,
+			ActionReboot:             true,
+			ActionShutdown:           true,
+			ActionRebootToFWSettings: true,
+			ActionContactOEM:         true,
+			ActionContactOSVendor:    true,
+		},
+		expectedActions: []Action{ActionNone},
+	}
+}
+
+// testActionAvailable will perform some tests in order to determine whether
+// the specified action is available.
+func (c *RunChecksContext) testActionAvailable(action Action) error {
+	available := false
+
+	switch action {
+	// TODO: Populate with actions to test as we add them later on.
+	}
+
+	c.availableActions[action] = available
+	return nil
+}
+
+// filterUnavailableActions will filter out any actions in the supplied slice
+// that are unavailable, and return a new slice containing only actions that
+// are available.
+func (c *RunChecksContext) filterUnavailableActions(actions []Action) (out []Action, err error) {
+	for _, action := range actions {
+		available, tested := c.availableActions[action]
+		switch {
+		case !tested:
+			if err := c.testActionAvailable(action); err != nil {
+				return nil, fmt.Errorf("cannot test whether action %q is available: %w", action, err)
+			}
+			if available := c.availableActions[action]; available {
+				out = append(out, action)
+			}
+		case available:
+			out = append(out, action)
+		}
+	}
+
+	return out, nil
+}
+
+// isActionExpected determines if the supplied action is an expected
+// response to the last call to [RunChecksContext.Run].
+func (c *RunChecksContext) isActionExpected(action Action) bool {
+	for _, expected := range c.expectedActions {
+		if expected == action {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyRunChecksError converts the supplied error which is returned from
+// [RunChecks] into an [ErrorKind] and associated arguments where applicable
+// (see the documentation for each error kind).
+func (c *RunChecksContext) classifyRunChecksError(err error) (ErrorKind, []any, error) {
+	if errors.Is(err, ErrVirtualMachineDetected) {
+		return ErrorKindRunningInVM, nil, nil
+	}
+	if errors.Is(err, ErrNoTPM2Device) || errors.Is(err, ErrNoPCClientTPM) {
+		return ErrorKindNoSuitableTPM2Device, nil, nil
+	}
+	if errors.Is(err, ErrTPMFailure) {
+		return ErrorKindTPMDeviceFailure, nil, nil
+	}
+	if errors.Is(err, ErrTPMDisabled) {
+		return ErrorKindTPMDeviceDisabled, nil, nil
+	}
+
+	var ownershipErr *TPM2OwnedHierarchiesError
+	if errors.As(err, &ownershipErr) {
+		var args []any
+		for _, hierarchy := range ownershipErr.WithAuthValue {
+			args = append(args, TPMHierarchyOwnershipInfo{
+				Hierarchy: hierarchy,
+				Type:      TPMHierarchyOwnershipAuthValue,
+			})
+		}
+		for _, hierarchy := range ownershipErr.WithAuthPolicy {
+			args = append(args, TPMHierarchyOwnershipInfo{
+				Hierarchy: hierarchy,
+				Type:      TPMHierarchyOwnershipAuthPolicy,
+			})
+		}
+		return ErrorKindTPMHierarchiesOwned, args, nil
+	}
+
+	if errors.Is(err, ErrTPMLockout) {
+		var (
+			lockoutCounter  uint32
+			lockoutInterval uint32
+		)
+		dev, err := c.env.TPMDevice()
+		if err != nil {
+			// This shouldn't be possible - we just did some tests against a TPM device.
+			return ErrorKindNone, nil, fmt.Errorf("cannot obtain TPM device: %w", err)
+		}
+		tpm, err := tpm2.OpenTPMDevice(dev)
+		if err != nil {
+			// Likewise, this also shouldn't be possible, for the same reason.
+			return ErrorKindNone, nil, fmt.Errorf("cannot open TPM device: %w", err)
+		}
+		defer tpm.Close()
+
+		var vals []uint32
+		for _, prop := range []tpm2.Property{tpm2.PropertyLockoutCounter, tpm2.PropertyLockoutInterval} {
+			val, err := tpm.GetCapabilityTPMProperty(prop)
+			if err != nil {
+				return ErrorKindNone, nil, fmt.Errorf("cannot read property %d: %w", prop, err)
+			}
+			vals = append(vals, val)
+		}
+		lockoutCounter = vals[0]
+		lockoutInterval = vals[1]
+		return ErrorKindTPMDeviceLockout, []any{time.Duration(lockoutInterval) * time.Second, time.Duration(lockoutInterval) * time.Second * time.Duration(lockoutCounter)}, nil
+	}
+
+	if errors.Is(err, ErrTPMInsufficientNVCounters) {
+		return ErrorKindInsufficientTPMStorage, nil, nil
+	}
+
+	// This has to become before MeasuredBootError because that error wraps this one.
+	var pcrAlgErr *NoSuitablePCRAlgorithmError
+	if errors.As(err, &pcrAlgErr) {
+		// RunChecks indicates that there is no suitable PCR bank. The possibilities here:
+		// - One or more ErrPCRBankMissingFromLog errors for algorithms supported by this
+		//   package that aren't present in the TCG log (SHA-512, SHA-384, SHA-256, and maybe
+		//   SHA1).
+		// - One or more PCR specific errors for mandatory PCRs, such as PCRValueMismatchError.
+		return ErrorKindNoSuitablePCRBank, nil, nil
+	}
+
+	var mbErr *MeasuredBootError
+	if errors.As(err, &mbErr) {
+		return ErrorKindMeasuredBoot, nil, nil
+	}
+
+	var tpmErr *TPM2DeviceError
+	if errors.As(err, &tpmErr) {
+		tpmRsp, isTpmErr := errorAsTPMErrorResponse(err)
+		switch {
+		case isTpmErr:
+			// TODO: Test this case
+			return ErrorKindTPMCommandFailed, []any{tpmRsp}, nil
+		case isInvalidTPMResponse(err):
+			// TODO: Test this case
+			return ErrorKindInvalidTPMResponse, nil, nil
+		case isTPMCommunicationError(err):
+			// TODO: Test this case
+			return ErrorKindTPMCommunication, nil, nil
+		}
+	}
+
+	var emptyPcrsErr *EmptyPCRBanksError
+	if errors.As(err, &emptyPcrsErr) {
+		var args []any
+		for _, alg := range emptyPcrsErr.Algs {
+			args = append(args, alg)
+		}
+		return ErrorKindEmptyPCRBanks, args, nil
+	}
+
+	var upErr *UnsupportedPlatformError
+	if errors.As(err, &upErr) {
+		// TODO: Add a test for this. To trigger this, we need to move
+		// the TPM discreteness check to after the host security check, as
+		// setting the CPU to an unknown type triggers an error there
+		// instead. This will land in a follow-up PR.
+		return ErrorKindUnsupportedPlatform, nil, nil
+	}
+
+	if errors.Is(err, ErrUEFIDebuggingEnabled) {
+		return ErrorKindUEFIDebuggingEnabled, nil, nil
+	}
+
+	if errors.Is(err, ErrInsufficientDMAProtection) {
+		return ErrorKindInsufficientDMAProtection, nil, nil
+	}
+
+	if errors.Is(err, ErrNoKernelIOMMU) {
+		return ErrorKindNoKernelIOMMU, nil, nil
+	}
+
+	if errors.Is(err, ErrTPMStartupLocalityNotProtected) {
+		return ErrorKindTPMStartupLocalityNotProtected, nil, nil
+	}
+
+	var hsErr *HostSecurityError
+	if errors.As(err, &hsErr) {
+		return ErrorKindHostSecurity, nil, nil
+	}
+
+	var pfPcrErr *PlatformFirmwarePCRError
+	if errors.As(err, &pfPcrErr) {
+		// XXX: It's currently impossible to hit this case
+		return ErrorKindPCRUnusable, []any{internal_efi.PlatformFirmwarePCR}, nil
+	}
+
+	var pcPcrErr *PlatformConfigPCRError
+	if errors.As(err, &pcPcrErr) {
+		return ErrorKindPCRUnsupported, []any{internal_efi.PlatformConfigPCR, "https://github.com/canonical/secboot/issues/322"}, nil
+	}
+
+	if errors.Is(err, ErrVARSuppliedDriversPresent) {
+		return ErrorKindVARSuppliedDriversPresent, nil, nil
+	}
+
+	var daPcrErr *DriversAndAppsPCRError
+	if errors.As(err, &daPcrErr) {
+		// XXX: It's currently impossible to hit this case
+		return ErrorKindPCRUnusable, []any{internal_efi.DriversAndAppsPCR}, nil
+	}
+
+	var dacPcrErr *DriversAndAppsConfigPCRError
+	if errors.As(err, &dacPcrErr) {
+		return ErrorKindPCRUnsupported, []any{internal_efi.DriversAndAppsConfigPCR, "https://github.com/canonical/secboot/issues/341"}, nil
+	}
+
+	if errors.Is(err, ErrSysPrepApplicationsPresent) {
+		return ErrorKindSysPrepApplicationsPresent, nil, nil
+	}
+	if errors.Is(err, ErrAbsoluteComputraceActive) {
+		return ErrorKindAbsolutePresent, nil, nil
+	}
+
+	var bmcPcrErr *BootManagerCodePCRError
+	if errors.As(err, &bmcPcrErr) {
+		return ErrorKindPCRUnusable, []any{internal_efi.BootManagerCodePCR}, nil
+	}
+
+	var bmccPcrErr *BootManagerConfigPCRError
+	if errors.As(err, &bmccPcrErr) {
+		return ErrorKindPCRUnsupported, []any{internal_efi.BootManagerConfigPCR, "https://github.com/canonical/secboot/issues/323"}, nil
+	}
+
+	if errors.Is(err, ErrNoSecureBoot) || errors.Is(err, ErrNoDeployedMode) {
+		return ErrorKindInvalidSecureBootMode, nil, nil
+	}
+	if errors.Is(err, ErrWeakSecureBootAlgorithmDetected) {
+		return ErrorKindWeakSecureBootAlgorithmsDetected, nil, nil
+	}
+	if errors.Is(err, ErrPreOSVerificationUsingDigests) {
+		return ErrorKindPreOSDigestVerificationDetected, nil, nil
+	}
+
+	var sbPcrErr *SecureBootPolicyPCRError
+	if errors.As(err, &sbPcrErr) {
+		return ErrorKindPCRUnusable, []any{internal_efi.SecureBootPolicyPCR}, nil
+	}
+
+	return ErrorKindInternal, nil, nil
+}
+
+func (c *RunChecksContext) runAction(action Action, args ...any) error {
+	if !c.isActionExpected(action) {
+		return &ErrorKindAndActions{
+			ErrorKind: ErrorKindUnexpectedAction,
+			err:       errors.New("specified action is not expected"),
+		}
+	}
+
+	if action.IsPseudoAction() {
+		return &ErrorKindAndActions{
+			ErrorKind: ErrorKindUnexpectedAction,
+			err:       errors.New("specified action is not implemented directly by this package"),
+		}
+	}
+
+	switch action {
+	case ActionNone:
+		// ok, do nothing
+		return nil
+	default:
+		return &ErrorKindAndActions{
+			ErrorKind: ErrorKindUnexpectedAction,
+			err:       errors.New("specified action is invalid"),
+		}
+	}
+}
+
+// LastError returns the error from the last [RunChecks] invocation. If it completed
+// successfully, this will return nil.
+func (c *RunChecksContext) LastError() error {
+	return c.lastErr
+}
+
+// Errors returns all errors from every [RunChecks] invocation.
+func (c *RunChecksContext) Errors() []error {
+	return c.errs
+}
+
+// Result returns the result from a successful invocation of [RunChecks]. This will
+// be nil if it hasn't completed successfully yet.
+func (c *RunChecksContext) Result() *CheckResult {
+	return c.result
+}
+
+// Run will run the specified action, and if that completes successfully will run another
+// iteration of [RunChecks] and test the result against the preferred [WithAutoTCGPCRProfile]
+// configuration. On success, this will return the CheckResult. On failure, this will return
+// an error which will either be a single ErrorKindAndActions, or multiple ErrorKindAndActions
+// wrapped by an error type that implements the [CompoundError] interface. If there are any
+// actions associated with an error, the install environment may try one or more of them in
+// order to try to resolve the issue that caused the error. In some cases, it may be appropriate
+// to ask permission from the user to perform an action.
+func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) (*CheckResult, error) {
+	if err := c.runAction(action, args...); err != nil {
+		return nil, err
+	}
+
+	c.expectedActions = []Action{ActionNone}
+	var errs []error
+	for {
+		result, err := RunChecks(ctx, c.flags, c.loadedImages)
+		c.lastErr = err
+
+		var profileErr error
+		if err == nil {
+			// If RunChecks succeeded, test the result against the profile options
+			// to see if we can generate a PCR combination.
+			profile := WithAutoTCGPCRProfile(result, c.profileOpts)
+			_, profileErr = profile.PCRs()
+		}
+		if err == nil && profileErr == nil {
+			// If neither step failed, break and return success.
+			c.result = result
+			break
+		}
+
+		if err != nil {
+			// If RunChecks failed, save its error and return the appropriate error kinds.
+			c.errs = append(c.errs, err)
+
+			// Reset the list of expected actions
+			c.expectedActions = nil
+
+			// Convert each error into ErrorKindAndActions
+			for _, e := range unwrapCompoundError(err) {
+				kind, args, err := c.classifyRunChecksError(e)
+				if err != nil {
+					return nil, &ErrorKindAndActions{
+						ErrorKind: ErrorKindInternal,
+						err:       fmt.Errorf("cannot classify error %v: %w", e, err),
+					}
+				}
+				jsonArgs, err := json.Marshal(args)
+				if err != nil {
+					return nil, &ErrorKindAndActions{
+						ErrorKind: ErrorKindInternal,
+						err:       fmt.Errorf("cannot serialize error arguments: %w", err),
+					}
+				}
+				actions := errorKindToActions[kind]
+				actions, err = c.filterUnavailableActions(actions)
+				if err != nil {
+					return nil, &ErrorKindAndActions{
+						ErrorKind: ErrorKindInternal,
+						err:       fmt.Errorf("cannot filter unavailable actions: %w", err),
+					}
+				}
+
+				errs = append(errs, &ErrorKindAndActions{
+					ErrorKind: kind,
+					ErrorArgs: jsonArgs,
+					Actions:   actions,
+					err:       e,
+				})
+				c.expectedActions = append(c.expectedActions, actions...)
+			}
+
+			break
+		}
+
+		// RunChecks succeeded but there was a profile error with the
+		// current PCRProfileOptionsFlags. Most errors should tell us which
+		// PCRs we're lacking support for.
+		var requiredPCRsErr *UnsupportedRequiredPCRsError
+		if !errors.As(profileErr, &requiredPCRsErr) {
+			return nil, &ErrorKindAndActions{
+				ErrorKind: ErrorKindInternal,
+				err:       fmt.Errorf("cannot test whether a PCR combination can be generated: %w", err),
+			}
+		}
+
+		// Make any PCRs we're lacking support for mandatory so that they end
+		// up being returned in the RunChecks error on the next iteration,
+		// which means we return a more appropriate set of error kinds.
+		for _, pcr := range requiredPCRsErr.PCRs {
+			switch pcr {
+			case 0:
+				c.flags |= PlatformFirmwareProfileSupportRequired
+			case 1:
+				c.flags |= PlatformConfigProfileSupportRequired
+			case 2:
+				c.flags |= DriversAndAppsProfileSupportRequired
+			case 3:
+				c.flags |= DriversAndAppsConfigProfileSupportRequired
+			case 4:
+				c.flags |= BootManagerCodeProfileSupportRequired
+			case 5:
+				c.flags |= BootManagerConfigProfileSupportRequired
+			case 7:
+				c.flags |= SecureBootPolicyProfileSupportRequired
+			}
+		}
+	}
+
+	if c.result != nil {
+		return c.result, nil
+	}
+
+	return nil, joinErrors(errs...)
+}

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -142,6 +142,10 @@ type RunChecksContext struct {
 	lastErr error
 	result  *CheckResult
 
+	// availableActions stores one of 3 states:
+	// - untested (a lack of value), meaning that a test of availability needs to be performed.
+	// - unavailable (a value of false).
+	// - available (a value of true).
 	availableActions map[Action]bool
 	expectedActions  []Action
 }

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -22,13 +22,14 @@ package preinstall_test
 import (
 	"context"
 	"crypto"
-	"errors"
 	"io"
 
 	"github.com/canonical/cpuid"
 	efi "github.com/canonical/go-efilib"
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/objectutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
+	"github.com/canonical/tcglog-parser"
 	secboot_efi "github.com/snapcore/secboot/efi"
 	. "github.com/snapcore/secboot/efi/preinstall"
 	internal_efi "github.com/snapcore/secboot/internal/efi"
@@ -38,43 +39,60 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type runChecksSuite struct {
+type runChecksContextSuite struct {
 	tpm2_testutil.TPMSimulatorTest
 	tpmPropertyModifierMixin
 	tcglogReplayMixin
 }
 
-func (s *runChecksSuite) SetUpTest(c *C) {
+func (s *runChecksContextSuite) SetUpTest(c *C) {
 	s.TPMSimulatorTest.SetUpTest(c)
 	s.tpmPropertyModifierMixin.transport = s.Transport
 	s.tcglogReplayMixin.impl = s
 }
 
-func (s *runChecksSuite) Tpm() *tpm2.TPMContext {
+func (s *runChecksContextSuite) Tpm() *tpm2.TPMContext {
 	return s.TPM
 }
 
-var _ = Suite(&runChecksSuite{})
+var _ = Suite(&runChecksContextSuite{})
 
-type testRunChecksParams struct {
+type actionAndArgs struct {
+	action Action
+	args   []any
+}
+
+type testRunChecksContextRunParams struct {
 	env                  internal_efi.HostEnvironment
 	tpmPropertyModifiers map[tpm2.Property]uint32
 	enabledBanks         []tpm2.HashAlgorithmId
-	prepare              func()
-	flags                CheckFlags
-	loadedImages         []secboot_efi.Image
+
+	initialFlags CheckFlags
+	loadedImages []secboot_efi.Image
+	profileOpts  PCRProfileOptionsFlags
+
+	iterations            int
+	prepare               func(int)
+	actions               []actionAndArgs
+	checkIntermediateErrs func(int, []*ErrorKindAndActions)
 
 	expectedPcrAlg            tpm2.HashAlgorithmId
 	expectedUsedSecureBootCAs []*X509CertificateID
 	expectedFlags             CheckResultFlags
+	expectedWarningsMatch     string
 }
 
-func (s *runChecksSuite) testRunChecks(c *C, params *testRunChecksParams) (warnings []error, err error) {
-	s.allocatePCRBanks(c, params.enabledBanks...)
-	log, err := params.env.ReadEventLog()
-	c.Assert(err, IsNil)
-	s.resetTPMAndReplayLog(c, log, log.Algorithms...)
-	s.addTPMPropertyModifiers(c, params.tpmPropertyModifiers)
+func (s *runChecksContextSuite) testRun(c *C, params *testRunChecksContextRunParams) (errs []*ErrorKindAndActions) {
+	_, err := params.env.TPMDevice()
+	if err == nil {
+		s.allocatePCRBanks(c, params.enabledBanks...)
+		s.addTPMPropertyModifiers(c, params.tpmPropertyModifiers)
+
+		log, err := params.env.ReadEventLog()
+		if err == nil {
+			s.resetTPMAndReplayLog(c, log, log.Algorithms...)
+		}
+	}
 
 	restore := MockEfiComputePeImageDigest(func(alg crypto.Hash, r io.ReaderAt, sz int64) ([]byte, error) {
 		c.Check(alg, Equals, params.expectedPcrAlg.GetHash())
@@ -83,6 +101,7 @@ func (s *runChecksSuite) testRunChecks(c *C, params *testRunChecksParams) (warni
 		c.Check(sz, Equals, int64(len(imageReader.contents)))
 		return imageReader.digest, nil
 	})
+	defer restore()
 
 	restore = MockRunChecksEnv(params.env)
 	defer restore()
@@ -99,31 +118,81 @@ func (s *runChecksSuite) testRunChecks(c *C, params *testRunChecksParams) (warni
 	})
 	defer restore()
 
-	if params.prepare != nil {
-		params.prepare()
+	ctx := NewRunChecksContext(params.initialFlags, params.loadedImages, params.profileOpts)
+	c.Assert(ctx, NotNil)
+
+	iterations := params.iterations
+	if iterations == 0 {
+		iterations = 1
+	}
+	c.Assert(params.actions, HasLen, iterations)
+
+	var result *CheckResult
+	for i := 0; i < iterations; i++ {
+		if params.prepare != nil {
+			params.prepare(i)
+		}
+
+		errs = nil
+
+		var err error
+		result, err = ctx.Run(context.Background(), params.actions[i].action, params.actions[i].args...)
+		if err == nil {
+			c.Check(i, Equals, iterations-1)
+			break
+		}
+
+		for _, e := range UnwrapCompoundError(err) {
+			c.Assert(e, testutil.ConvertibleTo, &ErrorKindAndActions{})
+			errs = append(errs, e.(*ErrorKindAndActions))
+		}
+
+		if i < (iterations-1) && params.checkIntermediateErrs != nil {
+			params.checkIntermediateErrs(i, errs)
+		}
 	}
 
-	result, err := RunChecks(context.Background(), params.flags, params.loadedImages)
-	if err != nil {
-		return nil, err
+	// Make sure we don't leave any open TPM connections
+	dev, err := params.env.TPMDevice()
+	if err == nil {
+		c.Assert(dev, testutil.ConvertibleTo, &tpm2_testutil.TransportBackedDevice{})
+		c.Check(dev.(*tpm2_testutil.TransportBackedDevice).NumberOpen(), Equals, 0)
 	}
 
+	// Check errors that were captured from intermediate execution of the Run() loop.
+	expectedErrsLen := iterations - 1
+	if len(errs) > 0 {
+		// The final loop failed, so we're expecting an extra error.
+		expectedErrsLen += 1
+	}
+	c.Assert(ctx.Errors(), HasLen, expectedErrsLen)
+
+	// Make sure that LastError() is the same as the last value returned from Errors()
+	if len(ctx.Errors()) > 0 {
+		c.Check(ctx.LastError(), Equals, ctx.Errors()[len(ctx.Errors())-1])
+	}
+
+	if len(errs) > 0 {
+		// Bail early on errors and have the caller test these.
+		return errs
+	}
+
+	// We passed without any errors, so test the result.
 	c.Check(result.PCRAlg, Equals, params.expectedPcrAlg)
 	c.Assert(result.UsedSecureBootCAs, HasLen, len(params.expectedUsedSecureBootCAs))
 	for i, ca := range result.UsedSecureBootCAs {
 		c.Check(ca, DeepEquals, params.expectedUsedSecureBootCAs[i])
 	}
 	c.Check(result.Flags, Equals, params.expectedFlags)
+	c.Check(result.Warnings, ErrorMatches, params.expectedWarningsMatch)
 
-	dev, err := params.env.TPMDevice()
-	c.Assert(err, IsNil)
-	c.Assert(dev, testutil.ConvertibleTo, &tpm2_testutil.TransportBackedDevice{})
-	c.Check(dev.(*tpm2_testutil.TransportBackedDevice).NumberOpen(), Equals, 0)
+	c.Check(ctx.Result(), DeepEquals, result)
 
-	return result.Warnings.Unwrap(), nil
+	return nil
 }
 
-func (s *runChecksSuite) TestRunChecksGood(c *C) {
+func (s *runChecksContextSuite) TestRunGood(c *C) {
+	// Good test on a fTPM with a single run
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -147,12 +216,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -180,30 +249,22 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodSHA384(c *C) {
+func (s *runChecksContextSuite) TestRunGoodSHA384(c *C) {
+	// Good test on a fTPM with a single run and SHA384 selected as the PCR bank
 	s.RequireAlgorithm(c, tpm2.AlgorithmSHA384)
 
 	meiAttrs := map[string][]byte{
@@ -229,14 +290,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA384},
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA384}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -264,30 +323,23 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "6c2df9007211786438be210b6908f2935d0b25ebdcd2c65621826fd2ec55fb9fbacbfe080d48db98f0ef970273b8254a")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "42f61b3089f5ce0646b422a59c9632065db2630f3e5b01690e63c41420ed31f10ff2a191f3440f9501109fc85f7fb00f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA384,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodSHA1(c *C) {
+func (s *runChecksContextSuite) TestRunGoodSHA1FromInitialFlags(c *C) {
+	// Good test on a fTPM with a single run and SHA1 as the selected algorithm,
+	// permitted by passing the PermitWeakPCRBanks flag as an initial flag.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -311,12 +363,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA1}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -333,6 +385,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA1},
+		initialFlags: PermitWeakPCRBanks,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -344,31 +397,27 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "1dc8bcbdb8b5ee60e87281e36161ec1f923f53b7")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "fc7840d38322a595e50a6b477685fdd2244f9292")},
 		},
-		flags:                     PermitWeakPCRBanks,
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA1,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodEmptySHA384(c *C) {
+// TODO: Test a good case that selects SHA1 without supplying the initial flag when we have an action to enable PermitWeakPCRBanks.
+
+func (s *runChecksContextSuite) TestRunGoodEmptySHA384FromInitialFlags(c *C) {
+	// Good test case on a fTPM despite an empty PCR bank, permitted by using
+	// PermitEmptyPCRBanks as an initial flag.
+	s.RequireAlgorithm(c, tpm2.AlgorithmSHA384)
+
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -392,12 +441,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -414,6 +463,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA384},
+		initialFlags: PermitEmptyPCRBanks,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -425,31 +475,26 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
-		flags:                     PermitEmptyPCRBanks,
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodPostInstall(c *C) {
+// TODO: Test a good case with an empty SHA-384 bank when we have an action to turn on the PermitEmptyPCRBanks flag
+
+func (s *runChecksContextSuite) TestRunGoodPostInstall(c *C) {
+	// Test good post-install scenario on a fTPM, which skips some tests related to
+	// TPM ownership, lockout status and checking the number of available
+	// NV counters.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -473,12 +518,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -496,7 +541,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PostInstallChecks,
+		initialFlags: PostInstallChecks,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -508,145 +553,27 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodVirtualMachine1(c *C) {
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode("qemu", internal_efi.DetectVirtModeVM),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitVirtualMachine,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | RunningInVirtualMachine,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
+// TODO: Test a good case with a VM setup when we have an action to turn on the PermitVirtualMachine flag.
+//
+// TODO: Test a good case with a discrete TPM where the startup locality is 0, when we have an action to turn on the PermitNoDiscreteTPMResetMitigation flag.
 
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksGoodVirtualMachine2(c *C) {
-	family, err := s.TPM.GetCapabilityTPMProperty(tpm2.PropertyFamilyIndicator)
-	c.Assert(err, IsNil)
-
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode("qemu", internal_efi.DetectVirtModeVM),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: family,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerMSFT),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitVirtualMachine,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | RunningInVirtualMachine,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksGoodDiscreteTPMDetected(c *C) {
+func (s *runChecksContextSuite) TestRunGoodDiscreteTPMDetectedSL3(c *C) {
+	// Test a good case on a dTPM where the startup locality is 3 and
+	// access to locality 3 is restricted to ring 0 code.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -670,88 +597,7 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitNoDiscreteTPMResetMitigation,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | DiscreteTPMDetected | StartupLocalityNotProtected,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksGoodDiscreteTPMDetectedSL3(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -759,7 +605,7 @@ C7E003CB
 				Algorithms:      []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				StartupLocality: 3,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (2 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -787,30 +633,25 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | DiscreteTPMDetected,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodDiscreteTPMDetectedSL3NotProtected(c *C) {
+// TODO: Test a good case with a discrete TPM where the startup locality is 3, but not protected, when we have an action to turn on the PermitNoDiscreteTPMResetMitigation flag.
+
+func (s *runChecksContextSuite) TestRunGoodDiscreteTPMDetectedHCRTM(c *C) {
+	// Test a good case on a dTPM where there is a H-CRTM event and
+	// access to locality 4 is restricted to ring 0 code.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -834,91 +675,7 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms:      []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-				StartupLocality: 3,
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitNoDiscreteTPMResetMitigation,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | DiscreteTPMDetected | StartupLocalityNotProtected,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksGoodDiscreteTPMDetectedHCRTM(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -926,7 +683,7 @@ C7E003CB
 				Algorithms:      []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				StartupLocality: 4,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (2 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -954,30 +711,26 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | DiscreteTPMDetected,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodDiscreteTPMDetectedHCRTMLocality4NotProtected(c *C) {
+// TODO: Test a good case with a discrete TPM where there is a HCRTM event but startup locality is 4 is not protected, when we have an action to turn on the PermitNoDiscreteTPMResetMitigation flag.
+
+func (s *runChecksContextSuite) TestRunGoodInvalidPCR0Value(c *C) {
+	// Test a good case where the value of PCR0 is inconsistenw with the log,
+	// but in a configuration where PCR0 isn't required because the system is
+	// configured with verified boot and there is a fTPM.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1001,96 +754,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms:      []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-				StartupLocality: 4,
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitNoDiscreteTPMResetMitigation,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | DiscreteTPMDetected | StartupLocalityNotProtected,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksGoodInvalidPCR0Value(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1107,52 +776,41 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
 			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(0), []byte("foo"), nil)
 			c.Check(err, IsNil)
 		},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformFirmwareProfileSupport | NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- error with platform firmware \(PCR0\) measurements: PCR value mismatch \(actual from TPM 0xe9995745ca25279ec699688b70488116fe4d9f053cb0991dd71e82e7edfa66b5, reconstructed from log 0xa6602a7a403068b5556e78cc3f5b00c9c76d33d514093ca9b584dce7590e6c69\)
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 4)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform firmware \(PCR0\) measurements: PCR value mismatch \(actual from TPM 0xe9995745ca25279ec699688b70488116fe4d9f053cb0991dd71e82e7edfa66b5, reconstructed from log 0xa6602a7a403068b5556e78cc3f5b00c9c76d33d514093ca9b584dce7590e6c69\)`)
-	var pfe *PlatformFirmwarePCRError
-	c.Check(errors.As(warning, &pfe), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[3]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
 // TODO: Good test case for invalid PCR1 when we support it.
 
-func (s *runChecksSuite) TestRunChecksGoodInvalidPCR2Value(c *C) {
+func (s *runChecksContextSuite) TestRunGoodInvalidPCR2ValueWhenOmittedFromPCRProfileOpts(c *C) {
+	// Test a good case on a fTPM where the value of PCR2 is inconsistent
+	// with the log, but PCR2 isn't required for the specified profile options.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1176,12 +834,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1198,10 +856,6 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
-			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(2), []byte("foo"), nil)
-			c.Check(err, IsNil)
-		},
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -1213,37 +867,30 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts: PCRProfileOptionTrustCAsForVARSuppliedDrivers,
+		prepare: func(_ int) {
+			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(2), []byte("foo"), nil)
+			c.Check(err, IsNil)
+		},
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- error with drivers and apps \(PCR2\) measurements: PCR value mismatch \(actual from TPM 0xfa734a6a4d262d7405d47d48c0a1b127229ca808032555ad919ed5dd7c1f6519, reconstructed from log 0x3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969\)
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 4)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with drivers and apps \(PCR2\) measurements: PCR value mismatch \(actual from TPM 0xfa734a6a4d262d7405d47d48c0a1b127229ca808032555ad919ed5dd7c1f6519, reconstructed from log 0x3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969\)`)
-	var de *DriversAndAppsPCRError
-	c.Check(errors.As(warning, &de), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[3]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
 // TODO: Good test case for invalid PCR3 when we support it.
 
-func (s *runChecksSuite) TestRunChecksGoodInvalidPCR4Value(c *C) {
+func (s *runChecksContextSuite) TestRunGoodInvalidPCR4ValueWhenOmittedFromPCRProfileOpts(c *C) {
+	// Test a good case on a fTPM where the value of PCR4 is inconsistent
+	// with the log, but PCR4 isn't required for the specified profile options.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1267,12 +914,12 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1289,52 +936,43 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionTrustCAsForBootCode,
+		prepare: func(_ int) {
 			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(4), []byte("foo"), nil)
 			c.Check(err, IsNil)
 		},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerCodeProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- error with boot manager code \(PCR4\) measurements: PCR value mismatch \(actual from TPM 0x1c93930d6b26232e061eaa33ecf6341fae63ce598a0c6a26ee96a0828639c044, reconstructed from log 0x4bc74f3ffe49b4dd275c9f475887b68193e2db8348d72e1c3c9099c2dcfa85b0\)
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 4)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with boot manager code \(PCR4\) measurements: PCR value mismatch \(actual from TPM 0x1c93930d6b26232e061eaa33ecf6341fae63ce598a0c6a26ee96a0828639c044, reconstructed from log 0x4bc74f3ffe49b4dd275c9f475887b68193e2db8348d72e1c3c9099c2dcfa85b0\)`)
-	var bme *BootManagerCodePCRError
-	c.Check(errors.As(warning, &bme), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[3]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
 // TODO: Good test case for invalid PCR5 when we support it.
+// TODO: Good test case for invalid PCR7 when PCRProfileOptionPermitNoSecureBootPolicyProfile is supported.
 
-func (s *runChecksSuite) TestRunChecksGoodInvalidPCR7Value(c *C) {
+func (s *runChecksContextSuite) TestRunGoodVARDriversPresentFromInitialFlags(c *C) {
+	// Test good case on a fTPM where there are value-added-retailer drivers
+	// detected, and these are permitted with the PermitVARSuppliedDrivers
+	// initial flag.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1358,95 +996,7 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
-			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(7), []byte("foo"), nil)
-			c.Check(err, IsNil)
-		},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-		expectedFlags:  NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | NoSecureBootPolicyProfileSupport,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 4)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with secure boot policy \(PCR7\) measurements: PCR value mismatch \(actual from TPM 0xdf7b5d709755f1bd7142dd2f8c2d1195fc6b4dab5c78d41daf5c795da55db5f2, reconstructed from log 0xafc99bd8b298ea9b70d2796cb0ca22fe2b70d784691a1cae2aa3ba55edc365dc\)`)
-	var sbe *SecureBootPolicyPCRError
-	c.Check(errors.As(warning, &sbe), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[3]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksGoodVARDriversPresent(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -1454,7 +1004,7 @@ C7E003CB
 				Algorithms:          []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				IncludeDriverLaunch: true,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1471,7 +1021,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitVARSuppliedDrivers,
+		initialFlags: PermitVARSuppliedDrivers,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -1483,30 +1033,26 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | VARDriversPresent,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodSysPrepAppsPresent(c *C) {
+// TODO: Test the above case without the initial flag when we have an action to set PermitVARSuppliedDrivers.
+
+func (s *runChecksContextSuite) TestRunGoodSysPrepAppsPresentFromInitialFlags(c *C) {
+	// Test good case on a fTPM where there are system preparation applications
+	// detected, and these are permitted with the PermitSysPrepApplications
+	// initial flag.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1530,7 +1076,7 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -1538,7 +1084,7 @@ C7E003CB
 				Algorithms:              []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				IncludeSysPrepAppLaunch: true,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1555,7 +1101,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitSysPrepApplications,
+		initialFlags: PermitSysPrepApplications,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -1567,30 +1113,25 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | SysPrepApplicationsPresent,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodAbsoluteActive(c *C) {
+// TODO: Test the above case without the initial flag when we have an action to set PermitSysPrepApplications.
+
+func (s *runChecksContextSuite) TestRunGoodAbsoluteActiveFromInitialFlags(c *C) {
+	// Test good case on a fTPM where Absolute is detected, and this is
+	// permitted with the PermitAbsoluteComputrace initial flag.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1614,7 +1155,7 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -1622,7 +1163,7 @@ C7E003CB
 				Algorithms:                        []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				IncludeOSPresentFirmwareAppLaunch: efi.MakeGUID(0x821aca26, 0x29ea, 0x4993, 0x839f, [...]byte{0x59, 0x7f, 0xc0, 0x21, 0x70, 0x8d}),
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1639,7 +1180,9 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitAbsoluteComputrace,
+		profileOpts:  PCRProfileOptionsDefault,
+		actions:      []actionAndArgs{{action: ActionNone}},
+		initialFlags: PermitAbsoluteComputrace,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -1654,27 +1197,20 @@ C7E003CB
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | AbsoluteComputraceActive,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodNotAllBootManagerCodeDigestsVerified(c *C) {
+// TODO: Test the above case without the initial flag when we have an action to set PermitAbsoluteComputrace.
+
+func (s *runChecksContextSuite) TestRunGoodNoBootManagerCodeProfileSupportWhenOmittedFromPCRProfileOpts(c *C) {
+	// Test a good case on a fTPM where the launch digests in the log for OS components
+	// are invalid, but the profile options permits the omission of PCR4.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1698,96 +1234,14 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
 				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitNotVerifyingAllBootManagerCodeDigests,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | NotAllBootManagerCodeDigestsVerified,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksGoodNoBootManagerCodeProfileSupport(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1818,35 +1272,25 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "80fd5a9364df79953369758a419f7cb167201cf580160b91f837aad455c55bcd")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "c49a23d0315fa446781686de3ee5c04288078911c89c39618c6a54d5fedddf44")},
 		},
+		profileOpts:               PCRProfileOptionTrustCAsForBootCode,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerCodeProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager code \(PCR4\) measurements: log contains unexpected EV_EFI_BOOT_SERVICES_APPLICATION digest for OS-present application mock image: log digest matches flat file digest \(0xd5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0\) which suggests an image loaded outside of the LoadImage API and firmware lacking support for the EFI_TCG2_PROTOCOL and/or the PE_COFF_IMAGE flag
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 4)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager code \(PCR4\) measurements: log contains unexpected EV_EFI_BOOT_SERVICES_APPLICATION digest for OS-present application mock image: log digest matches flat file digest \(0xd5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0\) which suggests an image loaded outside of the LoadImage API and firmware lacking support for the EFI_TCG2_PROTOCOL and\/or the PE_COFF_IMAGE flag`)
-	var bme *BootManagerCodePCRError
-	c.Check(errors.As(warning, &bme), testutil.IsTrue)
-
-	warning = warnings[3]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodPreOSVerificationUsingDigests(c *C) {
+func (s *runChecksContextSuite) TestRunGoodPreOSVerificationUsingDigestsFromInitialFlags(c *C) {
+	// Test a good case where there are value-added-retailer drivers being loaded,
+	// authenticated by way of a digest in db, permitted by supplying PermitPreOSVerificationUsingDigests
+	// as one of the initial flags.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1870,7 +1314,7 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -1879,7 +1323,7 @@ C7E003CB
 				IncludeDriverLaunch:          true,
 				PreOSVerificationUsesDigests: crypto.SHA256,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1896,7 +1340,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitVARSuppliedDrivers | PermitPreOSVerificationUsingDigests,
+		initialFlags: PermitVARSuppliedDrivers | PermitPreOSVerificationUsingDigests,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -1908,30 +1352,26 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | VARDriversPresent | PreOSVerificationUsingDigestsDetected,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodWeakSecureBootAlgs(c *C) {
+// TODO: Test the above case without the initial flag when we have an action to set PermitPreOSVerificationUsingDigests.
+
+func (s *runChecksContextSuite) TestRunGoodWeakSecureBootAlgsFromInitialFlags(c *C) {
+	// Test a good case on a fTPM where there are weak secure boot algorithms
+	// detected, but this is permitted because PermitWeakSecureBootAlgorithms
+	// was supplied as an initial flag.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -1955,7 +1395,7 @@ C7E003CB
 		},
 	}
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -1964,7 +1404,7 @@ C7E003CB
 				IncludeDriverLaunch:          true,
 				PreOSVerificationUsesDigests: crypto.SHA1,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -1981,7 +1421,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitVARSuppliedDrivers | PermitWeakSecureBootAlgorithms | PermitPreOSVerificationUsingDigests,
+		initialFlags: PermitVARSuppliedDrivers | PermitWeakSecureBootAlgorithms | PermitPreOSVerificationUsingDigests,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -1993,159 +1433,123 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
 		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
 		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | VARDriversPresent | PreOSVerificationUsingDigestsDetected | WeakSecureBootAlgorithmsDetected,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 3)
-
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+	c.Check(errs, HasLen, 0)
 }
 
-func (s *runChecksSuite) TestRunChecksGoodNoSecureBootPolicyProfileSupport(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
+// TODO: Test the above case without the initial flag when we have an action to set PermitWeakSecureBootAlgorithms.
+// TODO: Good test case for invalid secure boot config (eg, no DeployedMode) when PCRProfileOptionPermitNoSecureBootPolicyProfile is supported.
 
-	warnings, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-		expectedFlags:  NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | NoSecureBootPolicyProfileSupport,
-	})
-	c.Assert(err, IsNil)
-	c.Assert(warnings, HasLen, 4)
+// **End of good cases ** //
 
-	warning := warnings[0]
-	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(warning, &pce), testutil.IsTrue)
-
-	warning = warnings[1]
-	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(warning, &dce), testutil.IsTrue)
-
-	warning = warnings[2]
-	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
-
-	warning = warnings[3]
-	c.Check(warning, ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles`)
-	c.Check(errors.Is(warning, ErrNoDeployedMode), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadVirtualMachine(c *C) {
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+func (s *runChecksContextSuite) TestRunBadVirtualMachine(c *C) {
+	// Test the error case where a virtualized environment
+	// is detected.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode("qemu", internal_efi.DetectVirtModeVM),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
 		),
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		actions:      []actionAndArgs{{action: ActionNone}},
 	})
-	c.Check(err, Equals, ErrVirtualMachineDetected)
+	c.Assert(errs, HasLen, 1)
+	c.Assert(errs[0], ErrorMatches, `virtual machine environment detected {"kind":"running-in-vm","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindRunningInVM, nil, nil, ErrVirtualMachineDetected))
 }
 
-func (s *runChecksSuite) TestRunChecksBadTPM2DeviceDisabled(c *C) {
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+func (s *runChecksContextSuite) TestRunBadNoTPM2Device(c *C) {
+	// Test the error case where no valid TPM2 device is detected.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: no TPM2 device is available {"kind":"no-suitable-tpm2-device","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoSuitableTPM2Device, nil, nil, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMDeviceFailure(c *C) {
+	// Test the error case where the TPM device is in failure mode.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			// The next command following this is inside openAndCheckTPM2Device
+			// which runs TPM2_SelfTest(false) and will trigger the device's
+			// failure mode.
+			s.Mssim(c).TestFailureMode()
+		},
+		actions: []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is in failure mode {"kind":"tpm-device-failure","args":null,"actions":\["reboot","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindTPMDeviceFailure, nil, []Action{ActionReboot, ActionContactOEM}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadNoPCClientTPMDevice(c *C) {
+	// Test the error case where there is a TPM2 device, but it isn't
+	// a PC Client device.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 		),
 		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+			tpm2.PropertyPSFamilyIndicator: 2,
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
+		profileOpts:  PCRProfileOptionsDefault,
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but it is not a PC-Client TPM {"kind":"no-suitable-tpm2-device","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoSuitableTPM2Device, nil, nil, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPM2DeviceDisabled(c *C) {
+	// Test the error case where the TPM has been disabled by firmware.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		prepare: func(_ int) {
 			// Disable owner and endorsement hierarchies
 			c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
 			c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
 
 		},
+		actions: []actionAndArgs{{action: ActionNone}},
 	})
-	c.Check(err, ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware`)
-	c.Check(errors.Is(err, ErrTPMDisabled), testutil.IsTrue)
-	var te *TPM2DeviceError
-	c.Check(errors.As(err, &te), testutil.IsTrue)
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware {"kind":"tpm-device-disabled","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadTPMOwnedHierarchiesAndLockedOut(c *C) {
-	// Test case with more than TPM error.
+func (s *runChecksContextSuite) TestRunBadTPMHierarchiesOwned(c *C) {
+	// Test the error case where one or more hierarchies of the TPM are already owned.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2169,12 +1573,658 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
+			c.Check(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), make([]byte, 32), tpm2.HashAlgorithmSHA256, nil), IsNil)
+		},
+		actions: []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
+- TPM_RH_LOCKOUT has an authorization value
+- TPM_RH_OWNER has an authorization policy
+ {"kind":"tpm-hierarchies-owned","args":\[{"hierarchy":1073741834,"type":"auth-value"},{"hierarchy":1073741825,"type":"auth-policy"}\],"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(
+		ErrorKindTPMHierarchiesOwned,
+		[]byte(`[{"hierarchy":1073741834,"type":"auth-value"},{"hierarchy":1073741825,"type":"auth-policy"}]`),
+		[]Action{ActionRebootToFWSettings},
+		errs[0].Unwrap(),
+	))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMDeviceLockedOut(c *C) {
+	// Test the error case where the TPM's DA protection has been tripped.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 32, 7200, 86400, nil), IsNil)
+			// Authorize the lockout hierarchy enough times with a bogus value to trip it
+			object, _, _, _, _, err := s.TPM.CreatePrimary(s.TPM.OwnerHandleContext(), &tpm2.SensitiveCreate{UserAuth: []byte("foo")}, objectutil.NewECCKeyTemplate(objectutil.UsageSign), nil, nil, nil)
+			c.Assert(err, IsNil)
+
+			object.SetAuthValue(nil)
+			digest := testutil.DecodeHexString(c, "fbde6a7fe0a4a95d2656f206437a3db64322a74822e581cf63b69f205c63ab6f")
+			scheme := &tpm2.SigScheme{
+				Scheme: tpm2.SigSchemeAlgECDSA,
+				Details: &tpm2.SigSchemeU{
+					ECDSA: &tpm2.SigSchemeECDSA{
+						HashAlg: tpm2.HashAlgorithmSHA256,
+					},
+				},
+			}
+
+			for i := 0; i < 32; i++ {
+				_, err := s.TPM.Sign(object, digest, scheme, nil, nil)
+				if tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandSign, 1) {
+					continue
+				}
+				if tpm2.IsTPMWarning(err, tpm2.WarningLockout, tpm2.CommandSign) {
+					break
+				}
+				c.Errorf("unexpected error: %v", err)
+			}
+		},
+		actions: []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode {"kind":"tpm-device-lockout","args":\[7200000000000,230400000000000\],"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindTPMDeviceLockout, []byte(`[7200000000000,230400000000000]`), []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMInsufficientCounters(c *C) {
+	// Test the error case where there appears to be too few NV counters.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     6,
+			tpm2.PropertyNVCounters:        5,
+			tpm2.PropertyPSFamilyIndicator: 1,
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: insufficient NV counters available {"kind":"insufficient-tpm-storage","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindInsufficientTPMStorage, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMHierarchiesOwnedAndLockedOut(c *C) {
+	// Test for the case where there is more than one TPM error.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 32, 7200, 86400, nil), IsNil)
+			// Authorize the lockout hierarchy enough times with a bogus value to trip it
+			object, _, _, _, _, err := s.TPM.CreatePrimary(s.TPM.OwnerHandleContext(), &tpm2.SensitiveCreate{UserAuth: []byte("foo")}, objectutil.NewECCKeyTemplate(objectutil.UsageSign), nil, nil, nil)
+			c.Assert(err, IsNil)
+
+			object.SetAuthValue(nil)
+			digest := testutil.DecodeHexString(c, "fbde6a7fe0a4a95d2656f206437a3db64322a74822e581cf63b69f205c63ab6f")
+			scheme := &tpm2.SigScheme{
+				Scheme: tpm2.SigSchemeAlgECDSA,
+				Details: &tpm2.SigSchemeU{
+					ECDSA: &tpm2.SigSchemeECDSA{
+						HashAlg: tpm2.HashAlgorithmSHA256,
+					},
+				},
+			}
+
+			for i := 0; i < 32; i++ {
+				_, err := s.TPM.Sign(object, digest, scheme, nil, nil)
+				if tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandSign, 1) {
+					continue
+				}
+				if tpm2.IsTPMWarning(err, tpm2.WarningLockout, tpm2.CommandSign) {
+					break
+				}
+				c.Errorf("unexpected error: %v", err)
+			}
+
+			s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
+		},
+		actions: []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 2)
+
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
+- TPM_RH_LOCKOUT has an authorization value
+ {"kind":"tpm-hierarchies-owned","args":\[{"hierarchy":1073741834,"type":"auth-value"}\],"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(
+		ErrorKindTPMHierarchiesOwned,
+		[]byte(`[{"hierarchy":1073741834,"type":"auth-value"}]`),
+		[]Action{ActionRebootToFWSettings},
+		errs[0].Unwrap(),
+	))
+
+	c.Check(errs[1], ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode {"kind":"tpm-device-lockout","args":\[7200000000000,230400000000000\],"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(
+		ErrorKindTPMDeviceLockout,
+		[]byte(`[7200000000000,230400000000000]`),
+		[]Action{ActionRebootToFWSettings},
+		errs[1].Unwrap(),
+	))
+}
+
+func (s *runChecksContextSuite) TestRunBadTCGLog(c *C) {
+	// Test the error case where the TCG log cannot be decoded.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: nil log {"kind":"measured-boot","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindMeasuredBoot, nil, nil, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadInvalidPCR0Value(c *C) {
+	// Test the error case where PCR0 is inconsistent for the log, but it
+	// gets marked as mandatory because we have a dTPM.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:      []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				StartupLocality: 3,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (2 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(0), []byte("foo"), nil)
+			c.Check(err, IsNil)
+		},
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
+- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA256: error with platform firmware \(PCR0\) measurements: PCR value mismatch \(actual from TPM 0x420bd3899738e6b41dccd18253a556e152e2b107559b89cbf0cbf1661ff6ee55, reconstructed from log 0xb0d6d5f50852be1524306ad88b928605c14338e56a1b8c0dc211a144524df2ef\).
+ {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadInvalidPCR2Value(c *C) {
+	// Test the error case where PCR2 is inconsistent with the log, but it
+	// has been marked as mandatory due to the usage of the Microsoft UEFI CA.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(2), []byte("foo"), nil)
+			c.Check(err, IsNil)
+		},
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
+- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA256: error with drivers and apps \(PCR2\) measurements: PCR value mismatch \(actual from TPM 0xfa734a6a4d262d7405d47d48c0a1b127229ca808032555ad919ed5dd7c1f6519, reconstructed from log 0x3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969\).
+ {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadInvalidPCR4Value(c *C) {
+	// Test the error case where PCR4 is inconsistent with the log, but it
+	// has been marked as mandatory due to the usage of the Microsoft UEFI CA.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(4), []byte("foo"), nil)
+			c.Check(err, IsNil)
+		},
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
+- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA256: error with boot manager code \(PCR4\) measurements: PCR value mismatch \(actual from TPM 0x1c93930d6b26232e061eaa33ecf6341fae63ce598a0c6a26ee96a0828639c044, reconstructed from log 0x4bc74f3ffe49b4dd275c9f475887b68193e2db8348d72e1c3c9099c2dcfa85b0\).
+ {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadInvalidPCR7Value(c *C) {
+	// Test the error case where PCR7 is inconsistent with the log, but it
+	// has been marked as mandatory because the default profile options
+	// require it.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(7), []byte("foo"), nil)
+			c.Check(err, IsNil)
+		},
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
+- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
+- TPM_ALG_SHA256: error with secure boot policy \(PCR7\) measurements: PCR value mismatch \(actual from TPM 0xdf7b5d709755f1bd7142dd2f8c2d1195fc6b4dab5c78d41daf5c795da55db5f2, reconstructed from log 0xafc99bd8b298ea9b70d2796cb0ca22fe2b70d784691a1cae2aa3ba55edc365dc\).
+ {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
+}
+
+// TODO: Add a test for ErrorKindUnsupportedPlatform
+
+func (s *runChecksContextSuite) TestRunBadUEFIDebuggingEnabled(c *C) {
+	// Test the error case where a UEFI debugger is enabled.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:       []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				FirmwareDebugger: true,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 		),
 		tpmPropertyModifiers: map[tpm2.Property]uint32{
@@ -2183,161 +2233,202 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
-			// Trip the DA logic by setting newMaxTries to 0
-			c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
-
-			// Take ownership of the storage hierarchy
-			s.HierarchyChangeAuth(c, tpm2.HandleOwner, []byte("1234"))
-		},
+		actions:      []actionAndArgs{{action: ActionNone}},
 	})
-	c.Check(err, ErrorMatches, `2 errors detected:
-- error with TPM2 device: one or more of the TPM hierarchies is already owned:
-  - TPM_RH_OWNER has an authorization value
-- error with TPM2 device: TPM is in DA lockout mode
-`)
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware contains a debugging endpoint enabled {"kind":"uefi-debugging-enabled","args":null,"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindUEFIDebuggingEnabled, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))
+}
 
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
+func (s *runChecksContextSuite) TestRunBadInsufficientDMAProtection(c *C) {
+	// Test the error case where DMA protection is disabled.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:            []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				DMAProtectionDisabled: efitest.DMAProtectionDisabled,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware indicates that DMA protections are insufficient {"kind":"insufficient-dma-protection","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindInsufficientDMAProtection, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadNoKernelIOMMU(c *C) {
+	// Test the error case where the kernel doesn't enable a IOMMU
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with system security: no kernel IOMMU support was detected {"kind":"no-kernel-iommu","args":null,"actions":\["contact-os-vendor"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadStartupLocalityNotProtected(c *C) {
+	// Test the error case where there is a dTPM and the startup locality
+	// is not protected from ring 0 access.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (2 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks {"kind":"tpm-startup-locality-not-protected","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindTPMStartupLocalityNotProtected, nil, nil, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunChecksBadUEFIDebuggingEnabledAndNoKernelIOMMU(c *C) {
+	// Test case with more than one host security error.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:       []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				FirmwareDebugger: true,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (2 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
 	c.Assert(errs, HasLen, 2)
+	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware contains a debugging endpoint enabled {"kind":"uefi-debugging-enabled","args":null,"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindUEFIDebuggingEnabled, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))
 
-	var te *TPM2DeviceError
-	c.Assert(errors.As(errs[0], &te), testutil.IsTrue)
-	var ohe *TPM2OwnedHierarchiesError
-	c.Check(errors.As(te, &ohe), testutil.IsTrue)
-
-	c.Assert(errors.As(errs[1], &te), testutil.IsTrue)
-	c.Check(errors.Is(te, ErrTPMLockout), testutil.IsTrue)
+	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected {"kind":"no-kernel-iommu","args":null,"actions":\["contact-os-vendor"\]}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadInvalidPCR0Value(c *C) {
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{}, 1, map[uint32]uint64{0x13a: (3 << 1)}),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
-			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(0), []byte("foo"), nil)
-			c.Check(err, IsNil)
-		},
-		flags: PlatformFirmwareProfileSupportRequired,
-	})
-	c.Check(err, ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
-- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256: error with platform firmware \(PCR0\) measurements: PCR value mismatch \(actual from TPM 0xe9995745ca25279ec699688b70488116fe4d9f053cb0991dd71e82e7edfa66b5, reconstructed from log 0xa6602a7a403068b5556e78cc3f5b00c9c76d33d514093ca9b584dce7590e6c69\).
-`)
-	var te *MeasuredBootError
-	c.Assert(errors.As(err, &te), testutil.IsTrue)
-	var pe *NoSuitablePCRAlgorithmError
-	c.Check(errors.As(te, &pe), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadInvalidPCR2Value(c *C) {
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{}, 1, map[uint32]uint64{0x13a: (3 << 1)}),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
-			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(2), []byte("foo"), nil)
-			c.Check(err, IsNil)
-		},
-		flags: DriversAndAppsProfileSupportRequired,
-	})
-	c.Check(err, ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
-- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256: error with drivers and apps \(PCR2\) measurements: PCR value mismatch \(actual from TPM 0xfa734a6a4d262d7405d47d48c0a1b127229ca808032555ad919ed5dd7c1f6519, reconstructed from log 0x3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969\).
-`)
-	var te *MeasuredBootError
-	c.Assert(errors.As(err, &te), testutil.IsTrue)
-	var pe *NoSuitablePCRAlgorithmError
-	c.Check(errors.As(te, &pe), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadInvalidPCR4Value(c *C) {
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{}, 1, map[uint32]uint64{0x13a: (3 << 1)}),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
-			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(4), []byte("foo"), nil)
-			c.Check(err, IsNil)
-		},
-		flags: BootManagerCodeProfileSupportRequired,
-	})
-	c.Check(err, ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
-- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256: error with boot manager code \(PCR4\) measurements: PCR value mismatch \(actual from TPM 0x1c93930d6b26232e061eaa33ecf6341fae63ce598a0c6a26ee96a0828639c044, reconstructed from log 0x4bc74f3ffe49b4dd275c9f475887b68193e2db8348d72e1c3c9099c2dcfa85b0\).
-`)
-	var te *MeasuredBootError
-	c.Assert(errors.As(err, &te), testutil.IsTrue)
-	var pe *NoSuitablePCRAlgorithmError
-	c.Check(errors.As(te, &pe), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadInvalidPCR7Value(c *C) {
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{}, 1, map[uint32]uint64{0x13a: (3 << 1)}),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
-			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(7), []byte("foo"), nil)
-			c.Check(err, IsNil)
-		},
-		flags: SecureBootPolicyProfileSupportRequired,
-	})
-	c.Check(err, ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
-- TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256: error with secure boot policy \(PCR7\) measurements: PCR value mismatch \(actual from TPM 0xdf7b5d709755f1bd7142dd2f8c2d1195fc6b4dab5c78d41daf5c795da55db5f2, reconstructed from log 0xafc99bd8b298ea9b70d2796cb0ca22fe2b70d784691a1cae2aa3ba55edc365dc\).
-`)
-	var te *MeasuredBootError
-	c.Assert(errors.As(err, &te), testutil.IsTrue)
-	var pe *NoSuitablePCRAlgorithmError
-	c.Check(errors.As(te, &pe), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadNoHardwareRootOfTrustError(c *C) {
-	// Test case with no hardware root-of-trust configured.
+func (s *runChecksContextSuite) TestRunBadHostSecurityError(c *C) {
+	// Test the error case where we're running on an Intel based device
+	// and BootGuard is mis-configured.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2361,12 +2452,12 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 		),
 		tpmPropertyModifiers: map[tpm2.Property]uint32{
@@ -2375,74 +2466,16 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		actions:      []actionAndArgs{{action: ActionNone}},
 	})
-	c.Check(err, ErrorMatches, `error with system security: encountered an error when determining platform firmware protections using Intel MEI: no hardware root-of-trust properly configured: ME is in manufacturing mode: no firmware protections are enabled`)
-
-	var hse *HostSecurityError
-	c.Assert(errors.As(err, &hse), testutil.IsTrue)
-	var rote *NoHardwareRootOfTrustError
-	c.Check(errors.As(hse, &rote), testutil.IsTrue)
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with system security: encountered an error when determining platform firmware protections using Intel MEI: no hardware root-of-trust properly configured: ME is in manufacturing mode: no firmware protections are enabled {"kind":"host-security","args":null,"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindHostSecurity, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadUEFIDebuggingEnabledAndNoKernelIOMMU(c *C) {
-	// Test case with more than one host security error.
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms:       []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-				FirmwareDebugger: true,
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-	})
-	c.Check(err, ErrorMatches, `2 errors detected:
-- error with system security: the platform firmware contains a debugging endpoint enabled
-- error with system security: no kernel IOMMU support was detected
-`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 2)
-
-	var hse *HostSecurityError
-	c.Assert(errors.As(errs[0], &hse), testutil.IsTrue)
-	c.Check(errors.Is(hse, ErrUEFIDebuggingEnabled), testutil.IsTrue)
-
-	c.Assert(errors.As(errs[1], &hse), testutil.IsTrue)
-	c.Check(errors.Is(hse, ErrNoKernelIOMMU), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadSHA1(c *C) {
+func (s *runChecksContextSuite) TestRunBadSHA1(c *C) {
+	// Test the error case where there is no suitable PCR bank other
+	// than SHA1, but SHA1 is disallowed by default.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2466,12 +2499,12 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA1}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -2499,23 +2532,23 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "1dc8bcbdb8b5ee60e87281e36161ec1f923f53b7")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "fc7840d38322a595e50a6b477685fdd2244f9292")},
 		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA1,
 	})
-	c.Check(err, ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: no suitable PCR algorithm available:
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA256: the PCR bank is missing from the TCG log.
-`)
-
-	var e *NoSuitablePCRAlgorithmError
-	c.Assert(errors.As(err, &e), testutil.IsTrue)
-
-	// Test that we can access individual errors.
-	c.Check(e.Errs[tpm2.HashAlgorithmSHA512], DeepEquals, []error{ErrPCRBankMissingFromLog})
-	c.Check(e.Errs[tpm2.HashAlgorithmSHA384], DeepEquals, []error{ErrPCRBankMissingFromLog})
-	c.Check(e.Errs[tpm2.HashAlgorithmSHA256], DeepEquals, []error{ErrPCRBankMissingFromLog})
+ {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadMandatoryPCR1(c *C) {
+func (s *runChecksContextSuite) TestRunBadPCRProfileMostSecure(c *C) {
+	// Test the error case where the profile options are set to "most secure".
+	// This is currently unsupported because of a lack of source for some
+	// PCRs - it is intended that this will work eventually.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2539,12 +2572,12 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -2561,7 +2594,6 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PlatformConfigProfileSupportRequired,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -2573,21 +2605,26 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:    PCRProfileOptionMostSecure,
+		actions:        []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Check(err, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
+	c.Assert(errs, HasLen, 3)
+	c.Check(errs[0], ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[1,"https://github.com/canonical/secboot/issues/322"\],"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnsupported, []byte("[1,\"https://github.com/canonical/secboot/issues/322\"]"), nil, errs[0].Unwrap()))
 
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
+	c.Check(errs[1], ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[3,"https://github.com/canonical/secboot/issues/341"\],"actions":null}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnsupported, []byte("[3,\"https://github.com/canonical/secboot/issues/341\"]"), nil, errs[1].Unwrap()))
 
-	var pce *PlatformConfigPCRError
-	c.Check(errors.As(errs[0], &pce), testutil.IsTrue)
+	c.Check(errs[2], ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[5,"https://github.com/canonical/secboot/issues/323"\],"actions":null}`)
+	c.Check(errs[2], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnsupported, []byte("[5,\"https://github.com/canonical/secboot/issues/323\"]"), nil, errs[2].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadMandatoryPCR3(c *C) {
+func (s *runChecksContextSuite) TestRunBadInvalidPCR7ValuePCRProfilePermitNoSecureBoot(c *C) {
+	// Test the error case where PCR7 is unusable and the profile options are set
+	// to permit policies without PCR7, but this fails due to a lack of support
+	// for some mandatory alternative PCRs - it is intended that this case will
+	// work in the future.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2611,12 +2648,12 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -2633,7 +2670,6 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        DriversAndAppsConfigProfileSupportRequired,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -2645,21 +2681,30 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts: PCRProfileOptionPermitNoSecureBootPolicyProfile,
+		prepare: func(_ int) {
+			_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(7), []byte("foo"), nil)
+			c.Check(err, IsNil)
+		},
+		actions:        []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Check(err, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
+	c.Assert(errs, HasLen, 3)
+	c.Check(errs[0], ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[1,"https://github.com/canonical/secboot/issues/322"\],"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnsupported, []byte("[1,\"https://github.com/canonical/secboot/issues/322\"]"), nil, errs[0].Unwrap()))
 
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
+	c.Check(errs[1], ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[3,"https://github.com/canonical/secboot/issues/341"\],"actions":null}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnsupported, []byte("[3,\"https://github.com/canonical/secboot/issues/341\"]"), nil, errs[1].Unwrap()))
 
-	var dce *DriversAndAppsConfigPCRError
-	c.Check(errors.As(errs[0], &dce), testutil.IsTrue)
+	c.Check(errs[2], ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[5,"https://github.com/canonical/secboot/issues/323"\],"actions":null}`)
+	c.Check(errs[2], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnsupported, []byte("[5,\"https://github.com/canonical/secboot/issues/323\"]"), nil, errs[2].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadMandatoryPCR5(c *C) {
+func (s *runChecksContextSuite) TestRunBadEmptySHA384(c *C) {
+	// Test the error case where the TPM has a SHA384 bank enabled but
+	// unused by the firmware.
+	s.RequireAlgorithm(c, tpm2.AlgorithmSHA384)
+
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2683,12 +2728,12 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -2704,8 +2749,7 @@ C7E003CB
 			tpm2.PropertyPSFamilyIndicator: 1,
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        BootManagerConfigProfileSupportRequired,
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA384},
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -2717,21 +2761,23 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Check(err, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
 	c.Assert(errs, HasLen, 1)
-
-	var bmce *BootManagerConfigPCRError
-	c.Check(errors.As(errs[0], &bmce), testutil.IsTrue)
+	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM {"kind":"empty-pcr-banks","args":\[12\],"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(
+		ErrorKindEmptyPCRBanks,
+		[]byte("[12]"),
+		[]Action{ActionRebootToFWSettings, ActionContactOEM},
+		&EmptyPCRBanksError{Algs: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA384}},
+	))
 }
 
-func (s *runChecksSuite) TestRunChecksBadVARDriversPresent(c *C) {
+func (s *runChecksContextSuite) TestRunBadVARDriversPresent(c *C) {
+	// Test the error case where value-added-retailer drivers have been detected
+	// but the initial flags do not permit these.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2755,7 +2801,7 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -2763,7 +2809,7 @@ C7E003CB
 				Algorithms:          []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				IncludeDriverLaunch: true,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -2791,20 +2837,18 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Check(err, ErrorMatches, `value added retailer supplied drivers were detected to be running`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
 	c.Assert(errs, HasLen, 1)
-
-	c.Check(errors.Is(errs[0], ErrVARSuppliedDriversPresent), testutil.IsTrue)
+	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running {"kind":"var-supplied-drivers-present","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindVARSuppliedDriversPresent, nil, nil, ErrVARSuppliedDriversPresent))
 }
 
-func (s *runChecksSuite) TestRunChecksBadSysPrepAppsPresent(c *C) {
+func (s *runChecksContextSuite) TestRunBadSysPrepAppsPresent(c *C) {
+	// Test the error case where system preparations have been detected
+	// but the initial flags do not permit these.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2828,7 +2872,7 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -2836,7 +2880,7 @@ C7E003CB
 				Algorithms:              []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				IncludeSysPrepAppLaunch: true,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -2864,20 +2908,18 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Check(err, ErrorMatches, `system preparation applications were detected to be running`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
 	c.Assert(errs, HasLen, 1)
-
-	c.Check(errors.Is(errs[0], ErrSysPrepApplicationsPresent), testutil.IsTrue)
+	c.Check(errs[0], ErrorMatches, `system preparation applications were detected to be running {"kind":"sys-prep-applications-present","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindSysPrepApplicationsPresent, nil, nil, ErrSysPrepApplicationsPresent))
 }
 
-func (s *runChecksSuite) TestRunChecksBadAbsoluteActive(c *C) {
+func (s *runChecksContextSuite) TestRunBadAbsoluteActive(c *C) {
+	// Test the error case where Absolute has been detected but the initial
+	// flags do not permit this.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2901,7 +2943,7 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -2909,7 +2951,7 @@ C7E003CB
 				Algorithms:                        []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 				IncludeOSPresentFirmwareAppLaunch: efi.MakeGUID(0x821aca26, 0x29ea, 0x4993, 0x839f, [...]byte{0x59, 0x7f, 0xc0, 0x21, 0x70, 0x8d}),
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -2937,20 +2979,21 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Check(err, ErrorMatches, `Absolute was detected to be active and it is advised that this is disabled`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	c.Check(errors.Is(errs[0], ErrAbsoluteComputraceActive), testutil.IsTrue)
+	c.Check(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `Absolute was detected to be active and it is advised that this is disabled {"kind":"absolute-present","args":null,"actions":\["contact-oem","reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindAbsolutePresent, nil, []Action{ActionContactOEM, ActionRebootToFWSettings}, ErrAbsoluteComputraceActive))
 }
 
-func (s *runChecksSuite) TestRunChecksBadNotAllBootManagerCodeDigestsVerified(c *C) {
+func (s *runChecksContextSuite) TestRunBadNotAllBootManagerCodeDigestsVerified(c *C) {
+	// Test the error case where PCR4 is mandatory because some of the components
+	// that were booted are signed under the Microsoft UEFI CA and the default
+	// profile options were supplied, but where PCR4 is marked unusable because
+	// not all of the EFI applications that were part of the current boot were
+	// supplied when creating the RunChecksContext.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2974,14 +3017,14 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
 				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -3009,21 +3052,18 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 		},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
 	})
-	c.Check(err, ErrorMatches, `error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
 	c.Assert(errs, HasLen, 1)
-
-	var bme *BootManagerCodePCRError
-	c.Assert(errors.As(errs[0], &bme), testutil.IsTrue)
-	c.Check(errors.Is(bme, ErrNotAllBootManagerCodeDigestsVerified), testutil.IsTrue)
+	c.Check(errs[0], ErrorMatches, `error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified {"kind":"tpm-pcr-unusable","args":\[4\],"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnusable, []byte("[4]"), []Action{ActionContactOEM}, errs[0].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadWeakSecureBootAlgs(c *C) {
+func (s *runChecksContextSuite) TestRunBadInvalidSecureBootMode(c *C) {
+	// Test the error case where PCR7 is mandatory with the supplied profile options,
+	// but is marked invalid because the system is not in deployed. Note that is is
+	// my intention to support user mode in the future.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -3047,7 +3087,166 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Check(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles {"kind":"invalid-secure-boot-mode","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindInvalidSecureBootMode, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadNoSecureBootPolicySupport(c *C) {
+	// Test the error case where PCR7 is mandatory but the secure boot checks fail
+	// because dbx is measured twice.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	log := efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})
+	var eventsCopy []*tcglog.Event
+	for _, ev := range log.Events {
+		eventsCopy = append(eventsCopy, ev)
+
+		if ev.PCRIndex != internal_efi.SecureBootPolicyPCR {
+			continue
+		}
+		if ev.EventType != tcglog.EventTypeEFIVariableDriverConfig {
+			continue
+		}
+		data, ok := ev.Data.(*tcglog.EFIVariableData)
+		c.Assert(ok, testutil.IsTrue)
+		if data.UnicodeName == "dbx" {
+			// Measure dbx twice
+			eventsCopy = append(eventsCopy, ev)
+		}
+	}
+	log.Events = eventsCopy
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(log),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Check(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: unexpected EV_EFI_VARIABLE_DRIVER_CONFIG event: all expected secure boot variable have been measured {"kind":"tpm-pcr-unusable","args":\[7\],"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindPCRUnusable, []byte("[7]"), []Action{ActionContactOEM}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadWeakSecureBootAlgs(c *C) {
+	// Test the error case where PCR7 is mandatory with the supplied profile options,
+	// but is marked invalid because the use of weak algorithms were detected during
+	// the current boot.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
@@ -3056,7 +3255,7 @@ C7E003CB
 				IncludeDriverLaunch:          true,
 				PreOSVerificationUsesDigests: crypto.SHA1,
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -3073,7 +3272,6 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        SecureBootPolicyProfileSupportRequired | PermitVARSuppliedDrivers,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -3085,24 +3283,23 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Check(err, ErrorMatches, `2 errors detected:
-- a weak cryptographic algorithm was detected during secure boot verification
-- some pre-OS components were authenticated from the authorized signature database using an Authenticode digest
-`)
+	c.Check(errs, HasLen, 3)
+	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running {"kind":"var-supplied-drivers-present","args":null,"actions":null}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindVARSuppliedDriversPresent, nil, nil, ErrVARSuppliedDriversPresent))
 
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 2)
+	c.Check(errs[1], ErrorMatches, `a weak cryptographic algorithm was detected during secure boot verification {"kind":"weak-secure-boot-algorithms-detected","args":null,"actions":null}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(ErrorKindWeakSecureBootAlgorithmsDetected, nil, nil, ErrWeakSecureBootAlgorithmDetected))
 
-	c.Check(errors.Is(errs[0], ErrWeakSecureBootAlgorithmDetected), testutil.IsTrue)
-	c.Check(errors.Is(errs[1], ErrPreOSVerificationUsingDigests), testutil.IsTrue)
+	c.Check(errs[2], ErrorMatches, `some pre-OS components were authenticated from the authorized signature database using an Authenticode digest {"kind":"pre-os-digest-verification-detected","args":null,"actions":null}`)
+	c.Check(errs[2], DeepEquals, NewErrorKindAndActions(ErrorKindPreOSDigestVerificationDetected, nil, nil, ErrPreOSVerificationUsingDigests))
 }
 
-func (s *runChecksSuite) TestRunChecksBadPreOSVerificationUsingDigests(c *C) {
+func (s *runChecksContextSuite) TestRunChecksBadTPMHierarchiesOwnedAndNoSecureBootPolicySupport(c *C) {
+	// Test case with more than one error.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -3126,164 +3323,14 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms:                   []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-				IncludeDriverLaunch:          true,
-				PreOSVerificationUsesDigests: crypto.SHA256,
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        PermitVARSuppliedDrivers,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-	})
-	c.Check(err, ErrorMatches, `some pre-OS components were authenticated from the authorized signature database using an Authenticode digest`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	c.Check(errors.Is(errs[0], ErrPreOSVerificationUsingDigests), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadNoBootManagerCodeProfileSupport(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
 				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        BootManagerCodeProfileSupportRequired,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			// We have to cheat a bit here because the digest is hardcoded in the test log. We set an invalid Authenticode digest for the mock image so the intial test
-			// fails and then have the following code digest the same string that produces the log digest ("mock grub executable"), to get a digest that matches what's in
-			// the log so the test thinks that the log contains the flat file digest.
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "80fd5a9364df79953369758a419f7cb167201cf580160b91f837aad455c55bcd")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "c49a23d0315fa446781686de3ee5c04288078911c89c39618c6a54d5fedddf44")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-	})
-	c.Check(err, ErrorMatches, `error with boot manager code \(PCR4\) measurements: log contains unexpected EV_EFI_BOOT_SERVICES_APPLICATION digest for OS-present application mock image: log digest matches flat file digest \(0xd5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0\) which suggests an image loaded outside of the LoadImage API and firmware lacking support for the EFI_TCG2_PROTOCOL and\/or the PE_COFF_IMAGE flag`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	var bce *BootManagerCodePCRError
-	c.Check(errors.As(errs[0], &bce), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadNoSecureBootPolicyProfileSupport(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -3300,378 +3347,10 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		flags:        SecureBootPolicyProfileSupportRequired,
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-	})
-	c.Check(err, ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	var sbe *SecureBootPolicyPCRError
-	c.Assert(errors.As(errs[0], &sbe), testutil.IsTrue)
-	c.Check(errors.Is(sbe, ErrNoDeployedMode), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadDiscreteTPMDetectedSL0NotProtected(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-	})
-	c.Check(err, ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	var hse *HostSecurityError
-	c.Assert(errors.As(errs[0], &hse), testutil.IsTrue)
-	c.Check(errors.Is(hse, ErrTPMStartupLocalityNotProtected), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadDiscreteTPMDetectedSL3NotProtected(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms:      []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-				StartupLocality: 3,
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-	})
-	c.Check(err, ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	var hse *HostSecurityError
-	c.Assert(errors.As(errs[0], &hse), testutil.IsTrue)
-	c.Check(errors.Is(hse, ErrTPMStartupLocalityNotProtected), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadDiscreteTPMDetectedHCRTMLocality4NotProtected(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
-				Algorithms:      []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-				StartupLocality: 4,
-			})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (2 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
-	})
-	c.Check(err, ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	var hse *HostSecurityError
-	c.Assert(errors.As(errs[0], &hse), testutil.IsTrue)
-	c.Check(errors.Is(hse, ErrTPMStartupLocalityNotProtected), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadEmptySHA384(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA384},
-		loadedImages: []secboot_efi.Image{
-			&mockImage{
-				contents: []byte("mock shim executable"),
-				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
-				signatures: []*efi.WinCertificateAuthenticode{
-					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
-				},
-			},
-			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
-			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
-		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
-	})
-	c.Assert(err, ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 1)
-
-	var be *EmptyPCRBanksError
-	c.Check(errors.As(errs[0], &be), testutil.IsTrue)
-}
-
-func (s *runChecksSuite) TestRunChecksBadTPMHierarchiesOwnedAndNoSecureBootPolicySupport(c *C) {
-	meiAttrs := map[string][]byte{
-		"fw_ver": []byte(`0:16.1.27.2176
-0:16.1.27.2176
-0:16.0.15.1624
-`),
-		"fw_status": []byte(`94000245
-09F10506
-00000020
-00004000
-00041F03
-C7E003CB
-`),
-	}
-	devices := map[string][]internal_efi.SysfsDevice{
-		"iommu": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
-			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
-		},
-		"mei": []internal_efi.SysfsDevice{
-			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
-		},
-	}
-
-	_, err := s.testRunChecks(c, &testRunChecksParams{
-		env: efitest.NewMockHostEnvironmentWithOpts(
-			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
-			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
-			efitest.WithSysfsDevices(devices),
-			efitest.WithMockVars(efitest.MockVars{
-				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
-				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
-				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
-		),
-		tpmPropertyModifiers: map[tpm2.Property]uint32{
-			tpm2.PropertyNVCountersMax:     0,
-			tpm2.PropertyPSFamilyIndicator: 1,
-			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-		},
-		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
-		prepare: func() {
+		prepare: func(_ int) {
 			c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 		},
-		flags: SecureBootPolicyProfileSupportRequired,
+		initialFlags: SecureBootPolicyProfileSupportRequired,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -3683,32 +3362,22 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Assert(err, ErrorMatches, `2 errors detected:
-- error with TPM2 device: one or more of the TPM hierarchies is already owned:
-  - TPM_RH_LOCKOUT has an authorization value
-- error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles
-`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
 	c.Assert(errs, HasLen, 2)
 
-	var te *TPM2DeviceError
-	c.Assert(errors.As(errs[0], &te), testutil.IsTrue)
-	var ohe *TPM2OwnedHierarchiesError
-	c.Check(errors.As(te, &ohe), testutil.IsTrue)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
+- TPM_RH_LOCKOUT has an authorization value
+ {"kind":"tpm-hierarchies-owned","args":\[{"hierarchy":1073741834,"type":"auth-value"}\],"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindTPMHierarchiesOwned, []byte(`[{"hierarchy":1073741834,"type":"auth-value"}]`), []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 
-	var sbpe *SecureBootPolicyPCRError
-	c.Check(errors.As(errs[1], &sbpe), testutil.IsTrue)
+	c.Check(errs[1], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles {"kind":"invalid-secure-boot-mode","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(ErrorKindInvalidSecureBootMode, nil, []Action{ActionRebootToFWSettings}, errs[1].Unwrap()))
 }
 
-func (s *runChecksSuite) TestRunChecksBadEmptyPCRBankAndNoBootManagerCodeProfileSupport(c *C) {
+func (s *runChecksContextSuite) TestRunChecksBadEmptyPCRBankAndNoBootManagerCodeProfileSupport(c *C) {
 	s.RequireAlgorithm(c, tpm2.AlgorithmSHA384)
 
 	meiAttrs := map[string][]byte{
@@ -3734,12 +3403,14 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
@@ -3756,7 +3427,7 @@ C7E003CB
 			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA384},
-		flags:        BootManagerCodeProfileSupportRequired,
+		initialFlags: BootManagerCodeProfileSupportRequired,
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -3767,30 +3438,30 @@ C7E003CB
 			},
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Assert(err, ErrorMatches, `2 errors detected:
-- the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM
-- error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified
-`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
 	c.Assert(errs, HasLen, 2)
 
-	var be *EmptyPCRBanksError
-	c.Check(errors.As(errs[0], &be), testutil.IsTrue)
+	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM {"kind":"empty-pcr-banks","args":\[12\],"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(
+		ErrorKindEmptyPCRBanks,
+		[]byte(`[12]`),
+		[]Action{ActionRebootToFWSettings, ActionContactOEM},
+		errs[0].Unwrap(),
+	))
 
-	var bme *BootManagerCodePCRError
-	c.Assert(errors.As(errs[1], &bme), testutil.IsTrue)
-	c.Check(errors.Is(bme, ErrNotAllBootManagerCodeDigestsVerified), testutil.IsTrue)
+	c.Check(errs[1], ErrorMatches, `error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified {"kind":"tpm-pcr-unusable","args":\[4\],"actions":\["contact-oem"\]}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(
+		ErrorKindPCRUnusable,
+		[]byte(`[4]`),
+		[]Action{ActionContactOEM},
+		errs[1].Unwrap(),
+	))
 }
 
-func (s *runChecksSuite) TestRunChecksBadEmptyPCRBankAndNoKernelIOMMU(c *C) {
+func (s *runChecksContextSuite) TestRunChecksBadEmptyPCRBankAndNoKernelIOMMU(c *C) {
 	s.RequireAlgorithm(c, tpm2.AlgorithmSHA384)
 
 	meiAttrs := map[string][]byte{
@@ -3812,18 +3483,19 @@ C7E003CB
 		},
 	}
 
-	_, err := s.testRunChecks(c, &testRunChecksParams{
+	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
 			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
-			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
-			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
 			efitest.WithSysfsDevices(devices),
 			efitest.WithMockVars(efitest.MockVars{
 				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
 				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
 				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
-				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
 				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
 				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
@@ -3845,25 +3517,15 @@ C7E003CB
 			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
 			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
 		},
-		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
-		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
-		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		profileOpts:    PCRProfileOptionsDefault,
+		actions:        []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
-	c.Assert(err, ErrorMatches, `2 errors detected:
-- the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM
-- error with system security: no kernel IOMMU support was detected
-`)
-
-	var ce CompoundError
-	c.Assert(err, Implements, &ce)
-	ce = err.(CompoundError)
-	errs := ce.Unwrap()
 	c.Assert(errs, HasLen, 2)
 
-	var be *EmptyPCRBanksError
-	c.Check(errors.As(errs[0], &be), testutil.IsTrue)
+	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM {"kind":"empty-pcr-banks","args":\[12\],"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], DeepEquals, NewErrorKindAndActions(ErrorKindEmptyPCRBanks, []byte(`[12]`), []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 
-	var hse *HostSecurityError
-	c.Assert(errors.As(errs[1], &hse), testutil.IsTrue)
-	c.Check(errors.Is(hse, ErrNoKernelIOMMU), testutil.IsTrue)
+	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected {"kind":"no-kernel-iommu","args":null,"actions":\["contact-os-vendor"\]}`)
+	c.Check(errs[1], DeepEquals, NewErrorKindAndActions(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
 }

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -1465,7 +1465,7 @@ func (s *runChecksContextSuite) TestRunBadVirtualMachine(c *C) {
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Assert(errs[0], ErrorMatches, `virtual machine environment detected {"kind":"running-in-vm","args":null,"actions":null}`)
+	c.Assert(errs[0], ErrorMatches, `virtual machine environment detected`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRunningInVM, nil, nil, ErrVirtualMachineDetected))
 }
 
@@ -1480,7 +1480,7 @@ func (s *runChecksContextSuite) TestRunBadNoTPM2Device(c *C) {
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with TPM2 device: no TPM2 device is available {"kind":"no-suitable-tpm2-device","args":null,"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: no TPM2 device is available`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoSuitableTPM2Device, nil, nil, errs[0].Unwrap()))
 }
 
@@ -1502,7 +1502,7 @@ func (s *runChecksContextSuite) TestRunBadTPMDeviceFailure(c *C) {
 		actions: []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is in failure mode {"kind":"tpm-device-failure","args":null,"actions":\["reboot","contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is in failure mode`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceFailure, nil, []Action{ActionReboot, ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -1522,7 +1522,7 @@ func (s *runChecksContextSuite) TestRunBadNoPCClientTPMDevice(c *C) {
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but it is not a PC-Client TPM {"kind":"no-suitable-tpm2-device","args":null,"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but it is not a PC-Client TPM`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoSuitableTPM2Device, nil, nil, errs[0].Unwrap()))
 }
 
@@ -1544,7 +1544,7 @@ func (s *runChecksContextSuite) TestRunBadTPM2DeviceDisabled(c *C) {
 		actions: []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware {"kind":"tpm-device-disabled","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 }
 
@@ -1608,7 +1608,7 @@ C7E003CB
 	c.Check(errs[0], ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
 - TPM_RH_LOCKOUT has an authorization value
 - TPM_RH_OWNER has an authorization policy
- {"kind":"tpm-hierarchies-owned","args":\[{"hierarchy":1073741834,"type":"auth-value"},{"hierarchy":1073741825,"type":"auth-policy"}\],"actions":\["reboot-to-fw-settings"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindTPMHierarchiesOwned,
 		[]byte(`[{"hierarchy":1073741834,"type":"auth-value"},{"hierarchy":1073741825,"type":"auth-policy"}]`),
@@ -1697,7 +1697,7 @@ C7E003CB
 		actions: []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode {"kind":"tpm-device-lockout","args":\[7200000000000,230400000000000\],"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceLockout, []byte(`[7200000000000,230400000000000]`), []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 }
 
@@ -1753,7 +1753,7 @@ C7E003CB
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with TPM2 device: insufficient NV counters available {"kind":"insufficient-tpm-storage","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: insufficient NV counters available`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindInsufficientTPMStorage, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 }
 
@@ -1843,7 +1843,7 @@ C7E003CB
 
 	c.Check(errs[0], ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
 - TPM_RH_LOCKOUT has an authorization value
- {"kind":"tpm-hierarchies-owned","args":\[{"hierarchy":1073741834,"type":"auth-value"}\],"actions":\["reboot-to-fw-settings"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindTPMHierarchiesOwned,
 		[]byte(`[{"hierarchy":1073741834,"type":"auth-value"}]`),
@@ -1851,7 +1851,7 @@ C7E003CB
 		errs[0].Unwrap(),
 	))
 
-	c.Check(errs[1], ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode {"kind":"tpm-device-lockout","args":\[7200000000000,230400000000000\],"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[1], ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindTPMDeviceLockout,
 		[]byte(`[7200000000000,230400000000000]`),
@@ -1877,7 +1877,7 @@ func (s *runChecksContextSuite) TestRunBadTCGLog(c *C) {
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: nil log {"kind":"measured-boot","args":null,"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `error with or detected from measurement log: nil log`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindMeasuredBoot, nil, nil, errs[0].Unwrap()))
 }
 
@@ -1956,7 +1956,7 @@ C7E003CB
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA256: error with platform firmware \(PCR0\) measurements: PCR value mismatch \(actual from TPM 0x420bd3899738e6b41dccd18253a556e152e2b107559b89cbf0cbf1661ff6ee55, reconstructed from log 0xb0d6d5f50852be1524306ad88b928605c14338e56a1b8c0dc211a144524df2ef\).
- {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -2032,7 +2032,7 @@ C7E003CB
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA256: error with drivers and apps \(PCR2\) measurements: PCR value mismatch \(actual from TPM 0xfa734a6a4d262d7405d47d48c0a1b127229ca808032555ad919ed5dd7c1f6519, reconstructed from log 0x3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969\).
- {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -2108,7 +2108,7 @@ C7E003CB
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA256: error with boot manager code \(PCR4\) measurements: PCR value mismatch \(actual from TPM 0x1c93930d6b26232e061eaa33ecf6341fae63ce598a0c6a26ee96a0828639c044, reconstructed from log 0x4bc74f3ffe49b4dd275c9f475887b68193e2db8348d72e1c3c9099c2dcfa85b0\).
- {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -2185,7 +2185,7 @@ C7E003CB
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA256: error with secure boot policy \(PCR7\) measurements: PCR value mismatch \(actual from TPM 0xdf7b5d709755f1bd7142dd2f8c2d1195fc6b4dab5c78d41daf5c795da55db5f2, reconstructed from log 0xafc99bd8b298ea9b70d2796cb0ca22fe2b70d784691a1cae2aa3ba55edc365dc\).
- {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -2236,7 +2236,7 @@ C7E003CB
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware contains a debugging endpoint enabled {"kind":"uefi-debugging-enabled","args":null,"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware contains a debugging endpoint enabled`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindUEFIDebuggingEnabled, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -2285,7 +2285,7 @@ C7E003CB
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware indicates that DMA protections are insufficient {"kind":"insufficient-dma-protection","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware indicates that DMA protections are insufficient`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindInsufficientDMAProtection, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 }
 
@@ -2327,7 +2327,7 @@ C7E003CB
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with system security: no kernel IOMMU support was detected {"kind":"no-kernel-iommu","args":null,"actions":\["contact-os-vendor"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[0].Unwrap()))
 }
 
@@ -2374,7 +2374,7 @@ C7E003CB
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks {"kind":"tpm-startup-locality-not-protected","args":null,"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMStartupLocalityNotProtected, nil, nil, errs[0].Unwrap()))
 }
 
@@ -2419,10 +2419,10 @@ C7E003CB
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 2)
-	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware contains a debugging endpoint enabled {"kind":"uefi-debugging-enabled","args":null,"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware contains a debugging endpoint enabled`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindUEFIDebuggingEnabled, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))
 
-	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected {"kind":"no-kernel-iommu","args":null,"actions":\["contact-os-vendor"\]}`)
+	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
 }
 
@@ -2469,7 +2469,7 @@ C7E003CB
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with system security: encountered an error when determining platform firmware protections using Intel MEI: no hardware root-of-trust properly configured: ME is in manufacturing mode: no firmware protections are enabled {"kind":"host-security","args":null,"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with system security: encountered an error when determining platform firmware protections using Intel MEI: no hardware root-of-trust properly configured: ME is in manufacturing mode: no firmware protections are enabled`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindHostSecurity, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -2541,7 +2541,7 @@ C7E003CB
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA256: the PCR bank is missing from the TCG log.
- {"kind":"no-suitable-pcr-bank","args":null,"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoSuitablePCRBank, nil, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -2610,13 +2610,13 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Assert(errs, HasLen, 3)
-	c.Check(errs[0], ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[1,"https://github.com/canonical/secboot/issues/322"\],"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnsupported, []byte("[1,\"https://github.com/canonical/secboot/issues/322\"]"), nil, errs[0].Unwrap()))
 
-	c.Check(errs[1], ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[3,"https://github.com/canonical/secboot/issues/341"\],"actions":null}`)
+	c.Check(errs[1], ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnsupported, []byte("[3,\"https://github.com/canonical/secboot/issues/341\"]"), nil, errs[1].Unwrap()))
 
-	c.Check(errs[2], ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[5,"https://github.com/canonical/secboot/issues/323"\],"actions":null}`)
+	c.Check(errs[2], ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
 	c.Check(errs[2], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnsupported, []byte("[5,\"https://github.com/canonical/secboot/issues/323\"]"), nil, errs[2].Unwrap()))
 }
 
@@ -2690,13 +2690,13 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Assert(errs, HasLen, 3)
-	c.Check(errs[0], ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[1,"https://github.com/canonical/secboot/issues/322"\],"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnsupported, []byte("[1,\"https://github.com/canonical/secboot/issues/322\"]"), nil, errs[0].Unwrap()))
 
-	c.Check(errs[1], ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[3,"https://github.com/canonical/secboot/issues/341"\],"actions":null}`)
+	c.Check(errs[1], ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnsupported, []byte("[3,\"https://github.com/canonical/secboot/issues/341\"]"), nil, errs[1].Unwrap()))
 
-	c.Check(errs[2], ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet {"kind":"tpm-pcr-unsupported","args":\[5,"https://github.com/canonical/secboot/issues/323"\],"actions":null}`)
+	c.Check(errs[2], ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
 	c.Check(errs[2], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnsupported, []byte("[5,\"https://github.com/canonical/secboot/issues/323\"]"), nil, errs[2].Unwrap()))
 }
 
@@ -2766,7 +2766,7 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM {"kind":"empty-pcr-banks","args":\[12\],"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindEmptyPCRBanks,
 		[]byte("[12]"),
@@ -2842,7 +2842,7 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running {"kind":"var-supplied-drivers-present","args":null,"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindVARSuppliedDriversPresent, nil, nil, ErrVARSuppliedDriversPresent))
 }
 
@@ -2913,7 +2913,7 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `system preparation applications were detected to be running {"kind":"sys-prep-applications-present","args":null,"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `system preparation applications were detected to be running`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindSysPrepApplicationsPresent, nil, nil, ErrSysPrepApplicationsPresent))
 }
 
@@ -2984,7 +2984,7 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Check(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `Absolute was detected to be active and it is advised that this is disabled {"kind":"absolute-present","args":null,"actions":\["contact-oem","reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], ErrorMatches, `Absolute was detected to be active and it is advised that this is disabled`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindAbsolutePresent, nil, []Action{ActionContactOEM, ActionRebootToFWSettings}, ErrAbsoluteComputraceActive))
 }
 
@@ -3056,7 +3056,7 @@ C7E003CB
 		actions:        []actionAndArgs{{action: ActionNone}},
 	})
 	c.Assert(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified {"kind":"tpm-pcr-unusable","args":\[4\],"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnusable, []byte("[4]"), []Action{ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -3127,7 +3127,7 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Check(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles {"kind":"invalid-secure-boot-mode","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindInvalidSecureBootMode, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 }
 
@@ -3215,7 +3215,7 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Check(errs, HasLen, 1)
-	c.Check(errs[0], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: unexpected EV_EFI_VARIABLE_DRIVER_CONFIG event: all expected secure boot variable have been measured {"kind":"tpm-pcr-unusable","args":\[7\],"actions":\["contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: unexpected EV_EFI_VARIABLE_DRIVER_CONFIG event: all expected secure boot variable have been measured`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindPCRUnusable, []byte("[7]"), []Action{ActionContactOEM}, errs[0].Unwrap()))
 }
 
@@ -3288,13 +3288,13 @@ C7E003CB
 		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
 	})
 	c.Check(errs, HasLen, 3)
-	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running {"kind":"var-supplied-drivers-present","args":null,"actions":null}`)
+	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindVARSuppliedDriversPresent, nil, nil, ErrVARSuppliedDriversPresent))
 
-	c.Check(errs[1], ErrorMatches, `a weak cryptographic algorithm was detected during secure boot verification {"kind":"weak-secure-boot-algorithms-detected","args":null,"actions":null}`)
+	c.Check(errs[1], ErrorMatches, `a weak cryptographic algorithm was detected during secure boot verification`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindWeakSecureBootAlgorithmsDetected, nil, nil, ErrWeakSecureBootAlgorithmDetected))
 
-	c.Check(errs[2], ErrorMatches, `some pre-OS components were authenticated from the authorized signature database using an Authenticode digest {"kind":"pre-os-digest-verification-detected","args":null,"actions":null}`)
+	c.Check(errs[2], ErrorMatches, `some pre-OS components were authenticated from the authorized signature database using an Authenticode digest`)
 	c.Check(errs[2], DeepEquals, NewWithKindAndActionsError(ErrorKindPreOSDigestVerificationDetected, nil, nil, ErrPreOSVerificationUsingDigests))
 }
 
@@ -3370,10 +3370,10 @@ C7E003CB
 
 	c.Check(errs[0], ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
 - TPM_RH_LOCKOUT has an authorization value
- {"kind":"tpm-hierarchies-owned","args":\[{"hierarchy":1073741834,"type":"auth-value"}\],"actions":\["reboot-to-fw-settings"\]}`)
+`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMHierarchiesOwned, []byte(`[{"hierarchy":1073741834,"type":"auth-value"}]`), []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
 
-	c.Check(errs[1], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles {"kind":"invalid-secure-boot-mode","args":null,"actions":\["reboot-to-fw-settings"\]}`)
+	c.Check(errs[1], ErrorMatches, `error with secure boot policy \(PCR7\) measurements: deployed mode should be enabled in order to generate secure boot profiles`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindInvalidSecureBootMode, nil, []Action{ActionRebootToFWSettings}, errs[1].Unwrap()))
 }
 
@@ -3444,7 +3444,7 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 2)
 
-	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM {"kind":"empty-pcr-banks","args":\[12\],"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindEmptyPCRBanks,
 		[]byte(`[12]`),
@@ -3452,7 +3452,7 @@ C7E003CB
 		errs[0].Unwrap(),
 	))
 
-	c.Check(errs[1], ErrorMatches, `error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified {"kind":"tpm-pcr-unusable","args":\[4\],"actions":\["contact-oem"\]}`)
+	c.Check(errs[1], ErrorMatches, `error with boot manager code \(PCR4\) measurements: not all EV_EFI_BOOT_SERVICES_APPLICATION boot manager launch digests could be verified`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindPCRUnusable,
 		[]byte(`[4]`),
@@ -3523,9 +3523,9 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 2)
 
-	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM {"kind":"empty-pcr-banks","args":\[12\],"actions":\["reboot-to-fw-settings","contact-oem"\]}`)
+	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindEmptyPCRBanks, []byte(`[12]`), []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
 
-	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected {"kind":"no-kernel-iommu","args":null,"actions":\["contact-os-vendor"\]}`)
+	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
 }

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -1574,6 +1574,17 @@ C7E003CB
 
 // **End of good cases ** //
 
+func (s *runChecksContextSuite) TestRunBadUnexpexctedAction(c *C) {
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env:         efitest.NewMockHostEnvironmentWithOpts(),
+		profileOpts: PCRProfileOptionsDefault,
+		actions:     []actionAndArgs{{action: "fake-action"}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Assert(errs[0], ErrorMatches, `specified action is not expected`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindUnexpectedAction, nil, nil, errs[0].Unwrap()))
+}
+
 func (s *runChecksContextSuite) TestRunBadVirtualMachine(c *C) {
 	// Test the error case where a virtualized environment
 	// is detected.

--- a/efi/preinstall/error_kinds.go
+++ b/efi/preinstall/error_kinds.go
@@ -1,0 +1,216 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+// ErrorKind describes an error detected during preinstall checks when
+// using the [RunChecksContext] API.
+type ErrorKind string
+
+const (
+	// ErrorKindNone indicates that no error occurred.
+	ErrorKindNone ErrorKind = ""
+
+	// ErrorKindInternal indicates that some kind of unexpected internal error
+	// occurred that doesn't have a more appropriate error kind.
+	ErrorKindInternal ErrorKind = "internal-error"
+
+	// ErrorKindShutdownRequired indicates that a shutdown is required, and
+	// is returned in response to some actions.
+	ErrorKindShutdownRequired ErrorKind = "shutdown-required"
+
+	// ErrorKindRebootRequired indicates that a reboot is required, and is
+	// returned in response to some actions.
+	ErrorKindRebootRequired ErrorKind = "reboot-required"
+
+	// ErrorKindUnexpectedAction indicates that an action was supplied that
+	// is unexpected because it isn't a remedial action associated with the
+	// previously returned errors, or because the action is not supported.
+	ErrorKindUnexpectedAction ErrorKind = "unexpected-action"
+
+	// ErrorKindMissingArgument is returned if an action was supplied
+	// that requires one or more arguments, but not enough arguments
+	// are supplied.
+	ErrorKindMissingArgument ErrorKind = "missing-argument"
+
+	// ErrorKindInvalidArgument is returned if an action was supplied
+	// that requires one or more arguments, but one or more of the
+	// supplied arguments are of an invalid type of are an invalid value.
+	// This will be supplied with a single argument of type int that
+	// indicates which argument is invalid (and will be zero-indexed).
+	ErrorKindInvalidArgument ErrorKind = "invalid-argument"
+
+	// ErrorKindRunningInVM indicates that the current environment is a
+	// virtal machine.
+	ErrorKindRunningInVM ErrorKind = "running-in-vm"
+
+	// ErrorKindNoSuitableTPM2Device indicates that the device has no
+	// suitable TPM2 device. This is a fatal error. This error means that
+	// full-disk encryption is not supported on this device.
+	ErrorKindNoSuitableTPM2Device ErrorKind = "no-suitable-tpm2-device"
+
+	// ErrorKindTPMDeviceFailure indicates that the TPM device has failed
+	// an internal self check.
+	ErrorKindTPMDeviceFailure ErrorKind = "tpm-device-failure"
+
+	// ErrorKindTPMDeviceDisabled indicates that there is a TPM device
+	// but it is currently disabled. Note that after enabling it, it may
+	// still fail further checks which mean it is unsuitable.
+	ErrorKindTPMDeviceDisabled ErrorKind = "tpm-device-disabled"
+
+	// ErrorKindTPMHierarchiesOwned indicates that one or more TPM hierarchy
+	// is currently owned, either because it has an authorization value or policy
+	// set. This will be supplied with one or more arguments of
+	// TPMHierarchyOwnershipInfo structures to indicate which hierarchies are
+	// owned and whether it's because they have an authorization value or a policy.
+	ErrorKindTPMHierarchiesOwned ErrorKind = "tpm-hierarchies-owned"
+
+	// ErrorKindTPMDeviceLockout indicates that the TPM's dictionary attack
+	// logic is currently triggered, preventing the use of any DA protected
+	// resources. This will be accompanied with 2 arguments of type time.Duration,
+	// with the first argument being the maximum time that it will take for the
+	// lockout to clear, and the second argument being the maximum time it will
+	// take for the fail count to reach 0.
+	ErrorKindTPMDeviceLockout ErrorKind = "tpm-device-lockout"
+
+	// ErrorKindInsufficientTPMStorage indicates that there isn't sufficient
+	// storage space available to support FDE along with reprovisioning in
+	// the future.
+	ErrorKindInsufficientTPMStorage ErrorKind = "insufficient-tpm-storage"
+
+	// ErrorKindNoSuitablePCRBank indicates that it was not possible to select
+	// a suitable PCR bank. This could be because some mandatory PCR values are
+	// inconsistent with the TCG log.
+	// TODO: Expose some information about the error as arguments
+	ErrorKindNoSuitablePCRBank ErrorKind = "no-suitable-pcr-bank"
+
+	// ErrorKindMeasuredBoot indicates that there was an error with the TCG log
+	// or some other error detected from the TCG log that isn't represented by
+	// a more specific error kind.
+	ErrorKindMeasuredBoot ErrorKind = "measured-boot"
+
+	// ErrorKindEmptyPCRBanks indicates that one or more PCR banks thar are not
+	// present in the TCG log are enabled but have unused PCRs in the TCG defined
+	// space (ie, any of PCRs 0-7 are at their reset value). Whilst this isn't an
+	// issue for the FDE use case because we can just select a good bank, it does
+	// break remote attestation from this device, permitting an adversary to spoof
+	// arbitrary trusted platforms by replaying PCR extends from software. This
+	// will be accompanied with a slice of arguments of type tpm2.HashAlgorithmId
+	// to indicate which banks are broken.
+	ErrorKindEmptyPCRBanks ErrorKind = "empty-pcr-banks"
+
+	// ErrorKindTPMCommandFailed indicates that an error occurred whilst
+	// executing a TPM command. It will be accompanied with a single argument
+	// of the type TPMErrorResponse.
+	ErrorKindTPMCommandFailed ErrorKind = "tpm-command-failed"
+
+	// ErrorKindInvalidTPMResponse indicates that the response from the TPM is
+	// invalid, which makes it impossible to obtain a response code. This could
+	// be because the response packet cannot be decoded, or one or more sessions
+	// failed the response HMAC check.
+	ErrorKindInvalidTPMResponse ErrorKind = "invalid-tpm-response"
+
+	// ErrorKindTPMCommunication indicates that an error occurred at the transport
+	// layer when executing a TPM command.
+	ErrorKindTPMCommunication ErrorKind = "tpm-communication"
+
+	// ErrorKindUnsupportedPlatform indicates that the current host platform is
+	// not compatible with FDE. This generally occurs because the checks lack
+	// the support for testing properties of the current platform, eg, whether
+	// there is a correctly configured hardware RTM.
+	ErrorKindUnsupportedPlatform ErrorKind = "unsupported-platform"
+
+	// ErrorKindUEFIDebuggingEnabled indicates that the platform firmware currently
+	// has a debugging endpoint enabled.
+	ErrorKindUEFIDebuggingEnabled ErrorKind = "uefi-debugging-enabled"
+
+	// ErrorKindInsufficientDMAProtection indicates that I/O DMA remapping was
+	// disabled during the current boot cycle.
+	ErrorKindInsufficientDMAProtection ErrorKind = "insufficient-dma-protection"
+
+	// ErrorKindNoKernelIOMMU indicates that the OS kernel was not built with DMA
+	// remapping support, or some configuration has resulted in it being disabled.
+	ErrorKindNoKernelIOMMU ErrorKind = "no-kernel-iommu"
+
+	// ErrorKindTPMStartupLocalityNotProtected indicates that the system has a discrete TPM
+	// and the startup locality is not protected from access by privileged code running at
+	// ring 0, such as the platform firmware or OS kernel. This makes it impossible to enable
+	// a mitigation against reset attacks (see the description for DiscreteTPMDetected for more
+	// information).
+	ErrorKindTPMStartupLocalityNotProtected ErrorKind = "tpm-startup-locality-not-protected"
+
+	// ErrorKindHostSecurity indicates that there is some problem with the system
+	// security that isn't represented by a more specific error kind.
+	ErrorKindHostSecurity ErrorKind = "host-security"
+
+	// ErrorKindPCRUnusable indicates an error in the way that the platform
+	// firmware performs measurements such that the PCR becomes unusable.
+	// This will include a single tpm2.Handle argument to indicate which PCR
+	// failed.
+	ErrorKindPCRUnusable ErrorKind = "tpm-pcr-unusable"
+
+	// ErrorKindPCRUnsupported indicates that a required PCR is currently
+	// unsupported by the efi sub-package. This will include 2 arguments - the
+	// first one being a tpm2.Handle to indicate which PCR is unsupported. The
+	// second argument will be a string containing a URL to a github issue.
+	ErrorKindPCRUnsupported ErrorKind = "tpm-pcr-unsupported"
+
+	// ErrorKindVARSuppliedDriversPresent indicates that drivers running from value-added-retailer
+	// components were detected. Whilst these should generally be authenticated as part of the
+	// secure boot chain and the digsts of the executed code measured to the TPM, the presence of
+	// these does increase PCR fragility, and a user may choose not to trust this code (in which
+	// case, they will need to disable it somehow).
+	// TODO: it might be worth including the device paths from the launch events in PCR2 as an
+	// argument.
+	ErrorKindVARSuppliedDriversPresent ErrorKind = "var-supplied-drivers-present"
+
+	// ErrorKindSysPrepApplicationsPresent indicates that system preparation applications were
+	// detected to be running before the operating system. The OS does not use these and they
+	// increase the fragility of PCR4 because they are beyond the control of the operating system.
+	// In general, it is recommended that these are disabled.
+	// TODO: it might be worth including the device paths from the launch events in PCR4 as an
+	// argument.
+	ErrorKindSysPrepApplicationsPresent ErrorKind = "sys-prep-applications-present"
+
+	// ErrorKindAbsolutePresent indicates that Absolute was detected to be executing before the
+	// initial OS loader. This is an endpoint management agent that is shipped with the platform
+	// firmware. As it requires an OS component, it is generally recommended that this is disabled
+	// via the firmware settings UI. Leaving it enabled does increase fragility of PCR4 because it
+	// exposes it to changes via firmware updates.
+	ErrorKindAbsolutePresent ErrorKind = "absolute-present"
+
+	// ErrorKindInvalidSecureBootMode indicates that the secure boot mode is invalid. Either secure
+	// boot is disabled or deployed mode is not enabled.
+	ErrorKindInvalidSecureBootMode ErrorKind = "invalid-secure-boot-mode"
+
+	// ErrorKindWeakSecureBootAlgorithmsDetected indicates that either pre-OS components were
+	// authenticated with weak Authenticode digests, or CAs with weak public keys were used to
+	// authenticate components. This check does have some limitations - for components other than
+	// OS components, it is not possible to determine the properties of the signing key for signed
+	// components - it is only possible to determine the properties of the trust anchor (the
+	// certificate that is stored in db).
+	ErrorKindWeakSecureBootAlgorithmsDetected ErrorKind = "weak-secure-boot-algorithms-detected"
+
+	// ErrorKindPreOSDigestVerificationDetected indicates that pre-OS components were authenticated
+	// by matching their Authenticode digest to an entry in db. This means that db has to change with
+	// every firmware update, increasing the fragility of PCR7.
+	// TODO: it might be worth attempting to match the verification with a corresponding
+	// launch event from PCR2 or PCR4 to grab the device path and include it as an argument.
+	ErrorKindPreOSDigestVerificationDetected ErrorKind = "pre-os-digest-verification-detected"
+)

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -824,17 +824,17 @@ func (e *UnsupportedRequiredPCRsError) Error() string {
 	}
 }
 
-// ErrorKindAndActions is an error type that can be serialized to JSON, represented by
+// WithKindAndActionsError is an error type that can be serialized to JSON, represented by
 // an error kind, associated arguments and a set of potential remedial actions.
-type ErrorKindAndActions struct {
-	ErrorKind ErrorKind       `json:"kind"`    // The error kind
-	ErrorArgs json.RawMessage `json:"args"`    // The arguments associated with the error, as a slice. See the documentation for the ErrorKind for the meaning of these.
-	Actions   []Action        `json:"actions"` // Potential remedial actions. This may be empty. Note that not all actions can be supplied to RunChecksContext.Run.
+type WithKindAndActionsError struct {
+	Kind    ErrorKind       `json:"kind"`    // The error kind
+	Args    json.RawMessage `json:"args"`    // The arguments associated with the error, as a slice. See the documentation for the ErrorKind for the meaning of these.
+	Actions []Action        `json:"actions"` // Potential remedial actions. This may be empty. Note that not all actions can be supplied to RunChecksContext.Run.
 
 	err error `json:"-"` // The original error. This is not serialized to JSON.
 }
 
-func (e *ErrorKindAndActions) Error() string {
+func (e *WithKindAndActionsError) Error() string {
 	data, err := json.Marshal(e)
 	if err != nil {
 		data = []byte(fmt.Sprintf("cannot serialize error: %v", err))
@@ -842,6 +842,6 @@ func (e *ErrorKindAndActions) Error() string {
 	return fmt.Sprintf("%v %s", e.err, string(data))
 }
 
-func (e *ErrorKindAndActions) Unwrap() error {
+func (e *WithKindAndActionsError) Unwrap() error {
 	return e.err
 }

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -466,9 +466,9 @@ func (e *PlatformFirmwarePCRError) Unwrap() error {
 // because there is currently no support in [github.com/snapcore/secboot/efi] for
 // generating profiles for PCR 1.
 //
-// This error will be returned wrapped wrapped in [NoSuitablePCRAlgorithmError]
-// if the PlatformConfigProfileSupportRequired flag is supplied to [RunChecks]
-// and the PCR 1 value is inconsistent with the value recorded from the TCG log.
+// This error will be returned wrapped in [NoSuitablePCRAlgorithmError] if the
+// PlatformConfigProfileSupportRequired flag is supplied to [RunChecks] and the
+// PCR 1 value is inconsistent with the value recorded from the TCG log.
 //
 // This error will otherwise currently always be returned wrapped in a type that
 // implements [CompoundError] if the PlatformConfigProfileSupportRequired flag is
@@ -529,10 +529,9 @@ var (
 // [RunChecks], because there is currently no support in
 // [github.com/snapcore/secboot/efi] for generating profiles for PCR 3.
 //
-// This error will be returned wrapped wrapped in [NoSuitablePCRAlgorithmError]
-// if the DriversAndAppsConfigProfileSupportRequired flag is supplied to
-// [RunChecks] and the PCR 3 value is inconsistent with the value recorded from
-// the TCG log.
+// This error will be returned wrapped in [NoSuitablePCRAlgorithmError] if the
+// DriversAndAppsConfigProfileSupportRequired flag is supplied to [RunChecks] and
+// the PCR 3 value is inconsistent with the value recorded from the TCG log.
 //
 // This error will otherwise currently always be returned wrapped in a type that
 // implements [CompoundError] if the DriversAndAppsConfigProfileSupportRequired flag
@@ -580,9 +579,9 @@ func (e *DriversAndAppsConfigPCRError) Unwrap() error {
 // to indicate that [github.com/snapcore/secboot/efi.WithBootManagerCodeProfile]
 // cannot be used to generate profiles for PCR 4.
 //
-// This error will be returned wrapped wrapped in [NoSuitablePCRAlgorithmError]
-// if the BootManagerCodeProfileSupportRequired flag is supplied to [RunChecks]
-// and the PCR 4 value is inconsistent with the value recorded from the TCG log.
+// This error will be returned wrapped in [NoSuitablePCRAlgorithmError] if the
+// BootManagerCodeProfileSupportRequired flag is supplied to [RunChecks] and the
+// PCR 4 value is inconsistent with the value recorded from the TCG log.
 //
 // If any other error occurs and the BootManagerCodeProfileSupportRequired flag is
 // supplied to [RunChecks], this error will be returned wrapped in a type that
@@ -632,9 +631,9 @@ var (
 // because there is currently no support in [github.com/snapcore/secboot/efi]
 // for generating profiles for PCR 5.
 //
-// This error will be returned wrapped wrapped in [NoSuitablePCRAlgorithmError]
-// if the BootManagerConfigProfileSupportRequired flag is supplied to [RunChecks]
-// and the PCR 5 value is inconsistent with the value recorded from the TCG log.
+// This error will be returned wrapped in [NoSuitablePCRAlgorithmError] if the
+// BootManagerConfigProfileSupportRequired flag is supplied to [RunChecks] and the
+// PCR 5 value is inconsistent with the value recorded from the TCG log.
 //
 // This error will otherwise currently always be returned wrapped in
 // a type that implements [CompoundError] if the
@@ -704,9 +703,9 @@ func (e *BootManagerConfigPCRError) Unwrap() error {
 // to indicate that [github.com/snapcore/secboot/efi.WithSecureBootPolicyProfile]
 // cannot be used to generate profiles for PCR 7.
 //
-// This error will be returned wrapped wrapped in [NoSuitablePCRAlgorithmError]
-// if the SecureBootPolicyProfileSupportRequired flag is supplied to [RunChecks]
-// and the PCR 7 value is inconsistent with the value recorded from the TCG log.
+// This error will be returned wrapped in [NoSuitablePCRAlgorithmError] if the
+// SecureBootPolicyProfileSupportRequired flag is supplied to [RunChecks] and the
+// PCR 7 value is inconsistent with the value recorded from the TCG log.
 //
 // If any other error occurs and the SecureBootPolicyProfileSupportRequired flag is
 // supplied to [RunChecks], this error will be returned wrapped in a type that

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -835,11 +835,10 @@ type WithKindAndActionsError struct {
 }
 
 func (e *WithKindAndActionsError) Error() string {
-	data, err := json.Marshal(e)
-	if err != nil {
-		data = []byte(fmt.Sprintf("cannot serialize error: %v", err))
+	if e.err == nil {
+		return "<nil>"
 	}
-	return fmt.Sprintf("%v %s", e.err, string(data))
+	return e.err.Error()
 }
 
 func (e *WithKindAndActionsError) Unwrap() error {

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -779,7 +779,7 @@ func wrapPCRError(pcr tpm2.Handle, err error) error {
 	}
 }
 
-// UnsupportedReqiredPCRsError is returned from methods of [PCRProfileAutoEnablePCRsOption]
+// UnsupportedRequiredPCRsError is returned from methods of [PCRProfileAutoEnablePCRsOption]
 // when a valid PCR configuration cannot be created based on the supplied [PCRProfileOptionsFlags]
 // and [CheckResult].
 type UnsupportedRequiredPCRsError struct {

--- a/efi/preinstall/errors_test.go
+++ b/efi/preinstall/errors_test.go
@@ -20,9 +20,11 @@
 package preinstall_test
 
 import (
+	"encoding/json"
 	"errors"
 
 	. "github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/secboot/internal/testutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -56,4 +58,229 @@ multiple lines
 func (s *errorsSuite) TestJoinErrorOneError(c *C) {
 	err := JoinErrors(errors.New("some error"))
 	c.Check(err.Error(), Equals, `some error`)
+}
+
+func (s *errorsSuite) TestNewWithKindAndActionsErrorNoArgsOrActions(c *C) {
+	kind := ErrorKind("foo")
+	rawErr := errors.New("some error")
+	err := NewWithKindAndActionsError(kind, nil, nil, rawErr)
+	c.Check(err, DeepEquals, NewWithKindAndActionsErrorForTest(kind, nil, nil, rawErr))
+}
+
+func (s *errorsSuite) TestNewWithKindAndActionsErrorNoArgs(c *C) {
+	kind := ErrorKind("bar")
+	actions := []Action{"action1", "action2"}
+	rawErr := errors.New("another error")
+	err := NewWithKindAndActionsError(kind, nil, actions, rawErr)
+	c.Check(err, DeepEquals, NewWithKindAndActionsErrorForTest(kind, nil, actions, rawErr))
+}
+
+func (s *errorsSuite) TestNewWithKindAndActionsError(c *C) {
+	kind := ErrorKind("foo")
+	args := map[string]any{
+		"arg1": 1,
+		"arg2": "bar",
+	}
+	argJson := make(map[string]json.RawMessage)
+	for k, v := range args {
+		j, err := json.Marshal(v)
+		c.Assert(err, IsNil)
+		argJson[k] = j
+	}
+	actions := []Action{"action2", "action1"}
+	rawErr := errors.New("some error")
+	err := NewWithKindAndActionsError(kind, args, actions, rawErr)
+	c.Check(err, DeepEquals, NewWithKindAndActionsErrorForTest(kind, argJson, actions, rawErr))
+}
+
+type withKindAndActionsErrorArgs struct {
+	Arg1 string `json:"arg1"`
+	Arg2 int    `json:"arg2"`
+}
+
+func (s *errorsSuite) TestNewWithKindAndActionsErrorArgStructure(c *C) {
+	kind := ErrorKind("foo")
+	args := &withKindAndActionsErrorArgs{Arg1: "bar", Arg2: 35}
+	argsJson := map[string]json.RawMessage{
+		"arg1": []byte("\"bar\""),
+		"arg2": []byte("35"),
+	}
+	rawErr := errors.New("some error")
+	err := NewWithKindAndActionsError(kind, args, nil, rawErr)
+	c.Check(err, DeepEquals, NewWithKindAndActionsErrorForTest(kind, argsJson, nil, rawErr))
+}
+
+func (s *errorsSuite) TestNewWithKindAndActionsErrorMarshal(c *C) {
+	kind := ErrorKind("bar")
+	args := &withKindAndActionsErrorArgs{Arg1: "foo", Arg2: 35}
+	argsJson := map[string]json.RawMessage{
+		"arg1": []byte("\"foo\""),
+		"arg2": []byte("35"),
+	}
+	actions := []Action{"action1", "action2"}
+	rawErr := errors.New("some error")
+
+	data, err := json.Marshal(NewWithKindAndActionsError(kind, args, actions, rawErr))
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, testutil.DecodeHexString(c, "7b226b696e64223a22626172222c2261726773223a7b2261726731223a22666f6f222c2261726732223a33357d2c22616374696f6e73223a5b22616374696f6e31222c22616374696f6e32225d7d"))
+
+	var decodedErr *WithKindAndActionsError
+	c.Check(json.Unmarshal(data, &decodedErr), IsNil)
+	c.Check(decodedErr, DeepEquals, NewWithKindAndActionsErrorForTest(kind, argsJson, actions, nil))
+}
+
+func (s *errorsSuite) TestNewWithKindAndActionsErrorNoJsonArgsPanic(c *C) {
+	c.Check(func() {
+		NewWithKindAndActionsError("foo", []any{"bar1", json.RawMessage{0x22, 0x62, 0x61, 0x72}}, nil, errors.New("some error"))
+	}, PanicMatches, `cannot serialize arguments to JSON: json: error calling MarshalJSON for type json.RawMessage: unexpected end of JSON input`)
+}
+
+func (s *errorsSuite) TestNewWithKindAndActionsErrorNoMapArgsPanic(c *C) {
+	c.Check(func() { NewWithKindAndActionsError("foo", []string{"bar1", "bar2"}, nil, errors.New("some error")) }, PanicMatches, `cannot deserialize arguments JSON to map: json: cannot unmarshal array into Go value of type map\[string\]json.RawMessage`)
+}
+
+func (s *errorsSuite) TestWithKindAndActionsErrorGetArgByName1(c *C) {
+	kind := ErrorKind("foo")
+	args := &withKindAndActionsErrorArgs{Arg1: "bar", Arg2: 20}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, args, nil, rawErr)
+
+	val, err := testErr.GetArgByName("arg1")
+	c.Check(err, IsNil)
+	c.Check(val, Equals, any("bar"))
+}
+
+func (s *errorsSuite) TestWithKindAndActionsErrorGetArgByName2(c *C) {
+	kind := ErrorKind("foo")
+	args := &withKindAndActionsErrorArgs{Arg1: "bar", Arg2: 20}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, args, nil, rawErr)
+
+	val, err := testErr.GetArgByName("arg2")
+	c.Check(err, IsNil)
+	c.Check(val, Equals, any(float64(20)))
+}
+
+func (s *errorsSuite) TestWithKindAndActionsErrorGetArgByNameMissingName(c *C) {
+	kind := ErrorKind("foo")
+	args := &withKindAndActionsErrorArgs{Arg1: "bar", Arg2: 20}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, args, nil, rawErr)
+
+	_, err := testErr.GetArgByName("missing")
+	c.Check(err, ErrorMatches, `argument "missing" does not exist`)
+}
+
+func (s *errorsSuite) TestWithKindAndActionsErrorGetArgByNameInvalidJSON(c *C) {
+	kind := ErrorKind("foo")
+	args := map[string]json.RawMessage{
+		"arg": []byte("\"bar"),
+	}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsErrorForTest(kind, args, nil, rawErr)
+
+	_, err := testErr.GetArgByName("arg")
+	c.Check(err, ErrorMatches, `cannot deserialize argument "arg" from JSON: unexpected end of JSON input`)
+}
+
+func (s *errorsSuite) TestWithKindAndActionsErrorGetArgMap(c *C) {
+	kind := ErrorKind("foo")
+	args := &withKindAndActionsErrorArgs{Arg1: "bar", Arg2: 20}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, args, nil, rawErr)
+
+	val, err := testErr.GetArgMap()
+	c.Assert(err, IsNil)
+	c.Check(val, DeepEquals, map[string]any{
+		"arg1": any("bar"),
+		"arg2": any(float64(20)),
+	})
+}
+
+func (s *errorsSuite) TestWithKindAndActionsErrorGetArgMapInvalidJSON(c *C) {
+	kind := ErrorKind("foo")
+	args := map[string]json.RawMessage{
+		"arg1": []byte("\"bar"),
+		"arg2": []byte("40"),
+	}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsErrorForTest(kind, args, nil, rawErr)
+
+	_, err := testErr.GetArgMap()
+	c.Assert(err, ErrorMatches, `cannot deserialize argument "arg1" from JSON: unexpected end of JSON input`)
+}
+
+func (s *errorsSuite) TestGetWithKindAndActionsErrorArg1(c *C) {
+	kind := ErrorKind("foo")
+	expectedArgs := &withKindAndActionsErrorArgs{Arg1: "bar", Arg2: 20}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, expectedArgs, nil, rawErr)
+
+	args, err := GetWithKindAndActionsErrorArg[*withKindAndActionsErrorArgs](testErr)
+	c.Assert(err, IsNil)
+	c.Check(args, DeepEquals, expectedArgs)
+}
+
+func (s *errorsSuite) TestGetWithKindAndActionsErrorArg2(c *C) {
+	kind := ErrorKind("foo")
+	argsIn := map[string]any{
+		"arg1": "bar",
+		"arg2": 35,
+	}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, argsIn, nil, rawErr)
+
+	args, err := GetWithKindAndActionsErrorArg[withKindAndActionsErrorArgs](testErr)
+	c.Assert(err, IsNil)
+	c.Check(args, DeepEquals, withKindAndActionsErrorArgs{Arg1: "bar", Arg2: 35})
+}
+
+func (s *errorsSuite) TestGetWithKindAndActionsErrorInvalidMap(c *C) {
+	kind := ErrorKind("foo")
+	argsJson := map[string]json.RawMessage{
+		"arg1": []byte("\"bar"),
+		"arg2": []byte("40"),
+	}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsErrorForTest(kind, argsJson, nil, rawErr)
+
+	_, err := GetWithKindAndActionsErrorArg[*withKindAndActionsErrorArgs](testErr)
+	c.Assert(err, ErrorMatches, `cannot serialize argument map to JSON: json: error calling MarshalJSON for type json.RawMessage: unexpected end of JSON input`)
+}
+
+func (s *errorsSuite) TestGetWithKindAndActionsErrorInvalidType1(c *C) {
+	kind := ErrorKind("foo")
+	argsIn := map[string]any{
+		"arg3": "bar",
+		"arg4": 35,
+	}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, argsIn, nil, rawErr)
+
+	_, err := GetWithKindAndActionsErrorArg[*withKindAndActionsErrorArgs](testErr)
+	c.Assert(err, ErrorMatches, `cannot deserialize argument map from JSON to type \*preinstall_test.withKindAndActionsErrorArgs: json: unknown field "arg3"`)
+}
+
+func (s *errorsSuite) TestGetWithKindAndActionsErrorInvalidType2(c *C) {
+	kind := ErrorKind("foo")
+	argsIn := map[string]any{
+		"arg1": "bar",
+		"arg2": true,
+	}
+	rawErr := errors.New("some error")
+
+	testErr := NewWithKindAndActionsError(kind, argsIn, nil, rawErr)
+
+	_, err := GetWithKindAndActionsErrorArg[*withKindAndActionsErrorArgs](testErr)
+	c.Assert(err, ErrorMatches, `cannot deserialize argument map from JSON to type \*preinstall_test.withKindAndActionsErrorArgs: json: cannot unmarshal bool into Go struct field withKindAndActionsErrorArgs.arg2 of type int`)
 }

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -133,16 +133,16 @@ func MockRunChecksEnv(env internal_efi.HostEnvironment) (restore func()) {
 	}
 }
 
-func NewErrorKindAndActions(kind ErrorKind, args []byte, actions []Action, err error) *ErrorKindAndActions {
+func NewWithKindAndActionsError(kind ErrorKind, args []byte, actions []Action, err error) *WithKindAndActionsError {
 	if len(args) == 0 {
 		// encoding/json marshals an empty json.RawMessage to this already,
 		// but we need to do this to use the DeepEqual checker.
 		args = []byte("null")
 	}
-	return &ErrorKindAndActions{
-		ErrorKind: kind,
-		ErrorArgs: args,
-		Actions:   actions,
-		err:       err,
+	return &WithKindAndActionsError{
+		Kind:    kind,
+		Args:    args,
+		Actions: actions,
+		err:     err,
 	}
 }

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -90,6 +90,7 @@ var (
 	ReadIntelHFSTSRegistersFromMEISysfs                   = readIntelHFSTSRegistersFromMEISysfs
 	ReadIntelMEVersionFromMEISysfs                        = readIntelMEVersionFromMEISysfs
 	ReadLoadOptionFromLog                                 = readLoadOptionFromLog
+	UnwrapCompoundError                                   = unwrapCompoundError
 )
 
 func MockEfiComputePeImageDigest(fn func(crypto.Hash, io.ReaderAt, int64) ([]byte, error)) (restore func()) {
@@ -129,5 +130,19 @@ func MockRunChecksEnv(env internal_efi.HostEnvironment) (restore func()) {
 	runChecksEnv = env
 	return func() {
 		runChecksEnv = orig
+	}
+}
+
+func NewErrorKindAndActions(kind ErrorKind, args []byte, actions []Action, err error) *ErrorKindAndActions {
+	if len(args) == 0 {
+		// encoding/json marshals an empty json.RawMessage to this already,
+		// but we need to do this to use the DeepEqual checker.
+		args = []byte("null")
+	}
+	return &ErrorKindAndActions{
+		ErrorKind: kind,
+		ErrorArgs: args,
+		Actions:   actions,
+		err:       err,
 	}
 }

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -21,6 +21,7 @@ package preinstall
 
 import (
 	"crypto"
+	"encoding/json"
 	"io"
 
 	efi "github.com/canonical/go-efilib"
@@ -133,12 +134,7 @@ func MockRunChecksEnv(env internal_efi.HostEnvironment) (restore func()) {
 	}
 }
 
-func NewWithKindAndActionsError(kind ErrorKind, args []byte, actions []Action, err error) *WithKindAndActionsError {
-	if len(args) == 0 {
-		// encoding/json marshals an empty json.RawMessage to this already,
-		// but we need to do this to use the DeepEqual checker.
-		args = []byte("null")
-	}
+func NewWithKindAndActionsErrorForTest(kind ErrorKind, args map[string]json.RawMessage, actions []Action, err error) *WithKindAndActionsError {
 	return &WithKindAndActionsError{
 		Kind:    kind,
 		Args:    args,

--- a/efi/preinstall/tpm_util.go
+++ b/efi/preinstall/tpm_util.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"errors"
+
+	"github.com/canonical/go-tpm2"
+)
+
+// TPMErrorResponse represents a TPM response that can
+// be serialized to JSON.
+type TPMErrorResponse struct {
+	CommandCode  tpm2.CommandCode  `json:"command-code"`
+	ResponseCode tpm2.ResponseCode `json:"response-code"`
+}
+
+// errorAsTPMErrorResponse determines whether the supplied error is an
+// error associated with a TPM command, and returns a TPMErrorResponse
+// and true if it is, else it returns (nil, false).
+func errorAsTPMErrorResponse(err error) (*TPMErrorResponse, bool) {
+	tpmErr := tpm2.AsTPMError(err, tpm2.AnyErrorCode, tpm2.AnyCommandCode)
+	if tpmErr != nil {
+		return &TPMErrorResponse{tpmErr.CommandCode(), tpmErr.ResponseCode()}, true
+	}
+	tpmWarn := tpm2.AsTPMWarning(err, tpm2.AnyWarningCode, tpm2.AnyCommandCode)
+	if tpmWarn != nil {
+		return &TPMErrorResponse{tpmWarn.CommandCode(), tpmWarn.ResponseCode()}, true
+	}
+	vendorErr := tpm2.AsTPMVendorError(err, tpm2.AnyVendorResponseCode, tpm2.AnyCommandCode)
+	if vendorErr != nil {
+		return &TPMErrorResponse{vendorErr.CommandCode(), vendorErr.ResponseCode()}, true
+	}
+
+	return nil, false
+}
+
+// isInvalidTPMResponse determines whether the supplied error is an
+// error associated with a TPM response which prevents a response code
+// from being obtained.
+func isInvalidTPMResponse(err error) (yes bool) {
+	var e *tpm2.InvalidResponseError
+	return errors.As(err, &e)
+}
+
+// isTPMCommunicationError determines whether the supplied error is
+// associated with a failure to communicate with the TPM.
+func isTPMCommunicationError(err error) (yes bool) {
+	var e *tpm2.TransportError
+	return errors.As(err, &e)
+}
+
+// TPMHierarchyOwnershipType describes how a hierarchy is owned.
+type TPMHierarchyOwnershipType string
+
+const (
+	TPMHierarchyOwnershipAuthValue  TPMHierarchyOwnershipType = "auth-value"
+	TPMHierarchyOwnershipAuthPolicy TPMHierarchyOwnershipType = "auth-policy"
+)
+
+// TPMHierarchyOwnershipInfo contains information about a hierarchy that is owned.
+type TPMHierarchyOwnershipInfo struct {
+	Hierarchy tpm2.Handle               `json:"hierarchy"`
+	Type      TPMHierarchyOwnershipType `json:"type"`
+}

--- a/efi/preinstall/tpm_util.go
+++ b/efi/preinstall/tpm_util.go
@@ -21,12 +21,12 @@ package preinstall
 
 import (
 	"errors"
+	"time"
 
 	"github.com/canonical/go-tpm2"
 )
 
-// TPMErrorResponse represents a TPM response that can
-// be serialized to JSON.
+// TPMErrorResponse represents a TPM response that can be serialized to JSON.
 type TPMErrorResponse struct {
 	CommandCode  tpm2.CommandCode  `json:"command-code"`
 	ResponseCode tpm2.ResponseCode `json:"response-code"`
@@ -67,16 +67,16 @@ func isTPMCommunicationError(err error) (yes bool) {
 	return errors.As(err, &e)
 }
 
-// TPMHierarchyOwnershipType describes how a hierarchy is owned.
-type TPMHierarchyOwnershipType string
+// TPMDeviceLockoutArgs are the arguments associated with errors with an [ErrorKind]
+// of ErrorKindTPMDeviceLockout.
+type TPMDeviceLockoutArgs struct {
+	// IntervalDuration is the maximum amount of time it will
+	// take for the lockout counter to reduce by one so that the lockout
+	// clears, although it will only take a single authorization failure
+	// to trigger the lockout again.
+	IntervalDuration time.Duration `json:"interval-duration"`
 
-const (
-	TPMHierarchyOwnershipAuthValue  TPMHierarchyOwnershipType = "auth-value"
-	TPMHierarchyOwnershipAuthPolicy TPMHierarchyOwnershipType = "auth-policy"
-)
-
-// TPMHierarchyOwnershipInfo contains information about a hierarchy that is owned.
-type TPMHierarchyOwnershipInfo struct {
-	Hierarchy tpm2.Handle               `json:"hierarchy"`
-	Type      TPMHierarchyOwnershipType `json:"type"`
+	// TotalDuration is the maximum amount of time it will
+	// take for the lockout counter to reduce to zero.
+	TotalDuration time.Duration `json:"total-duration"`
 }


### PR DESCRIPTION
This API is easier to use than the other exported API (RunChecks) and
converts errors into error kinds that are suitable for representing in
JSON.

This API will eventually map certain error kinds to actions that can be
performed by this package in order to resolve some issues. The intention
here is that the installer UI eventually gives the user some information
about why FDE cannot be enabled, and it gives them the option of choosing
to fix some issues where it is possible and appropriate to do so (eg, say
the TPM device is detected but disabled, there should be an action to
enable it via the PPI).

The Action type and some pseudo actions are already defined - these are
actions that cannot be performed by this package, but are hints for
actions that can be performed by the caller, eg, shutdown, reboot and
reboot to firmware settings are some examples.

RunChecksContext will keep track of which actions are expected (based on
the previous response) and which actions are enabled - some actions are
enabled by default but may become disabled later on because of an error,
and some other actions will only be made available after performing
tests that indicate the action can be performed.