### PR TITLE
preinstall: Fix declaration of tcglogPhase enum constants

### DIFF
--- a/efi/preinstall/check_tcglog.go
+++ b/efi/preinstall/check_tcglog.go
@@ -388,7 +388,7 @@ const (
 	// the secure boot configuration is being measured.
 	// tcglogPhasePreOSBeforeMeasureSecureBootConfig transitions to this phase by the
 	// first non EV_SEPARATOR event in PCR7.
-	tcglogPhasePreOSMeasuringSecureBootConfig tcglogPhase = iota
+	tcglogPhasePreOSMeasuringSecureBootConfig
 
 	// tcglogPhasePreOSAfterMeasureSecureBootConfig is the pre-OS phase of the log after
 	// measuring the secure boot configuration and which may contain authentication and


### PR DESCRIPTION
This doesn't have any effect on the declared enum constants, hence there
are no unit test changes. It just fixes a mistake in the way that the
constants are declared, and makes them consistent with others in this
repository.