### PR TITLE
preinstall: Simplify NoSuitablePCRAlgorithmError

### DIFF
--- a/efi/preinstall/check_fw_protections_amd64.go
+++ b/efi/preinstall/check_fw_protections_amd64.go
@@ -23,9 +23,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/canonical/cpuid"
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/tcglog-parser"
-	"github.com/canonical/cpuid"
 	internal_efi "github.com/snapcore/secboot/internal/efi"
 )
 

--- a/efi/preinstall/checks.go
+++ b/efi/preinstall/checks.go
@@ -274,27 +274,21 @@ func RunChecks(ctx context.Context, flags CheckFlags, loadedImages []secboot_efi
 
 	// Record errors for non-mandatory PCRs as warnings.
 	for pcr, err := range logResults.pcrErrs() {
+		err = wrapPCRError(pcr, err)
 		switch pcr {
 		case 0:
-			err = &PlatformFirmwarePCRError{err}
 			result.Flags |= NoPlatformFirmwareProfileSupport
 		case 1:
-			err = &PlatformConfigPCRError{err}
 			result.Flags |= NoPlatformConfigProfileSupport
 		case 2:
-			err = &DriversAndAppsPCRError{err}
 			result.Flags |= NoDriversAndAppsProfileSupport
 		case 3:
-			err = &DriversAndAppsConfigPCRError{err}
 			result.Flags |= NoDriversAndAppsConfigProfileSupport
 		case 4:
-			err = &BootManagerCodePCRError{err}
 			result.Flags |= NoBootManagerCodeProfileSupport
 		case 5:
-			err = &BootManagerConfigPCRError{err}
 			result.Flags |= NoBootManagerConfigProfileSupport
 		case 7:
-			err = &SecureBootPolicyPCRError{err}
 			result.Flags |= NoSecureBootPolicyProfileSupport
 		}
 		result.Warnings.addErr(err)

--- a/efi/preinstall/checks_test.go
+++ b/efi/preinstall/checks_test.go
@@ -2161,7 +2161,7 @@ func (s *runChecksSuite) TestRunChecksBadInvalidPCR0Value(c *C) {
 	c.Check(err, ErrorMatches, `error with TCG log: no suitable PCR algorithm available:
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256\(PCR0\): PCR value mismatch \(actual from TPM 0xe9995745ca25279ec699688b70488116fe4d9f053cb0991dd71e82e7edfa66b5, reconstructed from log 0xa6602a7a403068b5556e78cc3f5b00c9c76d33d514093ca9b584dce7590e6c69\).
+- TPM_ALG_SHA256: error with platform firmware \(PCR0\) measurements: PCR value mismatch \(actual from TPM 0xe9995745ca25279ec699688b70488116fe4d9f053cb0991dd71e82e7edfa66b5, reconstructed from log 0xa6602a7a403068b5556e78cc3f5b00c9c76d33d514093ca9b584dce7590e6c69\).
 `)
 	var te *TCGLogError
 	c.Assert(errors.As(err, &te), testutil.IsTrue)
@@ -2192,7 +2192,7 @@ func (s *runChecksSuite) TestRunChecksBadInvalidPCR2Value(c *C) {
 	c.Check(err, ErrorMatches, `error with TCG log: no suitable PCR algorithm available:
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256\(PCR2\): PCR value mismatch \(actual from TPM 0xfa734a6a4d262d7405d47d48c0a1b127229ca808032555ad919ed5dd7c1f6519, reconstructed from log 0x3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969\).
+- TPM_ALG_SHA256: error with drivers and apps \(PCR2\) measurements: PCR value mismatch \(actual from TPM 0xfa734a6a4d262d7405d47d48c0a1b127229ca808032555ad919ed5dd7c1f6519, reconstructed from log 0x3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969\).
 `)
 	var te *TCGLogError
 	c.Assert(errors.As(err, &te), testutil.IsTrue)
@@ -2223,7 +2223,7 @@ func (s *runChecksSuite) TestRunChecksBadInvalidPCR4Value(c *C) {
 	c.Check(err, ErrorMatches, `error with TCG log: no suitable PCR algorithm available:
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256\(PCR4\): PCR value mismatch \(actual from TPM 0x1c93930d6b26232e061eaa33ecf6341fae63ce598a0c6a26ee96a0828639c044, reconstructed from log 0x4bc74f3ffe49b4dd275c9f475887b68193e2db8348d72e1c3c9099c2dcfa85b0\).
+- TPM_ALG_SHA256: error with boot manager code \(PCR4\) measurements: PCR value mismatch \(actual from TPM 0x1c93930d6b26232e061eaa33ecf6341fae63ce598a0c6a26ee96a0828639c044, reconstructed from log 0x4bc74f3ffe49b4dd275c9f475887b68193e2db8348d72e1c3c9099c2dcfa85b0\).
 `)
 	var te *TCGLogError
 	c.Assert(errors.As(err, &te), testutil.IsTrue)
@@ -2254,7 +2254,7 @@ func (s *runChecksSuite) TestRunChecksBadInvalidPCR7Value(c *C) {
 	c.Check(err, ErrorMatches, `error with TCG log: no suitable PCR algorithm available:
 - TPM_ALG_SHA512: the PCR bank is missing from the TCG log.
 - TPM_ALG_SHA384: the PCR bank is missing from the TCG log.
-- TPM_ALG_SHA256\(PCR7\): PCR value mismatch \(actual from TPM 0xdf7b5d709755f1bd7142dd2f8c2d1195fc6b4dab5c78d41daf5c795da55db5f2, reconstructed from log 0xafc99bd8b298ea9b70d2796cb0ca22fe2b70d784691a1cae2aa3ba55edc365dc\).
+- TPM_ALG_SHA256: error with secure boot policy \(PCR7\) measurements: PCR value mismatch \(actual from TPM 0xdf7b5d709755f1bd7142dd2f8c2d1195fc6b4dab5c78d41daf5c795da55db5f2, reconstructed from log 0xafc99bd8b298ea9b70d2796cb0ca22fe2b70d784691a1cae2aa3ba55edc365dc\).
 `)
 	var te *TCGLogError
 	c.Assert(errors.As(err, &te), testutil.IsTrue)
@@ -2381,9 +2381,9 @@ C7E003CB
 	c.Assert(errors.As(err, &e), testutil.IsTrue)
 
 	// Test that we can access individual errors.
-	c.Check(e.BankErrs[tpm2.HashAlgorithmSHA512], Equals, ErrPCRBankMissingFromLog)
-	c.Check(e.BankErrs[tpm2.HashAlgorithmSHA384], Equals, ErrPCRBankMissingFromLog)
-	c.Check(e.BankErrs[tpm2.HashAlgorithmSHA256], Equals, ErrPCRBankMissingFromLog)
+	c.Check(e.Errs[tpm2.HashAlgorithmSHA512], DeepEquals, []error{ErrPCRBankMissingFromLog})
+	c.Check(e.Errs[tpm2.HashAlgorithmSHA384], DeepEquals, []error{ErrPCRBankMissingFromLog})
+	c.Check(e.Errs[tpm2.HashAlgorithmSHA256], DeepEquals, []error{ErrPCRBankMissingFromLog})
 }
 
 func (s *runChecksSuite) TestRunChecksBadMandatoryPCR1(c *C) {

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -94,6 +94,11 @@ func makeIndentedListItem(indentation int, marker, str string) string {
 // of errors found during the process of running various tests on the platform.
 // It provides a mechanism to access each individual error. This is used as an alternative
 // to aborting early, in order for the caller to gather as much information as possible.
+// Where an error is related to a specific PCR, the error will be wrapped by one of the
+// PCR-specific error types: [PlatformFirmwarePCRError] (0), [PlatformConfigPCRError] (1),
+// [DriversAndAppsPCRError] (2), [DriversAndAppsConfigPCRError] (3),
+// [BootManagerCodePCRError] (4), [BootManagerConfigPCRError] (5), or
+// [SecureBootPolicyPCRError] (7).
 type RunChecksErrors struct {
 	Errs []error // All of the errors collected during the execution of RunChecks.
 }
@@ -373,7 +378,11 @@ func (e *EmptyPCRBanksError) Error() string {
 //     a PCR bank, and which is incompatible with predicting PCR policies.
 //
 // As multiple errors can occur during testing, this error wraps each individual error that
-// occurred and provides access to them.
+// occurred and provides access to them, keyed by the PCR bank. Where an error is related to
+// a specific PCR, the error will be wrapped by one of the PCR-specific error types:
+// [PlatformFirmwarePCRError] (0), [PlatformConfigPCRError] (1), [DriversAndAppsPCRError] (2),
+// [DriversAndAppsConfigPCRError] (3), [BootManagerCodePCRError] (4), [BootManagerConfigPCRError]
+// (5), or [SecureBootPolicyPCRError] (7).
 type NoSuitablePCRAlgorithmError struct {
 	Errs map[tpm2.HashAlgorithmId][]error
 }


### PR DESCRIPTION
NoSuitablePCRAlgorithm error had 2 fields from which to obtain errors -
a field for errors that affect an entire PCR bank, and a field for
errors that affect a single PCR in a bank.

Simplify this by having a single field for all errors, which are stored
in a map that is keyed by the PCR bank. PCR-specific errors are added to
this field wrapped in the relevant PCR-specific error type instead, so
that the PCR-specific errors are returned for any errors affecting a PCR,
regardless of whether that error occurs during or after the bank
selection.