### PR TITLE
preinstall: Move TPM discreteness check

### DIFF
--- a/efi/preinstall/check_fw_protections_intel.go
+++ b/efi/preinstall/check_fw_protections_intel.go
@@ -300,38 +300,6 @@ func checkPlatformFirmwareProtectionsIntelMEI(env internal_efi.HostEnvironment) 
 	return nil
 }
 
-const bootGuardStatusMsr = 0x13a
-
-const (
-	bootGuardStatusTpmMask uint64 = (3 << 1)
-	bootGuardStatusTpmNone uint64 = (0 << 1)
-	bootGuardStatusTpm12   uint64 = (1 << 1)
-	bootGuardStatusTpm2    uint64 = (2 << 1)
-	bootGuardStatusTpmPtt  uint64 = (3 << 1)
-)
-
-func checkIsTpmDiscreteIntel(env internal_efi.HostEnvironmentAMD64) (discreteTPM bool, err error) {
-	bootGuardStatus, err := env.ReadMSRs(bootGuardStatusMsr)
-	if err != nil {
-		return false, fmt.Errorf("failed to read BootGuard status: %w", err)
-	}
-	// NOTE: bootGuardStatus[0] is fine because BootGuard status MSR has the same value across all CPUs
-	switch bootGuardStatus[0] & bootGuardStatusTpmMask {
-	// System has no TPM or unsupported TPM 1.2 device
-	case bootGuardStatusTpmNone, bootGuardStatusTpm12:
-		return false, ErrNoTPM2Device
-	// System has a discrete TPM 2.0 device
-	case bootGuardStatusTpm2:
-		discreteTPM = true
-	// System has a PTT firmware TPM
-	case bootGuardStatusTpmPtt:
-		discreteTPM = false
-	default:
-		panic("executing unreachable code")
-	}
-	return discreteTPM, nil
-}
-
 const (
 	ia32DebugInterfaceMSR = 0xc80
 

--- a/efi/preinstall/check_tpm_amd64.go
+++ b/efi/preinstall/check_tpm_amd64.go
@@ -1,0 +1,53 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"errors"
+	"fmt"
+
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+// isTPMDiscrete determines whether the TPM is discrete
+func isTPMDiscrete(env internal_efi.HostEnvironment) (bool, error) {
+	amd64, err := env.AMD64()
+	if err != nil {
+		return false, err
+	}
+
+	cpuVendor, err := determineCPUVendor(env)
+	if err != nil {
+		return false, &UnsupportedPlatformError{fmt.Errorf("cannot determine CPU vendor: %w", err)}
+	}
+
+	switch cpuVendor {
+	case cpuVendorIntel:
+		discrete, err := isTPMDiscreteFromIntelBootGuard(amd64)
+		if err != nil {
+			return false, fmt.Errorf("cannot check TPM discreteness using Intel BootGuard status: %w", err)
+		}
+		return discrete, nil
+	case cpuVendorAMD:
+		return false, &UnsupportedPlatformError{errors.New("cannot check TPM discreteness on AMD systems")}
+	default:
+		panic("not reached")
+	}
+}

--- a/efi/preinstall/check_tpm_amd64_test.go
+++ b/efi/preinstall/check_tpm_amd64_test.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	"errors"
+
+	. "github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/secboot/internal/efitest"
+	"github.com/snapcore/secboot/internal/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type tpmAmd64Suite struct{}
+
+var _ = Suite(&tpmAmd64Suite{})
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteIntelYes(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}),
+	)
+	discrete, err := IsTPMDiscrete(env)
+	c.Check(err, IsNil)
+	c.Check(discrete, testutil.IsTrue)
+}
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteIntelNo(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}),
+	)
+	discrete, err := IsTPMDiscrete(env)
+	c.Check(err, IsNil)
+	c.Check(discrete, testutil.IsFalse)
+}
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteIntelNoTPM2(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (0 << 1)}),
+	)
+	_, err := IsTPMDiscrete(env)
+	c.Check(err, ErrorMatches, `cannot check TPM discreteness using Intel BootGuard status: no TPM2 device is available`)
+	c.Check(errors.Is(err, ErrNoTPM2Device), testutil.IsTrue)
+}
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteAMDNotSupported(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithAMD64Environment("AuthenticAMD", nil, 1, nil))
+	_, err := IsTPMDiscrete(env)
+	c.Check(err, ErrorMatches, `unsupported platform: cannot check TPM discreteness on AMD systems`)
+
+	var upe *UnsupportedPlatformError
+	c.Check(errors.As(err, &upe), testutil.IsTrue)
+}
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteUnrecognizedCPUVendor(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithAMD64Environment("GenuineInte", nil, 1, nil))
+	_, err := IsTPMDiscrete(env)
+	c.Check(err, ErrorMatches, `unsupported platform: cannot determine CPU vendor: unknown CPU vendor: GenuineInte`)
+
+	var upe *UnsupportedPlatformError
+	c.Check(errors.As(err, &upe), testutil.IsTrue)
+}

--- a/efi/preinstall/check_tpm_intel.go
+++ b/efi/preinstall/check_tpm_intel.go
@@ -1,0 +1,74 @@
+//go:build amd64
+
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"fmt"
+
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+const bootGuardStatusMsr = 0x13a
+
+type bootGuardStatus uint64
+
+const (
+	bootGuardStatusTPMShift                 = 1
+	bootGuardStatusTPMMask  bootGuardStatus = (3 << bootGuardStatusTPMShift)
+)
+
+type bootGuardTPMStatus uint64
+
+const (
+	bootGuardTPMStatusNone bootGuardTPMStatus = 0
+	bootGuardTPMStatus12   bootGuardTPMStatus = 1
+	bootGuardTPMStatus2    bootGuardTPMStatus = 2
+	bootGuardTPMStatusPTT  bootGuardTPMStatus = 3
+)
+
+func (s bootGuardStatus) tpmStatus() bootGuardTPMStatus {
+	return bootGuardTPMStatus(s&bootGuardStatusTPMMask) >> bootGuardStatusTPMShift
+}
+
+func isTPMDiscreteFromIntelBootGuard(env internal_efi.HostEnvironmentAMD64) (bool, error) {
+	msrValue, err := env.ReadMSRs(bootGuardStatusMsr)
+	if err != nil {
+		return false, fmt.Errorf("cannot read BootGuard status MSR: %w", err)
+	}
+
+	status := bootGuardStatus(msrValue[0])
+
+	// NOTE: bootGuardStatus[0] is fine because BootGuard status MSR has the same value across all CPUs
+	switch status.tpmStatus() {
+	case bootGuardTPMStatusNone, bootGuardTPMStatus12:
+		// System has no TPM or unsupported TPM 1.2 device
+		return false, ErrNoTPM2Device
+	case bootGuardTPMStatus2:
+		// System has a discrete TPM 2.0 device
+		return true, nil
+	case bootGuardTPMStatusPTT:
+		// System has a PTT firmware TPM
+		return false, nil
+	default:
+		panic("executing unreachable code")
+	}
+}

--- a/efi/preinstall/check_tpm_intel_test.go
+++ b/efi/preinstall/check_tpm_intel_test.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	. "github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/secboot/internal/efitest"
+	"github.com/snapcore/secboot/internal/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type tpmIntelSuite struct{}
+
+var _ = Suite(&tpmIntelSuite{})
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteFromIntelBootguardTPM2(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}),
+	)
+	amd64, err := env.AMD64()
+	c.Assert(err, IsNil)
+	discrete, err := IsTPMDiscreteFromIntelBootGuard(amd64)
+	c.Check(err, IsNil)
+	c.Check(discrete, testutil.IsTrue)
+}
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteFromIntelBootguardPTT(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}),
+	)
+	amd64, err := env.AMD64()
+	c.Assert(err, IsNil)
+	discrete, err := IsTPMDiscreteFromIntelBootGuard(amd64)
+	c.Check(err, IsNil)
+	c.Check(discrete, testutil.IsFalse)
+}
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteFromIntelBootguardTPM12(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (1 << 1)}),
+	)
+	amd64, err := env.AMD64()
+	c.Assert(err, IsNil)
+	_, err = IsTPMDiscreteFromIntelBootGuard(amd64)
+	c.Check(err, Equals, ErrNoTPM2Device)
+}
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteFromIntelBootguardNoTPM(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (0 << 1)}),
+	)
+	amd64, err := env.AMD64()
+	c.Assert(err, IsNil)
+	_, err = IsTPMDiscreteFromIntelBootGuard(amd64)
+	c.Check(err, Equals, ErrNoTPM2Device)
+}

--- a/efi/preinstall/check_tpm_null.go
+++ b/efi/preinstall/check_tpm_null.go
@@ -1,0 +1,33 @@
+//go:build !amd64
+
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"fmt"
+	"runtime"
+
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+func isTPMDiscrete(env internal_efi.HostEnvironment) (bool, error) {
+	return false, &UnsupportedPlatformError{fmt.Errorf("checking for TPM discreteness is not implemented on %s", runtime.GOARCH)}
+}

--- a/efi/preinstall/check_tpm_test.go
+++ b/efi/preinstall/check_tpm_test.go
@@ -101,9 +101,8 @@ func (s *tpmSuite) SetUpTest(c *C) {
 
 var _ = Suite(&tpmSuite{})
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersDiscreteTPM(c *C) {
-	// Test the good case for pre-install on bare-metal with a discrete TPM and
-	// infinite NV counters.
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCounters(c *C) {
+	// Test the good case for pre-install on bare-metal with infinite NV counters.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     0,
 		tpm2.PropertyPSFamilyIndicator: 1,
@@ -111,43 +110,19 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersD
 	})
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsTrue)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersFWTPM(c *C) {
-	// Test the good case for pre-install on bare-metal with a firmware TPM and infinite
-	// NV counters.
-	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyNVCountersMax:     0,
-		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-	})
-
-	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
-	c.Check(err, IsNil)
-	c.Assert(tpm, NotNil)
-	var tmpl tpm2_testutil.TransportWrapper
-	c.Assert(tpm.Transport(), Implements, &tmpl)
-	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsFalse)
-	c.Check(dev.NumberOpen(), Equals, int(1))
-}
-
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMFiniteCountersDiscreteTPM(c *C) {
-	// Test the good case for pre-install on bare-metal with a discrete TPM, and a
-	// finite but sufficient number of NV counters.
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMFiniteCounters(c *C) {
+	// Test the good case for pre-install on bare-metal with a finite but sufficient
+	// number of NV counters.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     6,
 		tpm2.PropertyNVCounters:        4,
@@ -156,21 +131,19 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMFiniteCountersDis
 	})
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsTrue)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMCountersCheckSkippedDiscreteTPM(c *C) {
-	// Test the good case for post-install on bare-metal with a discrete TPM, and make
-	// sure we skip the NV counter index check.
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMCountersCheckSkipped(c *C) {
+	// Test the good case for post-install on bare-metal, making sure we skip the NV
+	// counter index check.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     6,
 		tpm2.PropertyNVCounters:        5,
@@ -179,21 +152,19 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMCountersCheckSki
 	})
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsTrue)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSkippedDiscreteTPM(c *C) {
-	// Test the good case for post-install on bare-metal with a discrete TPM, and make
-	// sure we skip the hierarchy ownership check.
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSkipped(c *C) {
+	// Test the good case for post-install on bare-metal, making sure we skip the
+	// hierarchy ownership check.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyPSFamilyIndicator: 1,
 		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
@@ -203,21 +174,19 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSk
 	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsTrue)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSkippedDiscreteTPM_2(c *C) {
-	// Test the good case for post-install on bare-metal with a discrete TPM, and make
-	// sure we skip the hierarchy ownership check where we test for hierarchy policies.
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSkipped_2(c *C) {
+	// Test the good case for post-install on bare-metal, making sure we skip the
+	// hierarchy ownership check where we test for hierarchy policies.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyPSFamilyIndicator: 1,
 		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
@@ -227,21 +196,19 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMOwnershipCheckSk
 	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), make([]byte, 32), tpm2.HashAlgorithmSHA256, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsTrue)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMLockoutCheckSkipped(c *C) {
-	// Test the good case for post-install on bare-metal with a firmware TPM, and make
-	// sure we skip the lockout status check.
+	// Test the good case for post-install on bare-metal, making sure we skip the
+	// lockout status check.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     6,
 		tpm2.PropertyNVCounters:        4,
@@ -253,21 +220,18 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMLockoutCheckSkip
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsFalse)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCounters(c *C) {
-	// Test the good case for pre-install on a VM with a swtpm that has
-	// infinite NV counters.
+	// Test the good case for pre-install on a VM with infinite NV counters.
 	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
 		tpm2.PropertyNVCountersMax:     0,
 		tpm2.PropertyPSFamilyIndicator: 1,
@@ -276,13 +240,12 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCounters(c 
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
+	tpm, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsFalse)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
@@ -299,13 +262,12 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCountersWit
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
+	tpm, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
 	c.Check(err, IsNil)
 	c.Assert(tpm, NotNil)
 	var tmpl tpm2_testutil.TransportWrapper
 	c.Assert(tpm.Transport(), Implements, &tmpl)
 	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
-	c.Check(discreteTPM, testutil.IsFalse)
 	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
@@ -387,33 +349,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCountersWit
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceNoTPM(c *C) {
 	// Test the case where there isn't a TPM2 device.
 	env := efitest.NewMockHostEnvironmentWithOpts()
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
-	c.Check(err, Equals, ErrNoTPM2Device)
-}
-
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceBootGuardNoTPM(c *C) {
-	// TPM2 is connected but BootGuard MSR says no TPM
-	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-	})
-	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (0 << 1)}))
-	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
-	c.Check(err, Equals, ErrNoTPM2Device)
-}
-
-func (s *tpmSuite) TestOpenAndCheckTPM2DeviceBootGuardTPM12(c *C) {
-	// TPM2 is connected but BootGuard MSR says device is TPM1.2
-	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
-		tpm2.PropertyPSFamilyIndicator: 1,
-		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
-	})
-	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (1 << 1)}))
-	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	_, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, Equals, ErrNoTPM2Device)
 }
 
@@ -423,7 +359,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceFailureMode(c *C) {
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	_, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, Equals, ErrTPMFailure)
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -451,7 +387,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceWithBackgroundSelfTest(c *C) {
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	_, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `cannot perform partial self test: TPM returned a warning whilst executing command TPM_CC_SelfTest: TPM_RC_TESTING \(TPM is performing self-tests\)`)
 	c.Check(tpm2.IsTPMWarning(err, tpm2.WarningTesting, tpm2.CommandSelfTest), testutil.IsTrue)
 }
@@ -521,7 +457,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClient(c *C) {
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	_, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, Equals, ErrNoPCClientTPM)
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -535,7 +471,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClientWithSWTPMWorkaround(c 
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
+	_, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
 	c.Check(err, Equals, ErrNoPCClientTPM)
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -551,7 +487,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceDisabled(c *C) {
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
-	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	_, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, Equals, ErrTPMDisabled)
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -566,9 +502,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockout(c *C) {
 	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
 - TPM_RH_LOCKOUT has an authorization value
 `)
@@ -583,7 +518,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockout(c *C) {
 	c.Check(e.WithAuthPolicy, HasLen, 0)
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -598,9 +532,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwner(c *C) {
 	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.OwnerHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
 - TPM_RH_OWNER has an authorization value
 `)
@@ -615,7 +548,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwner(c *C) {
 	c.Check(e.WithAuthPolicy, HasLen, 0)
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -630,9 +562,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsement(c *C) {
 	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.EndorsementHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
 - TPM_RH_ENDORSEMENT has an authorization value
 `)
@@ -647,7 +578,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsement(c *C) {
 	c.Check(e.WithAuthPolicy, HasLen, 0)
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -662,9 +592,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockoutWithPolicy(c *C)
 	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.LockoutHandleContext(), testutil.DecodeHexString(c, "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"), tpm2.HashAlgorithmSHA256, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
 - TPM_RH_LOCKOUT has an authorization policy
 `)
@@ -679,7 +608,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockoutWithPolicy(c *C)
 	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleLockout})
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -694,9 +622,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwnerWithPolicy(c *C) {
 	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), testutil.DecodeHexString(c, "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"), tpm2.HashAlgorithmSHA256, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
 - TPM_RH_OWNER has an authorization policy
 `)
@@ -711,7 +638,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwnerWithPolicy(c *C) {
 	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleOwner})
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -726,9 +652,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsementWithPolicy(c
 	c.Assert(s.TPM.SetPrimaryPolicy(s.TPM.EndorsementHandleContext(), testutil.DecodeHexString(c, "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"), tpm2.HashAlgorithmSHA256, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `one or more of the TPM hierarchies is already owned:
 - TPM_RH_ENDORSEMENT has an authorization policy
 `)
@@ -743,7 +668,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsementWithPolicy(c
 	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleEndorsement})
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -758,9 +682,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceLockout(c *C) {
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 
 	var tmpl CompoundError
 	c.Assert(err, Implements, &tmpl)
@@ -769,7 +692,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceLockout(c *C) {
 	c.Check(err.(CompoundError).Unwrap()[0], Equals, ErrTPMLockout)
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -786,9 +708,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceCombinedHierarchyOwnershipAndLockou
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (3 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 	c.Check(err, ErrorMatches, `2 errors detected:
 - one or more of the TPM hierarchies is already owned:
   - TPM_RH_OWNER has an authorization value
@@ -807,7 +728,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceCombinedHierarchyOwnershipAndLockou
 	c.Check(err.(CompoundError).Unwrap()[1], Equals, ErrTPMLockout)
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsFalse)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }
@@ -821,9 +741,8 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceInsufficientNVCountersPreInstall(c 
 	})
 
 	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)
-	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev),
-		efitest.WithAMD64Environment("GenuineIntel", nil, 1, map[uint32]uint64{0x13a: (2 << 1)}))
-	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, err := OpenAndCheckTPM2Device(env, 0)
 
 	var tmpl CompoundError
 	c.Assert(err, Implements, &tmpl)
@@ -832,7 +751,6 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceInsufficientNVCountersPreInstall(c 
 	c.Check(err.(CompoundError).Unwrap()[0], Equals, ErrTPMInsufficientNVCounters)
 
 	c.Check(tpm, NotNil)
-	c.Check(discreteTPM, testutil.IsTrue)
 
 	c.Check(dev.NumberOpen(), Equals, int(0))
 }

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -2540,6 +2540,7 @@ C7E003CB
 			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
 			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
 				Algorithms:       []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				StartupLocality:  3,
 				FirmwareDebugger: true,
 			})),
 			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (2 << 1), 0xc80: 0x40000000}),
@@ -2553,6 +2554,7 @@ C7E003CB
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 		actions:      []actionAndArgs{{action: ActionNone}},
 	})
+	c.Logf("%v", errs)
 	c.Assert(errs, HasLen, 2)
 	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware contains a debugging endpoint enabled`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindUEFIDebuggingEnabled, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -84,6 +84,8 @@ var (
 	DetectVirtualization                                  = detectVirtualization
 	DetermineCPUVendor                                    = determineCPUVendor
 	IsLaunchedFromLoadOption                              = isLaunchedFromLoadOption
+	IsTPMDiscrete                                         = isTPMDiscrete
+	IsTPMDiscreteFromIntelBootGuard                       = isTPMDiscreteFromIntelBootGuard
 	JoinErrors                                            = joinErrors
 	NewX509CertificateID                                  = newX509CertificateID
 	OpenAndCheckTPM2Device                                = openAndCheckTPM2Device

--- a/efi/preinstall/util_amd64.go
+++ b/efi/preinstall/util_amd64.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"fmt"
+
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+type cpuVendor int
+
+const (
+	cpuVendorUnknown cpuVendor = iota
+	cpuVendorIntel
+	cpuVendorAMD
+)
+
+func determineCPUVendor(env internal_efi.HostEnvironment) (cpuVendor, error) {
+	amd64, err := env.AMD64()
+	if err != nil {
+		return cpuVendorUnknown, err
+	}
+
+	switch amd64.CPUVendorIdentificator() {
+	case "GenuineIntel":
+		return cpuVendorIntel, nil
+	case "AuthenticAMD":
+		return cpuVendorAMD, nil
+	default:
+		return cpuVendorUnknown, fmt.Errorf("unknown CPU vendor: %s", amd64.CPUVendorIdentificator())
+	}
+}

--- a/efi/preinstall/util_amd64_test.go
+++ b/efi/preinstall/util_amd64_test.go
@@ -1,0 +1,53 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	. "github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/secboot/internal/efitest"
+	. "gopkg.in/check.v1"
+)
+
+type utilAmd64Suite struct{}
+
+var _ = Suite(&utilAmd64Suite{})
+
+func (s *utilAmd64Suite) TestDetermineCPUVendorIntel(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithAMD64Environment("GenuineIntel", nil, 0, nil))
+
+	vendor, err := DetermineCPUVendor(env)
+	c.Check(err, IsNil)
+	c.Check(vendor, Equals, CpuVendorIntel)
+}
+
+func (s *utilAmd64Suite) TestDetermineCPUVendorAMD(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithAMD64Environment("AuthenticAMD", nil, 0, nil))
+
+	vendor, err := DetermineCPUVendor(env)
+	c.Check(err, IsNil)
+	c.Check(vendor, Equals, CpuVendorAMD)
+}
+
+func (s *utilAmd64Suite) TestDetermineCPUVendorUnknown(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithAMD64Environment("GenuineInte", nil, 0, nil))
+
+	_, err := DetermineCPUVendor(env)
+	c.Check(err, ErrorMatches, `unknown CPU vendor: GenuineInte`)
+}


### PR DESCRIPTION
The TPM discreteness check relies on the BootGuard status MSR on Intel.
Move this check until after the point where we know that BootGuard is
configured properly.