### PR TITLE
preinstall: Fix an issue with the TPM connection being closed prematurely

### DIFF
--- a/efi/preinstall/check_tpm.go
+++ b/efi/preinstall/check_tpm.go
@@ -63,8 +63,8 @@ func openAndCheckTPM2Device(env internal_efi.HostEnvironment, flags checkTPM2Dev
 	}
 	savedTpm := tpm
 	defer func() {
-		// Make sure it gets closed again if we return an error
-		if err == nil {
+		// Make sure it gets closed again if we return an error and no TPM context.
+		if tpm != nil {
 			return
 		}
 		savedTpm.Close()

--- a/efi/preinstall/check_tpm_test.go
+++ b/efi/preinstall/check_tpm_test.go
@@ -518,8 +518,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockout(c *C) {
 	c.Check(e.WithAuthPolicy, HasLen, 0)
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwner(c *C) {
@@ -548,8 +547,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwner(c *C) {
 	c.Check(e.WithAuthPolicy, HasLen, 0)
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsement(c *C) {
@@ -578,8 +576,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsement(c *C) {
 	c.Check(e.WithAuthPolicy, HasLen, 0)
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockoutWithPolicy(c *C) {
@@ -608,8 +605,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedLockoutWithPolicy(c *C)
 	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleLockout})
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwnerWithPolicy(c *C) {
@@ -638,8 +634,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedOwnerWithPolicy(c *C) {
 	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleOwner})
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsementWithPolicy(c *C) {
@@ -668,8 +663,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwnedEndorsementWithPolicy(c
 	c.Check(e.WithAuthPolicy, DeepEquals, tpm2.HandleList{tpm2.HandleEndorsement})
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceLockout(c *C) {
@@ -692,8 +686,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceLockout(c *C) {
 	c.Check(err.(CompoundError).Unwrap()[0], Equals, ErrTPMLockout)
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceCombinedHierarchyOwnershipAndLockout(c *C) {
@@ -728,8 +721,7 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceCombinedHierarchyOwnershipAndLockou
 	c.Check(err.(CompoundError).Unwrap()[1], Equals, ErrTPMLockout)
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }
 
 func (s *tpmSuite) TestOpenAndCheckTPM2DeviceInsufficientNVCountersPreInstall(c *C) {
@@ -751,6 +743,5 @@ func (s *tpmSuite) TestOpenAndCheckTPM2DeviceInsufficientNVCountersPreInstall(c 
 	c.Check(err.(CompoundError).Unwrap()[0], Equals, ErrTPMInsufficientNVCounters)
 
 	c.Check(tpm, NotNil)
-
-	c.Check(dev.NumberOpen(), Equals, int(0))
+	c.Check(dev.NumberOpen(), Equals, int(1))
 }

--- a/efi/preinstall/load_option_util_test.go
+++ b/efi/preinstall/load_option_util_test.go
@@ -172,7 +172,7 @@ func (s *loadOptionUtilSuite) TestIsLaunchedFromLoadOptionGood(c *C) {
 				Device:   0x0},
 			&efi.NVMENamespaceDevicePathNode{
 				NamespaceID:   0x1,
-				NamespaceUUID: 0x0},
+				NamespaceUUID: efi.EUI64{}},
 			&efi.HardDriveDevicePathNode{
 				PartitionNumber: 1,
 				PartitionStart:  0x800,
@@ -200,7 +200,7 @@ func (s *loadOptionUtilSuite) TestIsLaunchedFromLoadOptionGood(c *C) {
 					Device:   0x0},
 				&efi.NVMENamespaceDevicePathNode{
 					NamespaceID:   0x1,
-					NamespaceUUID: 0x0},
+					NamespaceUUID: efi.EUI64{}},
 				&efi.HardDriveDevicePathNode{
 					PartitionNumber: 1,
 					PartitionStart:  0x800,
@@ -249,7 +249,7 @@ func (s *loadOptionUtilSuite) TestIsLaunchedFromLoadOptionGoodShortFormOpt(c *C)
 					Device:   0x0},
 				&efi.NVMENamespaceDevicePathNode{
 					NamespaceID:   0x1,
-					NamespaceUUID: 0x0},
+					NamespaceUUID: efi.EUI64{}},
 				&efi.HardDriveDevicePathNode{
 					PartitionNumber: 1,
 					PartitionStart:  0x800,
@@ -535,7 +535,7 @@ func (s *loadOptionUtilSuite) TestIsLaunchedFromLoadOptionNotActive(c *C) {
 					Device:   0x0},
 				&efi.NVMENamespaceDevicePathNode{
 					NamespaceID:   0x1,
-					NamespaceUUID: 0x0},
+					NamespaceUUID: efi.EUI64{}},
 				&efi.HardDriveDevicePathNode{
 					PartitionNumber: 1,
 					PartitionStart:  0x800,

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.18
 
 require (
 	github.com/canonical/cpuid v0.0.0-20220614022739-219e067757cb
-	github.com/canonical/go-efilib v1.4.1
+	github.com/canonical/go-efilib v1.6.0
 	github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9
 	github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
-	github.com/canonical/go-tpm2 v1.12.2
+	github.com/canonical/go-tpm2 v1.13.0
 	github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981
 	github.com/snapcore/snapd v0.0.0-20220714152900-4a1f4c93fc85
 	golang.org/x/crypto v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/canonical/cpuid v0.0.0-20220614022739-219e067757cb/go.mod h1:6j8Sw3dw
 github.com/canonical/go-efilib v0.0.0-20210909101908-41435fa545d4/go.mod h1:9Sr9kd7IhQPYqaU5nut8Ky97/CtlhHDzQncQnrULgDM=
 github.com/canonical/go-efilib v1.4.1 h1:/VMNCypz+iVmnNuMcsm7WvmDMI1ObkEP2W1h8Ls7OyM=
 github.com/canonical/go-efilib v1.4.1/go.mod h1:n0Ttsy1JuHAvqaFbZBs6PAzoiiJdfkHsAmDOEbexYEQ=
+github.com/canonical/go-efilib v1.6.0 h1:0ZFcIclzoMBl6sAaHrSO98YVPUvKAPfXm6kjofhlHHw=
+github.com/canonical/go-efilib v1.6.0/go.mod h1:n0Ttsy1JuHAvqaFbZBs6PAzoiiJdfkHsAmDOEbexYEQ=
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9 h1:Twk1ZSTWRClfGShP16ePf2JIiayqWS4ix1rkAR6baag=
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9/go.mod h1:IneQ5/yQcfPXrGekEXpR6yeea55ZD24N5+kHzeDseOM=
 github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54 h1:JO3wAsxjrvQDf/X3q4RLIdzDCWrFjzhwUmCKrhnrIO8=
@@ -13,6 +15,8 @@ github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod
 github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61/go.mod h1:vG41hdbBjV4+/fkubTT1ENBBqSkLwLr7mCeW9Y6kpZY=
 github.com/canonical/go-tpm2 v1.12.2 h1:7sWef6xVlWwBAn7hsY+3j62ANzoAO+GZvrltMHXq9RQ=
 github.com/canonical/go-tpm2 v1.12.2/go.mod h1:zK+qESVwu78XyX+NPhiBdN+zwPPDoKk4rYlQ7VUsRp4=
+github.com/canonical/go-tpm2 v1.13.0 h1:Ka9VmUVwoz9pJef5JXP6Gd4CIhxFE70X26K8x3LeGtI=
+github.com/canonical/go-tpm2 v1.13.0/go.mod h1:P50xMwC7y5/uxPikzWdK4d9pW9orKi8+ZL5sBifxoBQ=
 github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2/go.mod h1:QoW2apR2tBl6T/4czdND/EHjL1Ia9cCmQnIj9Xe0Kt8=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981 h1:vrUzSfbhl8mzdXPzjxq4jXZPCCNLv18jy6S7aVTS2tI=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981/go.mod h1:ywdPBqUGkuuiitPpVWCfilf2/gq+frhq4CNiNs9KyHU=

--- a/internal/efi/absolute_test.go
+++ b/internal/efi/absolute_test.go
@@ -91,7 +91,7 @@ func (s *absoluteSuite) TestIsAbsoluteAgentLaunchFalseNotFirmwareVolume(c *C) {
 				&efi.ACPIDevicePathNode{HID: hid, UID: 0},
 				&efi.PCIDevicePathNode{Function: 0, Device: 6},
 				&efi.PCIDevicePathNode{Function: 0, Device: 0},
-				&efi.NVMENamespaceDevicePathNode{NamespaceID: 1, NamespaceUUID: 0},
+				&efi.NVMENamespaceDevicePathNode{NamespaceID: 1, NamespaceUUID: efi.EUI64{}},
 				&efi.HardDriveDevicePathNode{
 					PartitionNumber: 1,
 					PartitionStart:  0x800,

--- a/internal/efitest/log.go
+++ b/internal/efitest/log.go
@@ -425,7 +425,7 @@ func NewLog(c *C, opts *LogOptions) *tcglog.Log {
 					Device:   0x0},
 				&efi.NVMENamespaceDevicePathNode{
 					NamespaceID:   0x1,
-					NamespaceUUID: 0x0},
+					NamespaceUUID: efi.EUI64{}},
 				&efi.HardDriveDevicePathNode{
 					PartitionNumber: 1,
 					PartitionStart:  0x800,
@@ -646,7 +646,7 @@ func NewLog(c *C, opts *LogOptions) *tcglog.Log {
 					Device:   0x0},
 				&efi.NVMENamespaceDevicePathNode{
 					NamespaceID:   0x1,
-					NamespaceUUID: 0x0},
+					NamespaceUUID: efi.EUI64{}},
 				&efi.HardDriveDevicePathNode{
 					PartitionNumber: 1,
 					PartitionStart:  0x800,


### PR DESCRIPTION
This also updates the go-tpm2 version to pull in a fix that would have
meant the existing secboot tests would have caught this bug.