### PR TITLE
efi/preinstall: Add a test that the lockout hierarchy is enabled

### DIFF
--- a/efi/preinstall/error_kinds.go
+++ b/efi/preinstall/error_kinds.go
@@ -88,15 +88,27 @@ const (
 	// set. This will be supplied with a TPM2OwnedHierarchiesError as the argument,
 	// detailing which hierarchies are owned and whether they are owned with an
 	// authorization value or an authorization policy. The TPM2OwnedHierarchiesError
-	// describes the JSON format of the argument.
+	// type describes the JSON format of the argument.
 	ErrorKindTPMHierarchiesOwned ErrorKind = "tpm-hierarchies-owned"
 
 	// ErrorKindTPMDeviceLockout indicates that the TPM's dictionary attack
 	// logic is currently triggered, preventing the use of any DA protected
-	// resources. This will be accompanied with an argument of the type
-	// TPMDeviceLockoutArgs. The TPMDeviceLockoutArgs describes the JSON format
+	// resources. This only applies to DA protected resources other than the
+	// lockout hierarchy. This will be accompanied with an argument of the type
+	// TPMDeviceLockoutArgs. The TPMDeviceLockoutArgs type describes the JSON format
 	// of the argument.
 	ErrorKindTPMDeviceLockout ErrorKind = "tpm-device-lockout"
+
+	// ErrorKindTPMDeviceLockoutLockedOut indicates that the TPM's lockout hierarchy
+	// is currently unavailable because it is locked out. This is not the same as
+	// ErrorKindTPMDeviceLockout. As there is no way to test for this other than
+	// by performing an operation that requires authorizing the lockout hierarchy,
+	// the test for this is only performed once verifying that the lockout hierarchy
+	// has no authorization value set, and then an attempt is made to use the lockout
+	// hierarchy with an empty authorization value. This will be accompanied with an
+	// argument of the type TPMDeviceLockoutRecoveryArg. The TPMDeviceLockoutRecoveryArg
+	// type describes the JSON format of the argument.
+	ErrorKindTPMDeviceLockoutLockedOut ErrorKind = "tpm-device-lockout-locked-out"
 
 	// ErrorKindInsufficientTPMStorage indicates that there isn't sufficient
 	// storage space available to support FDE along with reprovisioning in
@@ -245,7 +257,7 @@ func (a *PCRUnusableArg) UnmarshalJSON(data []byte) error {
 	if !exists {
 		return errors.New("no \"pcr\" field")
 	}
-	*a = (PCRUnusableArg)(pcr)
+	*a = PCRUnusableArg(pcr)
 	return nil
 }
 

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -254,11 +254,28 @@ var (
 	ErrNoTPM2Device = internal_efi.ErrNoTPM2Device
 
 	// ErrTPMLockout is returned wrapped in TPM2DeviceError if the TPM is in DA
-	// lockout mode. This is checked after verifying that the authorization value for
-	// the lockout hierarchy is empty, so it may be easy to clear this as long as the
-	// lockout hierarchy is available. This test only runs during pre-install, and
-	// not if the PostInstall flag is passed to RunChecks.
+	// lockout mode. This only applies to the protection that is provided to DA protected
+	// resources other than the lockout hierarchy. This is checked after verifying that
+	// the authorization value for the lockout hierarchy is empty, so it may be easy to
+	// clear this using the TPM2_DictionaryAttackLockReset command as long as the lockout
+	// hierarchy is available. The alternative is to wait for the lockout to clear, the time
+	// of which depends on the pre-programmed lockoutInterval. This test only runs during
+	// pre-install, and not if the PostInstall flag is passed to RunChecks.
 	ErrTPMLockout = errors.New("TPM is in DA lockout mode")
+
+	// ErrTPMLockoutLockoutOut is returned wrapped in TPM2DeviceError if the TPM's
+	// lockout hierarchy is unavailable because it is locked out. This is not the same as
+	// ErrTPMLockout. As there is no way to test for this other than by attempting an
+	// operation that requires authorization of the lockout hierarchy, this test is only
+	// performed after first verifying that the lockout hierarchy is not protected by an
+	// authorization value. If it isn't, then the test attempts to use the lockout hierarchy
+	// with an empty authorization value in order to clear the DA counter using the
+	// TPM2_DictionaryAttackLockReset command. If this operation fails with TPM_RC_LOCKOUT
+	// then this error will be returned to indicate that the lockout hierarchy is unavailable
+	// due to it being locked out. It will remain locked out for the pre-programmed
+	// lockoutRecovery time, or until the TPM is cleared using the platform hierarchy. This
+	// test only runs during pre-install, and not if the PostInstall flag is passed to RunChecks.
+	ErrTPMLockoutLockedOut = errors.New("TPM's lockout hierarchy is unavailable because it is locked out")
 
 	// ErrTPMInsufficientNVCounters is returned wrapped in TPM2DeviceError if there are
 	// insufficient NV counters available for PCR policy revocation. If this is still

--- a/efi/preinstall/tpm_util_test.go
+++ b/efi/preinstall/tpm_util_test.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/secboot/internal/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type tpmutilSuite struct{}
+
+var _ = Suite(&tpmutilSuite{})
+
+func (*tpmutilSuite) TestDeviceLockoutArgsIsValidTrue(c *C) {
+	args := TPMDeviceLockoutArgs{
+		IntervalDuration: 2 * time.Hour,
+		TotalDuration:    64 * time.Hour,
+	}
+	c.Check(args.IsValid(), testutil.IsTrue)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutArgsIsValidNotMod1False1(c *C) {
+	args := TPMDeviceLockoutArgs{
+		IntervalDuration: (2 * time.Hour) + (15625 * time.Millisecond),
+		TotalDuration:    (64 * time.Hour) + time.Second,
+	}
+	c.Check(args.IsValid(), testutil.IsFalse)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutArgsIsValidNotMod1False2(c *C) {
+	args := TPMDeviceLockoutArgs{
+		IntervalDuration: 2 * time.Hour,
+		TotalDuration:    (64 * time.Hour) + (2 * time.Microsecond),
+	}
+	c.Check(args.IsValid(), testutil.IsFalse)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutArgsIsValidNegativeFalse1(c *C) {
+	args := TPMDeviceLockoutArgs{
+		IntervalDuration: -2 * time.Hour,
+		TotalDuration:    64 * time.Hour,
+	}
+	c.Check(args.IsValid(), testutil.IsFalse)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutRecoveryArgJSON(c *C) {
+	arg := TPMDeviceLockoutRecoveryArg(24 * time.Hour)
+	data, err := json.Marshal(arg)
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, testutil.DecodeHexString(c, "7b226475726174696f6e223a38363430303030303030303030307d"))
+
+	var arg2 TPMDeviceLockoutRecoveryArg
+	c.Check(json.Unmarshal(data, &arg2), IsNil)
+	c.Check(arg2, Equals, arg)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutRecoveryArgDuration(c *C) {
+	arg := TPMDeviceLockoutRecoveryArg(24 * time.Hour)
+	c.Check(arg.Duration(), Equals, 24*time.Hour)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutRecoveryArgLockoutClearsOnTPMStartupClearFalse(c *C) {
+	arg := TPMDeviceLockoutRecoveryArg(24 * time.Hour)
+	c.Check(arg.LockoutClearsOnTPMStartupClear(), testutil.IsFalse)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutRecoveryArgLockoutClearsOnTPMStartupClearTrue(c *C) {
+	var arg TPMDeviceLockoutRecoveryArg
+	c.Check(arg.LockoutClearsOnTPMStartupClear(), testutil.IsTrue)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutRecoveryArgIsValidTrue(c *C) {
+	arg := TPMDeviceLockoutRecoveryArg(24 * time.Hour)
+	c.Check(arg.IsValid(), testutil.IsTrue)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutRecoveryArgIsValidFalse1(c *C) {
+	arg := TPMDeviceLockoutRecoveryArg((24 * time.Hour) + (500 * time.Millisecond))
+	c.Check(arg.IsValid(), testutil.IsFalse)
+}
+
+func (*tpmutilSuite) TestDeviceLockoutRecoveryArgIsValidFalse2(c *C) {
+	arg := TPMDeviceLockoutRecoveryArg(-24 * time.Hour)
+	c.Check(arg.IsValid(), testutil.IsFalse)
+}


### PR DESCRIPTION
There is already a test that the dictionary attack protection hasn't
been triggered, which makes DA protected resources unavailable - this
results in a `ErrTPMLockout` error and a `ErrorKindTPMDeviceLockout` error
kind.

This adds another test that the actual lockout hierarchy is available,
which has its own dictionary attack protection. However, there is no
direct test for this other than to try authenticating the lockout
hierarchy, and only a single failure will trigger a lockout. To do this,
we execute `TPM2_DictionaryAttackLockReset` if the lockout hierarchy has
no authorization value set. If we authorize it with the empty value,
there is no valid reason for authorization to fail. If the TPM returns a
`TPM_RC_LOCKOUT` warning, then we return a separate error for this -
`ErrTPMLockoutLockedOut` - and separate error kind -
`ErrorKindTPMDeviceLockoutLockedOut`, which indicate that the lockout
hierarchy is unavailable. This will remain unavailable until the
pre-programmed `lockoutRecovery` time (we set this to 24 hours) expires
or the TPM is cleared using the platform hierarchy for authorization. There
is no other means to recover from this error.

This fixes https://github.com/canonical/secboot/issues/413