### PR TITLE
efi/preinstall: Provide a way to indicate that a required kernel module is missing

### DIFF
--- a/efi/preinstall/check_host_security_intel.go
+++ b/efi/preinstall/check_host_security_intel.go
@@ -197,7 +197,7 @@ func checkHostSecurityIntelBootGuard(env internal_efi.HostEnvironment) error {
 		return fmt.Errorf("cannot obtain devices with \"mei\" class: %w", err)
 	}
 	if len(devices) == 0 {
-		return fmt.Errorf("no MEI device available")
+		return MissingKernelModuleError("mei_me")
 	}
 	device := devices[0]
 
@@ -316,7 +316,10 @@ func checkHostSecurityIntelCPUDebuggingLocked(env internal_efi.HostEnvironmentAM
 	}
 
 	vals, err := env.ReadMSRs(ia32DebugInterfaceMSR)
-	if err != nil {
+	switch {
+	case errors.Is(err, internal_efi.ErrNoKernelMSRSupport):
+		return MissingKernelModuleError("msr")
+	case err != nil:
 		return fmt.Errorf("cannot read MSRs: %w", err)
 	}
 	if len(vals) == 0 {

--- a/efi/preinstall/check_tpm_intel.go
+++ b/efi/preinstall/check_tpm_intel.go
@@ -22,6 +22,7 @@
 package preinstall
 
 import (
+	"errors"
 	"fmt"
 
 	internal_efi "github.com/snapcore/secboot/internal/efi"
@@ -51,7 +52,10 @@ func (s bootGuardStatus) tpmStatus() bootGuardTPMStatus {
 
 func isTPMDiscreteFromIntelBootGuard(env internal_efi.HostEnvironmentAMD64) (bool, error) {
 	msrValue, err := env.ReadMSRs(bootGuardStatusMsr)
-	if err != nil {
+	switch {
+	case errors.Is(err, internal_efi.ErrNoKernelMSRSupport):
+		return false, MissingKernelModuleError("msr")
+	case err != nil:
 		return false, fmt.Errorf("cannot read BootGuard status MSR: %w", err)
 	}
 

--- a/efi/preinstall/check_tpm_intel_test.go
+++ b/efi/preinstall/check_tpm_intel_test.go
@@ -71,3 +71,14 @@ func (s *tpmIntelSuite) TestIsTPMDiscreteFromIntelBootguardNoTPM(c *C) {
 	_, err = IsTPMDiscreteFromIntelBootGuard(amd64)
 	c.Check(err, Equals, ErrNoTPM2Device)
 }
+
+func (s *tpmIntelSuite) TestIsTPMDiscreteFromIntelBootguardNoMSRSupport(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithAMD64Environment("GenuineIntel", nil, 0, nil),
+	)
+	amd64, err := env.AMD64()
+	c.Assert(err, IsNil)
+	_, err = IsTPMDiscreteFromIntelBootGuard(amd64)
+	c.Check(err, ErrorMatches, `the kernel module "msr" must be loaded`)
+	c.Check(err, Equals, MissingKernelModuleError("msr"))
+}

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -250,6 +250,14 @@ func (c *RunChecksContext) isActionExpected(action Action) bool {
 // [RunChecks] into an [ErrorKind] and associated arguments where applicable
 // (see the documentation for each error kind).
 func (c *RunChecksContext) classifyRunChecksError(err error) (ErrorKind, any, error) {
+	var me MissingKernelModuleError
+	if errors.As(err, &me) {
+		// A missing kernel module is an internal error because it's an
+		// error with the way that the caller is using the API, and not
+		// something that should be directly exposed to some UI.
+		return ErrorKindInternal, nil, nil
+	}
+
 	if errors.Is(err, ErrVirtualMachineDetected) {
 		return ErrorKindRunningInVM, nil, nil
 	}

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto"
 	"encoding/json"
+	"errors"
 	"io"
 	"time"
 
@@ -2738,6 +2739,86 @@ C7E003CB
 
 	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadHostSecurityErrorMissingIntelMEI(c *C) {
+	// Test case where host security checks fail because the intel MEI kernel module is missing.
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with system security: encountered an error when checking Intel BootGuard configuration: the kernel module "mei_me" must be loaded`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindInternal, nil, nil, errs[0].Unwrap()))
+	c.Check(errors.Is(errs[0], MissingKernelModuleError("mei_me")), testutil.IsTrue)
+}
+
+func (s *runChecksContextSuite) TestRunBadHostSecurityErrorMissingMSR(c *C) {
+	// Test case where host security checks fail because the MSR kernel module is missing.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 0, nil),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		actions:      []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with system security: encountered an error when checking Intel CPU debugging configuration: the kernel module "msr" must be loaded`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindInternal, nil, nil, errs[0].Unwrap()))
+	c.Check(errors.Is(errs[0], MissingKernelModuleError("msr")), testutil.IsTrue)
 }
 
 func (s *runChecksContextSuite) TestRunBadHostSecurityError(c *C) {

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -139,6 +139,22 @@ func (e *joinError) Unwrap() []error {
 	return e.errs
 }
 
+// MissingKernelModuleError is returned unwrapped from [RunChecks] to indicate that
+// the specified kernel module is not built as part of the currently executing kernel,
+// but is required to be loaded in order for tests to continue. The caller is expected
+// to load the required kernel module.
+type MissingKernelModuleError string
+
+func (e MissingKernelModuleError) Error() string {
+	return fmt.Sprintf("the kernel module %q must be loaded", string(e))
+}
+
+// String implements [fmt.Stringer] and returns the name of the kernel module that
+// should be loaded before calling [RunChecks].
+func (e MissingKernelModuleError) String() string {
+	return string(e)
+}
+
 var (
 	// ErrVirtualMachineDetected is returned unwrapped from RunChecks when the current
 	// OS is running in a virtual machine and the PermitVirtualMachine flag was not supplied.
@@ -151,7 +167,8 @@ var (
 	ErrVirtualMachineDetected = errors.New("virtual machine environment detected")
 )
 
-// EFIVariableAccessError describes an error that occurred when reading an EFI variable.
+// EFIVariableAccessError describes an error that occurred when reading an EFI variable and
+// is returned unwrapped from [RunChecks].
 type EFIVariableAccessError struct {
 	err error
 }

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -142,16 +142,17 @@ func (e *joinError) Unwrap() []error {
 // MissingKernelModuleError is returned unwrapped from [RunChecks] to indicate that
 // the specified kernel module is not built as part of the currently executing kernel,
 // but is required to be loaded in order for tests to continue. The caller is expected
-// to load the required kernel module.
+// to load the required kernel module, which it can obtain by calling
+// [MissingKernelModuleError.Module].
 type MissingKernelModuleError string
 
 func (e MissingKernelModuleError) Error() string {
 	return fmt.Sprintf("the kernel module %q must be loaded", string(e))
 }
 
-// String implements [fmt.Stringer] and returns the name of the kernel module that
-// should be loaded before calling [RunChecks].
-func (e MissingKernelModuleError) String() string {
+// Module returns the name of the kernel module associated with this error, and
+// which should be loaded before calling [RunChecks].
+func (e MissingKernelModuleError) Module() string {
 	return string(e)
 }
 

--- a/efi/preinstall/errors_test.go
+++ b/efi/preinstall/errors_test.go
@@ -284,3 +284,8 @@ func (s *errorsSuite) TestGetWithKindAndActionsErrorInvalidType2(c *C) {
 	_, err := GetWithKindAndActionsErrorArg[*withKindAndActionsErrorArgs](testErr)
 	c.Assert(err, ErrorMatches, `cannot deserialize argument map from JSON to type \*preinstall_test.withKindAndActionsErrorArgs: json: cannot unmarshal bool into Go struct field withKindAndActionsErrorArgs.arg2 of type int`)
 }
+
+func (s *errorsSuite) TestMissingKernelModuleErrorModule(c *C) {
+	c.Check(MissingKernelModuleError("msr").Module(), Equals, "msr")
+	c.Check(MissingKernelModuleError("mei_me").Module(), Equals, "mei_me")
+}

--- a/internal/efitest/hostenv.go
+++ b/internal/efitest/hostenv.go
@@ -129,9 +129,12 @@ func (e *mockHostEnvironmentAMD64) HasCPUIDFeature(feature uint64) bool {
 }
 
 func (e *mockHostEnvironmentAMD64) ReadMSRs(msr uint32) (map[uint32]uint64, error) {
+	if e.msrs == nil || e.cpus == 0 {
+		return nil, internal_efi.ErrNoKernelMSRSupport
+	}
 	val, exists := e.msrs[msr]
 	if !exists {
-		return nil, errors.New("MSR does not exist")
+		return nil, internal_efi.ErrNoMSRSupport
 	}
 	out := make(map[uint32]uint64)
 	for i := uint32(0); i < e.cpus; i++ {


### PR DESCRIPTION
Some tests rely on kernel APIs that are currently shipped in modules as
opposed to being shipped in the main kernel image. The required modules
may not be loaded in all circumstances.

Whilst I don't think that secboot, as a dependency of snapd, should be directly
loading kernel modules, there needs to be a mechanism to tell snapd which
kernel modules are required in order for the tests to run successfully. The
required kernel modules are an implementation detail of secboot and may be
architecture / platform dependent as well, so snapd shouldn't have a list of
kernel modules to load. Instead, if a feature that requires a kernel module
cannot complete because it appears that the kernel module isn't loaded,
secboot will return a `MissingKernelModuleError` which describes the module
that snapd needs to subsequently load in order for the tests to complete.

As the need to load modules is an implementation detail of the preinstall
checks in general and shouldn't be exposed to the installer, there's no specific
error kind for this - it just gets converted to `ErrorKindInternal` and snapd is
expected to just resolve this without exposing it publicly.

This fixes https://github.com/canonical/secboot/issues/409