### PR TITLE
Add initial StorageContainer abstractions

### DIFF
--- a/container.go
+++ b/container.go
@@ -102,10 +102,14 @@ type StorageContainer interface {
 	BackendName() string
 
 	// Activate unlocks this container with the specified key.
-	// The keyslot info can be supplied so that the backend can
-	// map the supplied key to a specific keyslot. If it is empty,
-	// it will iterate and try all keyslots. The caller can specify
-	// one or more options, which may be backend-specific.
+	// The caller can choose to supply the KeyslotInfo instance
+	// related to the keyslot from which the supplied key is
+	// associated with (obtained from StorageContainerReader.ReadKeyslot).
+	// If supplied, the backend can use this to target the supplied
+	// key at a specific keyslot. If keyslotInfo nil is supplied, the
+	// backend will have to test all keyslots with the supplied key.
+	// The caller can specify one or more options, which may be
+	// backend-specific.
 	Activate(ctx context.Context, keyslotInfo KeyslotInfo, key []byte, opts ...ActivateOption) error
 
 	// Deactivate locks this storage container.

--- a/container.go
+++ b/container.go
@@ -127,8 +127,11 @@ type StorageContainer interface {
 
 // NewStorageContainer creates a new StorageContainer from the specified
 // path, probing each of the registered backends to obtain an appropriate
-// instance. If no StorageContainer is found, a ErrNoStorageContainer error
-// is returned.
+// instance. The path may or may not be a path to a block device, depending
+// on the backends that are registered, because not all backends that may
+// exist in the future will make use of block devices for a storage container.
+//
+// If no StorageContainer is found, a ErrNoStorageContainer error is returned.
 //
 // This is safe to call from multiple goroutines.
 func NewStorageContainer(ctx context.Context, path string) (StorageContainer, error) {

--- a/container.go
+++ b/container.go
@@ -76,6 +76,7 @@ type StorageContainerReader interface {
 	// was opened from.
 	Container() StorageContainer
 
+	// io.Closer is used to close this reader.
 	io.Closer
 
 	// ListKeyslotNames returns a sorted list of keyslot names.

--- a/container.go
+++ b/container.go
@@ -1,0 +1,117 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+)
+
+var (
+	ErrNoStorageContainer = errors.New("no storage container for path")
+)
+
+type ActivateOptionVisitor interface {
+	Add(key, value any)
+}
+
+type ActivateOption interface {
+	ApplyTo(ActivateOptionVisitor)
+}
+
+// KeyslotType describes the type of a keyslot.
+type KeyslotType string
+
+const (
+	KeyslotTypePlatform KeyslotType = "platform"
+	KeyslotTypeRecovery KeyslotType = "recovery"
+)
+
+// KeyslotInfo provides information about a keyslot.
+type KeyslotInfo interface {
+	Type() KeyslotType
+	Name() string
+	Priority() int
+	Data() KeyDataReader
+}
+
+// StorageContainerReader provides a mechanism to perform read-only
+// operations on keyslots on a storage container. The backend should
+// permit as many of these to be opened as required, but should never
+// permit one to be opened at the same time as a [StorageContainerWriter].
+type StorageContainerReader interface {
+	io.Closer
+
+	// ListKeyslotNames returns a sorted list of keyslot names.
+	ListKeyslotNames(ctx context.Context) ([]string, error)
+
+	// ReadKeyslot returns information about the keyslot with
+	// the specified name.
+	ReadKeyslot(ctx context.Context, name string) (KeyslotInfo, error)
+}
+
+// StorageContainer represents some type of storage container that
+// can store keyslots, making the core code in secboot agnostic to
+// the storage backend.
+type StorageContainer interface {
+	Path() string // The path of this storage container.
+
+	// BackendName is the name of the backend that created this
+	// StorageContainer instance.
+	BackendName() string
+
+	// Activate unlocks this container with the specified key.
+	// The keyslot info can be supplied so that the backend can
+	// map the supplied key to a specific keyslot. If it is empty,
+	// it will iterate and try all keyslots. The caller can specify
+	// one or more options, which may be backend-specific.
+	Activate(ctx context.Context, keyslotInfo KeyslotInfo, key []byte, opts ...ActivateOption) error
+
+	// Deactivate locks this storage container.
+	Deactivate(ctx context.Context) error
+
+	// OpenRead opens this storage container in order to perform
+	// operations to keyslots that only require read access. The backend
+	// should permit as many of these to be opened as is requested, but
+	// must not allow a combination of StorageContainerReader and
+	// StorageContainerWriter to be opened (of which there should only
+	// ever be 1 open at a time).
+	OpenRead(ctx context.Context) (StorageContainerReader, error)
+}
+
+// NewStorageContainer creates a new StorageContainer from the specified
+// path, probing each of the registered backends to obtain an appropriate
+// instance. If no StorageContainer is found, a ErrNoStorageContainer error
+// is returned.
+func NewStorageContainer(ctx context.Context, path string) (StorageContainer, error) {
+	for name, backend := range storageContainerHandlers {
+		container, err := backend.Probe(ctx, path)
+		if err != nil {
+			return nil, fmt.Errorf("cannot probe %q backend for path %q: %w", name, path, err)
+		}
+		if container != nil {
+			return container, nil
+		}
+	}
+
+	return nil, ErrNoStorageContainer
+}

--- a/container_test.go
+++ b/container_test.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"context"
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/testutil"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+)
+
+type containerSuite struct {
+	snapd_testutil.BaseTest
+	backend *mockStorageContainerBackend
+}
+
+func (s *containerSuite) SetUpTest(c *C) {
+	s.backend = newMockStorageContainerBackend()
+	RegisterStorageContainerBackend(mockStorageContainerType, s.backend)
+	s.AddCleanup(func() { RegisterStorageContainerBackend(mockStorageContainerType, nil) })
+}
+
+var _ = Suite(&containerSuite{})
+
+func (s *containerSuite) TestNewStorageContainer1(c *C) {
+	expectedContainer := newMockStorageContainer("/dev/sda1")
+	s.backend.addContainer("/dev/sda1", expectedContainer)
+
+	expectedCtx := context.Background()
+
+	container, err := NewStorageContainer(expectedCtx, "/dev/sda1")
+	c.Assert(err, IsNil)
+	c.Assert(container, testutil.ConvertibleTo, &mockStorageContainerWithProbeContext{})
+	c.Check(container.(interface{ probeContext() context.Context }).probeContext(), Equals, expectedCtx)
+	c.Check(container.(*mockStorageContainerWithProbeContext).mockStorageContainer, Equals, expectedContainer)
+}
+
+func (s *containerSuite) TestNewStorageContainer2(c *C) {
+	expectedContainer := newMockStorageContainer("/dev/vdb2")
+	s.backend.addContainer("/dev/vdb2", expectedContainer)
+
+	expectedCtx := context.Background()
+
+	container, err := NewStorageContainer(expectedCtx, "/dev/vdb2")
+	c.Assert(err, IsNil)
+	c.Assert(container, testutil.ConvertibleTo, &mockStorageContainerWithProbeContext{})
+	c.Check(container.(interface{ probeContext() context.Context }).probeContext(), Equals, expectedCtx)
+	c.Check(container.(*mockStorageContainerWithProbeContext).mockStorageContainer, Equals, expectedContainer)
+}
+
+func (s *containerSuite) TestNewStorageContainerNotFound(c *C) {
+	_, err := NewStorageContainer(context.Background(), "/dev/sda1")
+	c.Check(err, Equals, ErrNoStorageContainer)
+}
+
+func (s *containerSuite) TestNewStorageContainerNotFoundWithMultipleBackends(c *C) {
+	RegisterStorageContainerBackend("foo", new(mockStorageContainerBackend))
+	defer RegisterStorageContainerBackend("foo", nil)
+
+	_, err := NewStorageContainer(context.Background(), "/dev/sda1")
+	c.Check(err, Equals, ErrNoStorageContainer)
+}
+
+func (s *containerSuite) TestNewStorageContainerProbeError1(c *C) {
+	expectedErr := errors.New("some error")
+	s.backend.setProbeErr(expectedErr)
+
+	_, err := NewStorageContainer(context.Background(), "/dev/sda1")
+	c.Check(err, ErrorMatches, `cannot probe "mock" backend for path "\/dev\/sda1": some error`)
+	c.Check(errors.Is(err, expectedErr), testutil.IsTrue)
+}
+
+func (s *containerSuite) TestNewStorageContainerProbeError2(c *C) {
+	otherBackend := newMockStorageContainerBackend()
+	expectedErr := errors.New("some error")
+	otherBackend.setProbeErr(expectedErr)
+	RegisterStorageContainerBackend("foo", otherBackend)
+	defer RegisterStorageContainerBackend("foo", nil)
+
+	_, err := NewStorageContainer(context.Background(), "/dev/sdb2")
+	c.Check(err, ErrorMatches, `cannot probe "foo" backend for path "\/dev\/sdb2": some error`)
+	c.Check(errors.Is(err, expectedErr), testutil.IsTrue)
+}

--- a/export_test.go
+++ b/export_test.go
@@ -39,6 +39,7 @@ const (
 var (
 	AcquireArgon2OutOfProcessHandlerSystemLock    = acquireArgon2OutOfProcessHandlerSystemLock
 	ErrArgon2OutOfProcessHandlerSystemLockTimeout = errArgon2OutOfProcessHandlerSystemLockTimeout
+	StorageContainerHandlers                      = storageContainerHandlers
 	UnmarshalV1KeyPayload                         = unmarshalV1KeyPayload
 	UnmarshalProtectedKeys                        = unmarshalProtectedKeys
 )

--- a/keydata.go
+++ b/keydata.go
@@ -478,7 +478,7 @@ func (d *KeyData) derivePassphraseKeys(passphrase string) (key, iv, auth []byte,
 }
 
 func (d *KeyData) updatePassphrase(payload, oldAuthKey []byte, passphrase string, platformContext any) error {
-	handlerInfo, exists := handlers[d.data.PlatformName]
+	handlerInfo, exists := keyDataHandlers[d.data.PlatformName]
 	if !exists {
 		return ErrNoPlatformHandlerRegistered
 	}
@@ -658,7 +658,7 @@ func (d *KeyData) RecoverKeys() (DiskUnlockKey, PrimaryKey, error) {
 		return nil, nil, errors.New("cannot recover key without authorization")
 	}
 
-	handlerInfo, exists := handlers[d.data.PlatformName]
+	handlerInfo, exists := keyDataHandlers[d.data.PlatformName]
 	if !exists {
 		return nil, nil, ErrNoPlatformHandlerRegistered
 	}
@@ -676,7 +676,7 @@ func (d *KeyData) RecoverKeysWithPassphrase(passphrase string) (DiskUnlockKey, P
 		return nil, nil, errors.New("cannot recover key with passphrase")
 	}
 
-	handlerInfo, exists := handlers[d.data.PlatformName]
+	handlerInfo, exists := keyDataHandlers[d.data.PlatformName]
 	if !exists {
 		return nil, nil, ErrNoPlatformHandlerRegistered
 	}

--- a/platform.go
+++ b/platform.go
@@ -140,7 +140,7 @@ type PlatformKeyDataHandler interface {
 	ChangeAuthKey(data *PlatformKeyData, old, new []byte, context any) ([]byte, error)
 }
 
-var handlers = make(map[string]platformKeyDataHandlerInfo)
+var keyDataHandlers = make(map[string]platformKeyDataHandlerInfo)
 
 // RegisterPlatformKeyDataHandler registers a handler for the specified platform name.
 // The platform can also specify a set of feature flags.
@@ -149,11 +149,11 @@ var handlers = make(map[string]platformKeyDataHandlerInfo)
 // if one exists.
 func RegisterPlatformKeyDataHandler(name string, handler PlatformKeyDataHandler, flags PlatformKeyDataHandlerFlags) {
 	if handler == nil {
-		delete(handlers, name)
+		delete(keyDataHandlers, name)
 		return
 	}
 
-	handlers[name] = platformKeyDataHandlerInfo{
+	keyDataHandlers[name] = platformKeyDataHandlerInfo{
 		handler: handler,
 		flags:   flags,
 	}
@@ -165,7 +165,7 @@ func RegisterPlatformKeyDataHandler(name string, handler PlatformKeyDataHandler,
 // If no platform with the specified name is registered, a ErrNoPlatformHandlerRegistered
 // error will be returned.
 func RegisteredPlatformKeyDataHandler(name string) (handler PlatformKeyDataHandler, flags PlatformKeyDataHandlerFlags, err error) {
-	handlerInfo, exists := handlers[name]
+	handlerInfo, exists := keyDataHandlers[name]
 	if !exists {
 		return nil, 0, ErrNoPlatformHandlerRegistered
 	}
@@ -176,7 +176,7 @@ func RegisteredPlatformKeyDataHandler(name string) (handler PlatformKeyDataHandl
 // of the registered PlatformKeyDataHandlers.
 func ListRegisteredKeyDataPlatforms() []string {
 	var platforms []string
-	for k := range handlers {
+	for k := range keyDataHandlers {
 		platforms = append(platforms, k)
 	}
 	sort.Strings(platforms)

--- a/storage.go
+++ b/storage.go
@@ -39,6 +39,10 @@ type StorageContainerBackend interface {
 	// indirect relationship to a storage container.
 	//
 	// Implementations of this must be safe to call from any goroutine.
+	//
+	// The supplied path may or may not be a path to a block device,
+	// depending on how the backend works - there may be backends in the
+	// future that don't use block devices for storage containers.
 	Probe(ctx context.Context, path string) (StorageContainer, error)
 }
 

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"context"
+)
+
+// StorageContainerBackend is an interface used by secboot to communicate
+// with a backend that has support for a specific type of encrypted storage
+// container.
+type StorageContainerBackend interface {
+	// Probe returns a StorageContainer instance for the supplied
+	// path if it can be handled by this backend, else it returns
+	// (nil, nil).
+	Probe(ctx context.Context, path string) (StorageContainer, error)
+}
+
+var storageContainerHandlers = make(map[string]StorageContainerBackend)
+
+// RegisterStorageContainerBackend permits a backend that manages storage containers
+// with keyslots to be registered with and used by this package. Specifying a nil
+// backend will delete the previously registered backend.
+func RegisterStorageContainerBackend(name string, backend StorageContainerBackend) {
+	if backend == nil {
+		delete(storageContainerHandlers, name)
+		return
+	}
+
+	storageContainerHandlers[name] = backend
+}

--- a/storage.go
+++ b/storage.go
@@ -21,6 +21,7 @@ package secboot
 
 import (
 	"context"
+	"sync"
 )
 
 // StorageContainerBackend is an interface used by secboot to communicate
@@ -30,15 +31,37 @@ type StorageContainerBackend interface {
 	// Probe returns a StorageContainer instance for the supplied
 	// path if it can be handled by this backend, else it returns
 	// (nil, nil).
+	//
+	// Implementations should always return the same StorageContainer
+	// instance for the same container referenced by the supplied path -
+	// the implementation should at least handle the cases of symbolic
+	// links and maybe any other cases where the supplied path has some
+	// indirect relationship to a storage container.
+	//
+	// Implementations of this must be safe to call from any goroutine.
 	Probe(ctx context.Context, path string) (StorageContainer, error)
 }
 
-var storageContainerHandlers = make(map[string]StorageContainerBackend)
+var (
+	storageContainerHandlersMu sync.Mutex
+	storageContainerHandlers   = make(map[string]StorageContainerBackend)
+)
 
 // RegisterStorageContainerBackend permits a backend that manages storage containers
 // with keyslots to be registered with and used by this package. Specifying a nil
 // backend will delete the previously registered backend.
+//
+// XXX(chrisccoulson): Should we use a string to identify a backend or use any
+// arbitrary comparable go type instead (in the same way that [context.Context]
+// works)? I think I would prefer this (but perhaps it should be considered as
+// these abstractions evolve). We can't do this for [RegisteredPlatformKeyDataHandler]
+// because the platform name is serialized as a string in the keyslot metadata and has
+// to be decoded later on in order to identify the platform - it's not possible to
+// preserve go types in this case.
 func RegisterStorageContainerBackend(name string, backend StorageContainerBackend) {
+	storageContainerHandlersMu.Lock()
+	defer storageContainerHandlersMu.Unlock()
+
 	if backend == nil {
 		delete(storageContainerHandlers, name)
 		return

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,139 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"context"
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+const mockStorageContainerType = "mock"
+
+type mockStorageContainer struct {
+	path string
+}
+
+func newMockStorageContainer(path string) *mockStorageContainer {
+	return &mockStorageContainer{path: path}
+}
+
+func (c *mockStorageContainer) Path() string {
+	return c.path
+}
+
+func (c *mockStorageContainer) BackendName() string {
+	return mockStorageContainerType
+}
+
+func (c *mockStorageContainer) Activate(ctx context.Context, keyslotInfo KeyslotInfo, key []byte, opts ...ActivateOption) error {
+	return errors.New("not supported")
+}
+
+func (c *mockStorageContainer) Deactivate(ctx context.Context) error {
+	return errors.New("not supported")
+}
+
+func (c *mockStorageContainer) OpenRead(ctx context.Context) (StorageContainerReader, error) {
+	return nil, errors.New("no StorageContainerReader")
+}
+
+type mockStorageContainerWithProbeContext struct {
+	backendProbeCtx context.Context
+	*mockStorageContainer
+}
+
+func (c *mockStorageContainerWithProbeContext) probeContext() context.Context {
+	return c.backendProbeCtx
+}
+
+type mockStorageContainerBackend struct {
+	containers map[string]*mockStorageContainer
+	probeErr   error
+}
+
+func newMockStorageContainerBackend() *mockStorageContainerBackend {
+	return &mockStorageContainerBackend{
+		containers: make(map[string]*mockStorageContainer),
+	}
+}
+
+func (b *mockStorageContainerBackend) addContainer(path string, container *mockStorageContainer) {
+	if container == nil {
+		delete(b.containers, path)
+		return
+	}
+	b.containers[path] = container
+}
+
+func (b *mockStorageContainerBackend) deleteContainer(path string) {
+	delete(b.containers, path)
+}
+
+func (b *mockStorageContainerBackend) setProbeErr(err error) {
+	b.probeErr = err
+}
+
+func (b *mockStorageContainerBackend) clearProbeErr() {
+	b.probeErr = nil
+}
+
+func (b *mockStorageContainerBackend) Probe(ctx context.Context, path string) (StorageContainer, error) {
+	if b.probeErr != nil {
+		return nil, b.probeErr
+	}
+
+	container, exists := b.containers[path]
+	if !exists {
+		return nil, nil
+	}
+	return &mockStorageContainerWithProbeContext{
+		backendProbeCtx:      ctx,
+		mockStorageContainer: container,
+	}, nil
+}
+
+type storageSuite struct{}
+
+func (s *storageSuite) SetUpTest(c *C) {}
+
+var _ = Suite(&storageSuite{})
+
+func (*storageSuite) TestRegisterStorageContainerBackend(c *C) {
+	_, exists := StorageContainerHandlers["foo"]
+	c.Check(exists, testutil.IsFalse)
+
+	expectedBackend := new(mockStorageContainerBackend)
+	RegisterStorageContainerBackend("foo", expectedBackend)
+	defer RegisterStorageContainerBackend("foo", nil)
+
+	backend, exists := StorageContainerHandlers["foo"]
+	c.Assert(exists, testutil.IsTrue)
+	c.Check(backend, Equals, expectedBackend)
+
+	RegisterStorageContainerBackend("foo", nil)
+
+	_, exists = StorageContainerHandlers["foo"]
+	c.Check(exists, testutil.IsFalse)
+}


### PR DESCRIPTION
This adds a new `StorageContainerBackend` interface to permit the core
secboot package to communicate with a registered package that handles
encrypted containers and keyslots (such as luks2) so that future code
in secboot will be agnostic to the type of storage container.

The `StorageContainerBackend` provides a way to probe a backend with a path
so that it can return a `StorageContainer` if appropriate. It also
provides a way to activate and deactivate an encrypted `StorageContainer`.

The `StorageContainer` provides a way to open a `StorageContainerReader`,
permitting code in secboot or outside of secboot to perform read only
operations on keyslots.

Eventually, the `StorageContainer` will provide a way to open a
`StorageContainerReadWriter`, permitting code in secboot or outside to
perform read/write operations to keyslots.

The backend implementation will be responsible for ensuring it is not
possible to have both `StorageContainerReader`s and `StorageContainerReadWriter`s
open at the same time, and that whilst it will be possible to have an
aribtrary number of `StorageContainerReader`s open, there will only ever be
a single `StorageContainerReadWriter` that is permitted to be open.

The next steps after this PR are to:
- Fix the locking in `internal/luks2` to not be "blocking" or
  "non-blocking". All current usage is blocking, so convert it to
  context based cancelation and expiration instead.
- Add a public luks2 package that registers a `StorageContainerBackend`
  implementation on import, and contains implementations of
  `StorageContainer` and `StorageContainerReader`. For now, these will just
  proxy to the existing APIs exported from secboot.
- Add an equivalent of `InitializeLUKS2Container` to the new luks2
  package, which will initially just proxy to the version currently
  exported from secboot.
- Add an initial implementation of the activation API with recovery key
  support (no PIN or passphrase support initially) which will make use
  of the newly implemented interfaces.
- Begin adding state to permit cross-checking of the primary keys during
  unlocking.
- Record unlocking state to the new activation API that can be serialized
  by snap-bootstrap.

Phase 2 tasks:
- Update the `AuthRequestor` interface so that it is possible to request
  a passphrase, PIN and recovery key at the same time via a unified
  interface.
- Add PIN / passphrase support to the new activation API.

Phase 3 tasks (all post spike):
- Add a `StorageContainerReadWriter` interface for adding / deleting /
  renaming keyslots and updating keyslot metadata.
- Add a locking framework into the new luks2 backend to serialize
  opened `StorageContainerReader`s and `StorageContainerReadWriter`s.
- Add an implementation of `StorageContainerReadWriter` to luks2, which for
  now will just proxy to the existing APIs exported from secboot.
- Provide native implementations of the various `StorageContainer`
  interfaces in the luks2 package rather than proxying everything to the
  existing secboot API.
- Merge the internal/luksview package into the new luks2 package.
- Delete the LUKS2 specific parts of the core secboot package's API.
- Replace `secboot.KeyDataReader` with just an `io.Reader`. The concrete
  implementation on the backend side can still contain backend specific
  information, such as luks2 keyslot IDs.