### PR TITLE
Add new public API `TestLUKS2ContainerKey` for testing LUKS2 container keys

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -1030,3 +1030,8 @@ func NameLegacyLUKS2ContainerKey(devicePath string, keyslot int, newName string)
 
 	return nil
 }
+
+// Check if key is valid key for LUKS2 container at devicePath.
+func TestLUKS2ContainerKey(devicePath string, key []byte) bool {
+	return luks2.TestContainerKey(devicePath, key)
+}

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -3114,7 +3114,7 @@ func (s *cryptSuiteUnmockedBase) testInitializeLUKS2Container(c *C, options *Ini
 	c.Check(keyslot.KDF.Iterations, Equals, 1000)
 	c.Check(keyslot.KDF.Hash, Equals, luks2.HashSHA256)
 
-	luks2test.CheckLUKS2Passphrase(c, path, key)
+	c.Check(TestLUKS2ContainerKey(path, key), testutil.IsTrue)
 }
 
 func (s *cryptSuiteUnmocked) TestInitializeLUKS2Container(c *C) {
@@ -3172,8 +3172,8 @@ func (s *cryptSuiteUnmockedBase) testAddLUKS2ContainerUnlockKey(c *C, keyslotNam
 	c.Check(keyslot.KDF.Iterations, Equals, 1000)
 	c.Check(keyslot.KDF.Hash, Equals, luks2.HashSHA256)
 
-	luks2test.CheckLUKS2Passphrase(c, path, newKey)
-	luks2test.CheckLUKS2Passphrase(c, path, key)
+	c.Check(TestLUKS2ContainerKey(path, newKey), testutil.IsTrue)
+	c.Check(TestLUKS2ContainerKey(path, key), testutil.IsTrue)
 }
 
 func (s *cryptSuiteUnmocked) TestAddLUKS2ContainerUnlockKey(c *C) {
@@ -3217,8 +3217,8 @@ func (s *cryptSuiteUnmockedBase) testAddLUKS2ContainerRecoveryKey(c *C, keyslotN
 	c.Check(keyslot.KDF.Iterations, Equals, 600000)
 	c.Check(keyslot.KDF.Hash, Equals, luks2.HashSHA256)
 
-	luks2test.CheckLUKS2Passphrase(c, path, recoveryKey[:])
-	luks2test.CheckLUKS2Passphrase(c, path, key)
+	c.Check(TestLUKS2ContainerKey(path, recoveryKey[:]), testutil.IsTrue)
+	c.Check(TestLUKS2ContainerKey(path, key), testutil.IsTrue)
 }
 
 func (s *cryptSuiteUnmockedExpensive) TestAddLUKS2ContainerRecoveryKey(c *C) {

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -501,3 +501,8 @@ func KillSlot(devicePath string, slot int) error {
 func SetSlotPriority(devicePath string, slot int, priority SlotPriority) error {
 	return cryptsetupCmd(nil, "config", "--priority", priority.String(), "--key-slot", strconv.Itoa(slot), devicePath)
 }
+
+// Check if key is valid key for LUKS2 container at devicePath.
+func TestContainerKey(devicePath string, key []byte) bool {
+	return cryptsetupCmd(bytes.NewReader(key), "open", "--test-passphrase", "--key-file", "-", devicePath) == nil
+}

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -38,6 +38,7 @@ import (
 	. "github.com/snapcore/secboot/internal/luks2"
 	"github.com/snapcore/secboot/internal/luks2/luks2test"
 	"github.com/snapcore/secboot/internal/paths/pathstest"
+	"github.com/snapcore/secboot/internal/testutil"
 )
 
 type cryptsetupSuiteBase struct {
@@ -413,7 +414,7 @@ func (s *cryptsetupSuiteBase) testFormat(c *C, data *testFormatData) {
 	// We used to time this to make sure we are supplying the correct parameters to
 	// cryptsetup, but that was unreliable. For now, we rely on the command line
 	// parameters that were tested earlier, and trust that those are correct.
-	luks2test.CheckLUKS2Passphrase(c, devicePath, data.key)
+	c.Check(TestContainerKey(devicePath, data.key), testutil.IsTrue)
 }
 
 func (s *cryptsetupSuiteExpensive) TestFormatDefaults(c *C) {
@@ -711,7 +712,7 @@ func (s *cryptsetupSuiteBase) testAddKey(c *C, data *testAddKeyData) {
 	// We used to time this to make sure we are supplying the correct parameters to
 	// cryptsetup, but that was unreliable. For now, we rely on the command line
 	// parameters that were tested earlier, and trust that those are correct.
-	luks2test.CheckLUKS2Passphrase(c, devicePath, data.key)
+	c.Check(TestContainerKey(devicePath, data.key), testutil.IsTrue)
 }
 
 func (s *cryptsetupSuiteExpensive) TestAddKeyDefaults(c *C) {
@@ -864,7 +865,7 @@ func (s *cryptsetupSuite) TestAddKeyWithIncorrectExistingKey(c *C) {
 	_, ok := info.Metadata.Keyslots[0]
 	c.Check(ok, Equals, true)
 
-	luks2test.CheckLUKS2Passphrase(c, devicePath, primaryKey)
+	c.Check(TestContainerKey(devicePath, primaryKey), testutil.IsTrue)
 }
 
 type testImportTokenData struct {
@@ -1201,7 +1202,7 @@ func (s *cryptsetupSuite) testKillSlot(c *C, data *testKillSlotData) {
 	_, ok = info.Metadata.Keyslots[data.slotId]
 	c.Check(ok, Equals, false)
 
-	luks2test.CheckLUKS2Passphrase(c, devicePath, data.testKey)
+	c.Check(TestContainerKey(devicePath, data.testKey), testutil.IsTrue)
 }
 
 func (s *cryptsetupSuite) TestKillSlot1(c *C) {
@@ -1240,7 +1241,7 @@ func (s *cryptsetupSuite) TestKillNonExistantSlot(c *C) {
 
 	c.Check(KillSlot(devicePath, 8), ErrorMatches, "cryptsetup failed with: Keyslot 8 is not active.")
 
-	luks2test.CheckLUKS2Passphrase(c, devicePath, key)
+	c.Check(TestContainerKey(devicePath, key), testutil.IsTrue)
 }
 
 type testSetSlotPriorityData struct {

--- a/internal/luks2/luks2test/luks2test.go
+++ b/internal/luks2/luks2test/luks2test.go
@@ -20,7 +20,6 @@
 package luks2test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -54,10 +53,4 @@ func CreateEmptyDiskImage(c *C, sz int) string {
 
 	c.Assert(f.Truncate(int64(sz)*1024*1024), IsNil)
 	return f.Name()
-}
-
-func CheckLUKS2Passphrase(c *C, devicePath string, key []byte) {
-	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", devicePath)
-	cmd.Stdin = bytes.NewReader(key)
-	c.Check(cmd.Run(), IsNil)
 }


### PR DESCRIPTION
Also remove internal API luks2test.CheckLUKS2Passphrase and adjust existing internal users of that API to use the new one.