### PR TITLE
luks2: Add initial LUKS2 StorageContainerBackend

### DIFF
--- a/container.go
+++ b/container.go
@@ -127,18 +127,53 @@ type StorageContainer interface {
 	OpenRead(ctx context.Context) (StorageContainerReader, error)
 }
 
-// NewStorageContainer creates a new StorageContainer from the specified
-// path, probing each of the registered backends to obtain an appropriate
-// instance. The path may or may not be a path to a block device, depending
-// on the backends that are registered, because not all backends that may
-// exist in the future will make use of block devices for a storage container.
+// FindStorageContainer returns a StorageContainer associated with the specified
+// path to a storage container source, probing each of the registered backends
+// to obtain an appropriate instance. The path may or may not be a path to a
+// block device, depending on the backends that are registered, because not all
+// backends that may exist in the future will make use of block devices for a
+// storage container.
+//
+// This will always return the same StorageContainer instance for any path that
+// points to the same storage container source, and will return the same
+// StorageContainer that [FindActivatedStorageContainer] returns when
+// it is supplied with the path of any container that is backed by this one.
 //
 // If no StorageContainer is found, a ErrNoStorageContainer error is returned.
 //
 // This is safe to call from multiple goroutines.
-func NewStorageContainer(ctx context.Context, path string) (StorageContainer, error) {
+func FindStorageContainer(ctx context.Context, path string) (StorageContainer, error) {
 	for name, backend := range storageContainerHandlers {
 		container, err := backend.Probe(ctx, path)
+		if err != nil {
+			return nil, fmt.Errorf("cannot probe %q backend for path %q: %w", name, path, err)
+		}
+		if container != nil {
+			return container, nil
+		}
+	}
+
+	return nil, ErrNoStorageContainer
+}
+
+// FindActivatedStorageContainer returns a StorageContainer associated
+// with the supplied path to some storage that is backed by a source storage
+// container, probing each of the registered backend to obtain an appropriate
+// instance. The path may or may not be a path to a block device, depending on
+// the backends that are registered, because not all backends that may exist in
+// the future will make use of block devices for a storage container.
+//
+// This will always return the same StorageContainer instance for any path that
+// points to the same activated storage container, and will return the same
+// StorageContainer that [FindStorageContainer] returns when it is supplied with
+// a path to the source container.
+//
+// If no StorageContainer is found, a ErrNoStorageContainer error is returned.
+//
+// This is safe to call from multiple goroutines.
+func FindActivatedStorageContainer(ctx context.Context, path string) (StorageContainer, error) {
+	for name, backend := range storageContainerHandlers {
+		container, err := backend.ProbeActivated(ctx, path)
 		if err != nil {
 			return nil, fmt.Errorf("cannot probe %q backend for path %q: %w", name, path, err)
 		}

--- a/container.go
+++ b/container.go
@@ -54,8 +54,8 @@ const (
 	KeyslotTypeRecovery KeyslotType = "recovery"
 )
 
-// KeyslotInfo provides information about a keyslot.
-type KeyslotInfo interface {
+// Keyslot provides information about a keyslot.
+type Keyslot interface {
 	Type() KeyslotType
 	Name() string
 	Priority() int
@@ -85,7 +85,7 @@ type StorageContainerReader interface {
 
 	// ReadKeyslot returns information about the keyslot with
 	// the specified name.
-	ReadKeyslot(ctx context.Context, name string) (KeyslotInfo, error)
+	ReadKeyslot(ctx context.Context, name string) (Keyslot, error)
 }
 
 // StorageContainer represents some type of storage container that
@@ -104,7 +104,7 @@ type StorageContainer interface {
 	BackendName() string
 
 	// Activate unlocks this container with the specified key.
-	// The caller can choose to supply the KeyslotInfo instance
+	// The caller can choose to supply the Keyslot instance
 	// related to the keyslot from which the supplied key is
 	// associated with (obtained from StorageContainerReader.ReadKeyslot).
 	// If supplied, the backend can use this to target the supplied
@@ -112,7 +112,7 @@ type StorageContainer interface {
 	// backend will have to test all keyslots with the supplied key.
 	// The caller can specify one or more options, which may be
 	// backend-specific.
-	Activate(ctx context.Context, keyslotInfo KeyslotInfo, key []byte, opts ...ActivateOption) error
+	Activate(ctx context.Context, ks Keyslot, key []byte, opts ...ActivateOption) error
 
 	// Deactivate locks this storage container.
 	Deactivate(ctx context.Context) error

--- a/container.go
+++ b/container.go
@@ -27,9 +27,10 @@ import (
 )
 
 var (
-	ErrContainerClosed    = errors.New("storage container reader/writer is already closed")
-	ErrKeyslotNotFound    = errors.New("keyslot not found")
-	ErrNoStorageContainer = errors.New("no storage container for path")
+	ErrStorageContainerClosed    = errors.New("storage container reader/writer is already closed")
+	ErrKeyslotNotFound           = errors.New("keyslot not found")
+	ErrStorageContainerNotActive = errors.New("storage container is not active")
+	ErrNoStorageContainer        = errors.New("no storage container for path")
 )
 
 // ActivateOptionVisitor is used for gathering options (using
@@ -73,7 +74,7 @@ type KeyslotInfo interface {
 // [StorageContainerReadWriter].
 type StorageContainerReader interface {
 	// Container returns the StorageContainer that this reader
-	// was opened from.
+	// was opened from. It can return nil once Close is called.
 	Container() StorageContainer
 
 	// io.Closer is used to close this reader.

--- a/keydata.go
+++ b/keydata.go
@@ -733,7 +733,7 @@ func (d *KeyData) WriteAtomic(w KeyDataWriter) error {
 // ReadKeyData reads the key data from the supplied KeyDataReader, returning a
 // new KeyData object.
 //
-// XXX: Eventually this API will take a KeyslotInfo type instead.
+// XXX: Eventually this API will take a Keyslot type instead.
 func ReadKeyData(r KeyDataReader) (*KeyData, error) {
 	d := &KeyData{readableName: r.ReadableName()}
 	dec := json.NewDecoder(r)

--- a/keydata.go
+++ b/keydata.go
@@ -732,6 +732,8 @@ func (d *KeyData) WriteAtomic(w KeyDataWriter) error {
 
 // ReadKeyData reads the key data from the supplied KeyDataReader, returning a
 // new KeyData object.
+//
+// XXX: Eventually this API will take a KeyslotInfo type instead.
 func ReadKeyData(r KeyDataReader) (*KeyData, error) {
 	d := &KeyData{readableName: r.ReadableName()}
 	dec := json.NewDecoder(r)

--- a/luks2/api.go
+++ b/luks2/api.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"context"
+	"io"
+
+	"github.com/snapcore/secboot"
+	internal_luks2 "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luksview"
+)
+
+type luksView interface {
+	TokenByName(name string) (token luksview.NamedToken, id int, inUse bool)
+}
+
+var newLuksView = func(ctx context.Context, path string) (luksView, error) {
+	return luksview.NewView(ctx, path)
+}
+
+type luks2KeyDataReader interface {
+	ReadableName() string
+	KeyslotID() int
+	Priority() int
+	io.Reader
+}
+
+func newLUKS2KeyDataReader(devicePath, name string) (luks2KeyDataReader, error) {
+	return secboot.NewLUKS2KeyDataReader(devicePath, name)
+}
+
+// luks2Api allows the legacy secboot calls to be mocked in unit tests.
+type luks2Api struct {
+	Activate             func(string, string, []byte, int) error
+	Deactivate           func(string) error
+	ListUnlockKeyNames   func(string) ([]string, error)
+	ListRecoveryKeyNames func(string) ([]string, error)
+	NewKeyDataReader     func(string, string) (luks2KeyDataReader, error)
+}
+
+// luks2Ops is a structure of LUKS2 operations that just delegate to the existing
+// LUKS2 specific secboot APIs - eventually this functionality (and that in
+// internal/luksview) will be implemented natively in this package and the
+// existing LUKS2 specific APIs in the core secboot package will be deleted.
+var luks2Ops = &luks2Api{
+	Activate:             internal_luks2.Activate,
+	Deactivate:           internal_luks2.Deactivate,
+	ListUnlockKeyNames:   secboot.ListLUKS2ContainerUnlockKeyNames,
+	ListRecoveryKeyNames: secboot.ListLUKS2ContainerRecoveryKeyNames,
+	NewKeyDataReader:     newLUKS2KeyDataReader,
+}

--- a/luks2/api.go
+++ b/luks2/api.go
@@ -44,6 +44,7 @@ type luks2KeyDataReader interface {
 }
 
 func newLUKS2KeyDataReader(devicePath, name string) (luks2KeyDataReader, error) {
+	// TODO: Don't depend on this function.
 	return secboot.NewLUKS2KeyDataReader(devicePath, name)
 }
 

--- a/luks2/backend.go
+++ b/luks2/backend.go
@@ -113,7 +113,10 @@ func (b *storageContainerBackend) Probe(ctx context.Context, path string) (secbo
 // ProbeActivated implements [secboot.StorageContainerBackend.ProbeActivated].
 //
 // The path can be the path to a DM device that is backed by a LUKS2 container, or
-// a symbolic link to one.
+// a symbolic link to one. Using the supplied path, it will walk up the stack of
+// DM devices until it finds a block device containing a LUKS2 container. It
+// supports nesting of DM devices, although it currently only has support for the
+// crypt and linear targets.
 //
 // It identifies a [StorageContainer] by its device number, and it will always return
 // the same instance for any paths that reference the same container, regardless of

--- a/luks2/backend.go
+++ b/luks2/backend.go
@@ -1,0 +1,147 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/snapcore/secboot"
+	internal_luks2 "github.com/snapcore/secboot/internal/luks2"
+	"golang.org/x/sys/unix"
+)
+
+type probeDepthKeyType struct{}
+
+var (
+	probeDepthKey = probeDepthKeyType{}
+
+	devRoot              = "/dev"
+	filepathEvalSymlinks = filepath.EvalSymlinks
+	osStat               = os.Stat
+	sysfsRoot            = "/sys"
+	unixStat             = unix.Stat
+)
+
+const storageContainerBackendName = "luks2"
+
+type storageContainerBackend struct {
+	// mu is used to protect access to containers so that the
+	// Probe() method is callable safely from multiple goroutines
+	// (eg, it should be safe to call from more than 1 task in snapd).
+	mu         sync.Mutex
+	containers map[uint64]*storageContainerImpl
+}
+
+func newStorageContainerBackend() *storageContainerBackend {
+	return &storageContainerBackend{
+		containers: make(map[uint64]*storageContainerImpl),
+	}
+}
+
+// Probe implements [secboot.StorageContainerBackend.Probe].
+//
+// The path can be the path to the LUKS2 source device, or a symbolic link to it, or it can
+// be a path to an open DM volume that is backed by a LUKS2 storage device - this function
+// will walk the DM tables in this case to find the underlying source device. It identifies
+// a [StorageContainer] by its device number, and so it will always return the same instance
+// for any paths that reference the same container, regardless of what type of path is supplied.
+func (b *storageContainerBackend) Probe(ctx context.Context, path string) (secboot.StorageContainer, error) {
+	// Use the luksview package to test if the supplied path is
+	// a device or file containing a LUKS2 container.
+	_, err := newLuksView(ctx, path)
+	if err != nil {
+		if errors.Is(err, internal_luks2.ErrInvalidMagic) {
+			// We expect this error if the supplied path genuinely doesn't reference
+			// a LUKS2 container. It's possible we were supplied a path to a DM
+			// device, so walk the tree of tables to obtain a source device.
+			sourcePath, err := sourceDeviceFromDMDevice(ctx, path)
+			switch {
+			case errors.Is(err, errNotDMBlockDevice):
+				// Not a DM block device, so ignore this.
+				return nil, nil
+			case errors.Is(err, errUnsupportedTargetType):
+				// Ignore DM block devices with unrecognized target types.
+				return nil, nil
+			case err != nil:
+				// Any other type of error is unexpected, so return this.
+				return nil, fmt.Errorf("cannot obtain source device for dm device %s: %w", path, err)
+			default:
+				// The supplied path is a DM device and we have a source path - try
+				// again to see if we can find a LUKS2 header on the new source path.
+				// Apply a depth limit here to avoid too much recursion. The permitted
+				// depth here should be sufficient for lvm (linear) inside crypt or
+				// the stack of DM devices associated with an in-progress reencrypt.
+				var depth uint
+				if d := ctx.Value(probeDepthKey); d != nil {
+					depth = d.(uint)
+					if depth > 10 {
+						return nil, errors.New("path to dm device that is too deeply nested")
+					}
+				}
+				ctx := context.WithValue(ctx, probeDepthKey, depth+1)
+				return b.Probe(ctx, sourcePath)
+			}
+		}
+
+		// The supplied device begins with what looks like a LUKS2 header,
+		// but the header failed to parse for some reason. Treat the supplied
+		// path as a path to a LUKS2 container and return an error in this
+		// case.
+		return nil, err
+	}
+
+	// The supplied path corresponds to a LUKS2 container. We want to return
+	// a container with a resolved path rather than symbolic links, so do that
+	// now.
+	resolved, err := filepathEvalSymlinks(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve symlink: %w", err)
+	}
+
+	// We map containers by device number so that we can return the same container
+	// if it's probed again, even with a different path. Obtain that here.
+	var st unix.Stat_t
+	if err := unixStat(resolved, &st); err != nil {
+		return nil, &os.PathError{Op: "stat", Path: resolved, Err: err}
+	}
+
+	// Find an existing container or create a new one.
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	container, exists := b.containers[st.Rdev]
+	if !exists {
+		container = &storageContainerImpl{
+			path: resolved,
+			dev:  st.Rdev,
+		}
+		b.containers[st.Rdev] = container
+	}
+
+	return container, nil
+}
+
+func init() {
+	secboot.RegisterStorageContainerBackend(storageContainerBackendName, newStorageContainerBackend())
+}

--- a/luks2/backend_test.go
+++ b/luks2/backend_test.go
@@ -1,0 +1,270 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+
+	internal_luks2 "github.com/snapcore/secboot/internal/luks2"
+	. "github.com/snapcore/secboot/luks2"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+	"golang.org/x/sys/unix"
+	. "gopkg.in/check.v1"
+)
+
+type backendSuite struct {
+	snapd_testutil.BaseTest
+
+	backend *StorageContainerBackend
+
+	probeCtxs []context.Context
+
+	luks2Devices map[string]struct{}
+	newViewErrs  map[string]error
+	dmDevices    map[string]string
+	dmDeviceErrs map[string]error
+	symlinks     map[string]string
+	info         map[string]unix.Stat_t
+}
+
+func (s *backendSuite) SetUpTest(c *C) {
+	s.backend = NewStorageContainerBackend()
+	s.probeCtxs = nil
+
+	s.luks2Devices = make(map[string]struct{})
+	s.newViewErrs = make(map[string]error)
+	restore := MockNewLuksView(func(ctx context.Context, path string) (LuksView, error) {
+		s.probeCtxs = append(s.probeCtxs, ctx)
+
+		target, exists := s.symlinks[path]
+		if exists {
+			path = target
+		}
+
+		err, exists := s.newViewErrs[path]
+		if exists {
+			return nil, err
+		}
+		_, exists = s.luks2Devices[path]
+		if !exists {
+			return nil, fmt.Errorf("error with binary header: %w", internal_luks2.ErrInvalidMagic)
+		}
+		return nil, nil
+	})
+	s.AddCleanup(restore)
+
+	s.dmDevices = make(map[string]string)
+	s.dmDeviceErrs = make(map[string]error)
+	restore = MockSourceDeviceFromDMDevice(func(ctx context.Context, path string) (string, error) {
+		target, exists := s.symlinks[path]
+		if exists {
+			path = target
+		}
+
+		err, exists := s.dmDeviceErrs[path]
+		if exists {
+			return "", err
+		}
+		sourcePath, exists := s.dmDevices[path]
+		if !exists {
+			return "", ErrNotDMBlockDevice
+		}
+		return sourcePath, nil
+	})
+	s.AddCleanup(restore)
+
+	s.symlinks = make(map[string]string)
+	restore = MockFilepathEvalSymlinks(s.symlinks)
+	s.AddCleanup(restore)
+
+	s.info = make(map[string]unix.Stat_t)
+	restore = MockUnixStat(func(path string, st *unix.Stat_t) error {
+		s, exists := s.info[path]
+		if !exists {
+			return syscall.ENOENT
+		}
+		*st = s
+		return nil
+	})
+	s.AddCleanup(restore)
+}
+
+func (s *backendSuite) addLUKS2Device(path string) {
+	s.luks2Devices[path] = struct{}{}
+}
+
+func (s *backendSuite) addNewViewErr(path string, err error) {
+	s.newViewErrs[path] = err
+}
+
+func (s *backendSuite) addDMDevice(dev, source string) {
+	s.dmDevices[dev] = source
+}
+
+func (s *backendSuite) addDMDeviceErr(dev string, err error) {
+	s.dmDeviceErrs[dev] = err
+}
+
+func (s *backendSuite) addSymlink(target, link string) {
+	s.symlinks[link] = target
+}
+
+func (s *backendSuite) addFile(path string, st unix.Stat_t) {
+	s.info[path] = st
+}
+
+var _ = Suite(&backendSuite{})
+
+func (s *backendSuite) TestBackendProbeCryptDevice(c *C) {
+	// Test Probe with the device node for the LUKS2 container.
+	s.addLUKS2Device("/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	ctx := context.Background()
+	container, err := s.backend.Probe(ctx, "/dev/nvme0n1p3")
+	c.Assert(err, IsNil)
+	c.Assert(container, NotNil)
+	c.Check(container.Path(), Equals, "/dev/nvme0n1p3")
+	var tmpl StorageContainer
+	c.Assert(container, Implements, &tmpl)
+	c.Check(container.(StorageContainer).Dev(), Equals, unix.Mkdev(259, 3))
+
+	c.Check(s.probeCtxs, DeepEquals, []context.Context{ctx})
+}
+
+func (s *backendSuite) TestBackendProbeCryptDeviceSymlink(c *C) {
+	// Test Probe with a symlink to the device node for the LUKS2 container.
+	s.addLUKS2Device("/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addSymlink("/dev/nvme0n1p3", "/dev/disk/by-path/pci-0000:00:0e.0-pci-10000:e1:00.0-nvme-1-part3")
+
+	ctx := context.Background()
+	container, err := s.backend.Probe(ctx, "/dev/disk/by-path/pci-0000:00:0e.0-pci-10000:e1:00.0-nvme-1-part3")
+	c.Assert(err, IsNil)
+	c.Assert(container, NotNil)
+	c.Check(container.Path(), Equals, "/dev/nvme0n1p3")
+	var tmpl StorageContainer
+	c.Assert(container, Implements, &tmpl)
+	c.Check(container.(StorageContainer).Dev(), Equals, unix.Mkdev(259, 3))
+
+	c.Check(s.probeCtxs, DeepEquals, []context.Context{ctx})
+}
+
+func (s *backendSuite) TestBackendProbeNoCryptOrDMDevice(c *C) {
+	// Test Probe with a device node that is not a LUKS2 or DM device.
+	ctx := context.Background()
+	container, err := s.backend.Probe(ctx, "/dev/sda1")
+	c.Assert(err, IsNil)
+	c.Assert(container, IsNil)
+
+	c.Check(s.probeCtxs, DeepEquals, []context.Context{ctx})
+}
+
+func (s *backendSuite) TestBackendProbeDMDeviceWithUnrecognizedTarget(c *C) {
+	// Test Probe with a device node that is a DM device with an unrecognized target type
+	s.addDMDeviceErr("/dev/dm-0", ErrUnsupportedTargetType)
+
+	ctx := context.Background()
+	container, err := s.backend.Probe(ctx, "/dev/dm-0")
+	c.Assert(err, IsNil)
+	c.Assert(container, IsNil)
+
+	c.Check(s.probeCtxs, DeepEquals, []context.Context{ctx})
+}
+
+func (s *backendSuite) TestBackendProbeUnexpectedSourceDeviceFromDMDeviceError(c *C) {
+	// Test Probe with a device node that is not a LUKS2 or DM device
+	// and an unexpected error is returned from sourceDeviceFromDMDevice.
+	s.addDMDeviceErr("/dev/dm-1", errors.New("some error"))
+
+	ctx := context.Background()
+	_, err := s.backend.Probe(ctx, "/dev/dm-1")
+	c.Check(err, ErrorMatches, `cannot obtain source device for dm device /dev/dm-1: some error`)
+
+	c.Check(s.probeCtxs, DeepEquals, []context.Context{ctx})
+}
+
+func (s *backendSuite) TestBackendProbeMappedCryptDevice(c *C) {
+	// Test Probe by passing a path to DM device that is backed by
+	// a LUKS2 device.
+	s.addLUKS2Device("/dev/nvme0n1p3")
+	s.addDMDevice("/dev/dm-0", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	ctx := context.Background()
+	container, err := s.backend.Probe(ctx, "/dev/dm-0")
+	c.Assert(err, IsNil)
+	c.Assert(container, NotNil)
+	c.Check(container.Path(), Equals, "/dev/nvme0n1p3")
+	var tmpl StorageContainer
+	c.Assert(container, Implements, &tmpl)
+	c.Check(container.(StorageContainer).Dev(), Equals, unix.Mkdev(259, 3))
+
+	ctx2 := context.WithValue(ctx, ProbeDepthKey, uint(1))
+	c.Check(s.probeCtxs, DeepEquals, []context.Context{ctx, ctx2})
+}
+
+func (s *backendSuite) TestBackendProbeMappedNestedLinearAndCryptDevice(c *C) {
+	// Test Probe by passing a path to DM device that is backed by
+	// a LUKS2 device - in this case, using linear inside a crypt device.
+	s.addLUKS2Device("/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addDMDevice("/dev/dm-0", "/dev/nvme0n1p3")
+	s.addDMDevice("/dev/dm-1", "/dev/dm-0")
+
+	ctx := context.Background()
+	container, err := s.backend.Probe(ctx, "/dev/dm-1")
+	c.Assert(err, IsNil)
+	c.Assert(container, NotNil)
+	c.Check(container.Path(), Equals, "/dev/nvme0n1p3")
+	var tmpl StorageContainer
+	c.Assert(container, Implements, &tmpl)
+	c.Check(container.(StorageContainer).Dev(), Equals, unix.Mkdev(259, 3))
+
+	ctx2 := context.WithValue(ctx, ProbeDepthKey, uint(1))
+	ctx3 := context.WithValue(ctx2, ProbeDepthKey, uint(2))
+	c.Check(s.probeCtxs, DeepEquals, []context.Context{ctx, ctx2, ctx3})
+}
+
+func (s *backendSuite) TestBackendProbeReturnsCachedDevice(c *C) {
+	// Test that Probe always returns the same container for the same
+	// device, regardless of how the container is addressed.
+	s.addLUKS2Device("/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addSymlink("/dev/nvme0n1p3", "/dev/disk/by-path/pci-0000:00:0e.0-pci-10000:e1:00.0-nvme-1-part3")
+	s.addDMDevice("/dev/dm-0", "/dev/nvme0n1p3")
+
+	ctx := context.Background()
+	container, err := s.backend.Probe(ctx, "/dev/nvme0n1p3")
+	c.Assert(err, IsNil)
+	c.Assert(container, NotNil)
+	c.Check(container.Path(), Equals, "/dev/nvme0n1p3")
+
+	container2, err := s.backend.Probe(ctx, "/dev/disk/by-path/pci-0000:00:0e.0-pci-10000:e1:00.0-nvme-1-part3")
+	c.Assert(err, IsNil)
+	c.Check(container2, Equals, container)
+
+	container3, err := s.backend.Probe(ctx, "/dev/dm-0")
+	c.Assert(err, IsNil)
+	c.Check(container3, Equals, container)
+}

--- a/luks2/backend_test.go
+++ b/luks2/backend_test.go
@@ -129,7 +129,7 @@ func (s *backendSuite) addSymlink(target, link string) {
 	s.symlinks[link] = target
 }
 
-func (s *backendSuite) addFile(path string, st unix.Stat_t) {
+func (s *backendSuite) addFileInfo(path string, st unix.Stat_t) {
 	s.info[path] = st
 }
 
@@ -138,7 +138,7 @@ var _ = Suite(&backendSuite{})
 func (s *backendSuite) TestBackendProbeCryptDevice(c *C) {
 	// Test Probe with the device node for the LUKS2 container.
 	s.addLUKS2Device("/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	ctx := context.Background()
 	container, err := s.backend.Probe(ctx, "/dev/nvme0n1p3")
@@ -155,7 +155,7 @@ func (s *backendSuite) TestBackendProbeCryptDevice(c *C) {
 func (s *backendSuite) TestBackendProbeCryptDeviceSymlink(c *C) {
 	// Test Probe with a symlink to the device node for the LUKS2 container.
 	s.addLUKS2Device("/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 	s.addSymlink("/dev/nvme0n1p3", "/dev/disk/by-path/pci-0000:00:0e.0-pci-10000:e1:00.0-nvme-1-part3")
 
 	ctx := context.Background()
@@ -209,7 +209,7 @@ func (s *backendSuite) TestBackendProbeActivatedMappedCryptDevice(c *C) {
 	// a LUKS2 device.
 	s.addLUKS2Device("/dev/nvme0n1p3")
 	s.addDMDevice("/dev/dm-0", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	ctx := context.Background()
 	container, err := s.backend.ProbeActivated(ctx, "/dev/dm-0")
@@ -227,7 +227,7 @@ func (s *backendSuite) TestBackendProbeActivatedMappedNestedLinearAndCryptDevice
 	// Test Probe by passing a path to DM device that is backed by
 	// a LUKS2 device - in this case, using linear inside a crypt device.
 	s.addLUKS2Device("/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 	s.addDMDevice("/dev/dm-0", "/dev/nvme0n1p3")
 	s.addDMDevice("/dev/dm-1", "/dev/dm-0")
 
@@ -247,7 +247,7 @@ func (s *backendSuite) TestBackendProbeReturnsCachedDevice(c *C) {
 	// Test that Probe and ProbeActivated always returns the same container for the same
 	// device, regardless of how the container is addressed.
 	s.addLUKS2Device("/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 	s.addSymlink("/dev/nvme0n1p3", "/dev/disk/by-path/pci-0000:00:0e.0-pci-10000:e1:00.0-nvme-1-part3")
 	s.addDMDevice("/dev/dm-0", "/dev/nvme0n1p3")
 

--- a/luks2/container.go
+++ b/luks2/container.go
@@ -173,7 +173,7 @@ func (c *storageContainerImpl) BackendName() string {
 }
 
 // Activate implements [secboot.StorageContainer.Activate]
-func (c *storageContainerImpl) Activate(ctx context.Context, ki secboot.KeyslotInfo, key []byte, opts ...secboot.ActivateOption) error {
+func (c *storageContainerImpl) Activate(ctx context.Context, ks secboot.Keyslot, key []byte, opts ...secboot.ActivateOption) error {
 	// TODO: Activate should require a temporary read lock (equivalent to OpenRead).
 	optsCtx := make(activateOptions)
 	for _, opt := range opts {
@@ -191,9 +191,9 @@ func (c *storageContainerImpl) Activate(ctx context.Context, ki secboot.KeyslotI
 	}
 
 	slot := luks2.AnySlot
-	if ki != nil {
-		if lki, ok := ki.(KeyslotInfo); ok {
-			slot = lki.KeyslotID()
+	if ks != nil {
+		if lks, ok := ks.(Keyslot); ok {
+			slot = lks.KeyslotID()
 		}
 	}
 

--- a/luks2/container.go
+++ b/luks2/container.go
@@ -85,8 +85,12 @@ func WithVolumeName(name string) secboot.ActivateOption {
 
 // storageContainerImpl is an implementation of [secboot.StorageContainer].
 type storageContainerImpl struct {
+	// path is the canonical path of the device node for this
+	// storage container.
 	path string
-	dev  uint64
+
+	// dev is the unix device number for this storage container.
+	dev uint64
 }
 
 // Dev implements [StorageContainer.Dev].

--- a/luks2/container.go
+++ b/luks2/container.go
@@ -137,7 +137,13 @@ func (c *storageContainerImpl) ActiveVolumeName(ctx context.Context) (string, er
 
 		// We've found a DM volume that is backed by this StorageContainer. Obtain
 		// the name of the volume from sysfs.
-		name, err := os.ReadFile(filepath.Join(sysfsRoot, "devices/virtual/block", filepath.Base(path), "dm/name"))
+
+		// Obtain the device number for the mapper device first.
+		if err := unixStat(path, &st); err != nil {
+			return "", &os.PathError{Op: "stat", Path: path, Err: err}
+		}
+
+		name, err := os.ReadFile(filepath.Join(sysfsRoot, "dev/block", fmt.Sprintf("%d:%d", unix.Major(st.Rdev), unix.Minor(st.Rdev)), "dm/name"))
 		if err != nil {
 			return "", fmt.Errorf("cannot read volume name for %s: %w", path, err)
 		}

--- a/luks2/container.go
+++ b/luks2/container.go
@@ -1,0 +1,225 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/luks2"
+	"golang.org/x/sys/unix"
+)
+
+// StorageContainer represents a LUKS2 storage container.
+type StorageContainer interface {
+	secboot.StorageContainer
+
+	// Dev returns the device number for the LUKS2 storage container.
+	// The major and minor components of this can be accessed with
+	// unix.Major and unix.Minor.
+	Dev() uint64
+
+	// ActiveVolumeName returns the associated volume name if this
+	// StorageContainer is active. If it isn't active, it is
+	// expected to return a secboot.ErrStorageContainerNotActive
+	// error.
+	ActiveVolumeName(ctx context.Context) (string, error)
+
+	// TODO: Add LUKS2 UUID / label accessors here as well.
+}
+
+type activateOptionKey string
+
+const (
+	volumeNameKey activateOptionKey = "volume-name"
+)
+
+type activateOptions map[any]any
+
+func (o activateOptions) Add(key, value any) {
+	o[key] = value
+}
+
+type volumeNameOption string
+
+func (o volumeNameOption) ApplyTo(visitor secboot.ActivateOptionVisitor) {
+	if _, ok := visitor.(activateOptions); !ok {
+		panic("WithVolumeName can only be used for the luks2 backend")
+	}
+	visitor.Add(volumeNameKey, string(o))
+}
+
+// WithVolumeName is used to specify the volume name used to create the
+// DM device when unlocking a LUKS2 container.
+//
+// XXX: It is mandatory for now for any [StorageContainer] managed by this
+// package. A future revision will relax this requirement and support a
+// mode where the volume name is created automatically, perhaps based on
+// the UUID of the LUKS2 container. An automatically generated volume name
+// can be retrieved afterwards using [StorageContainer.ActiveVolumeName].
+func WithVolumeName(name string) secboot.ActivateOption {
+	return volumeNameOption(name)
+}
+
+// storageContainerImpl is an implementation of [secboot.StorageContainer].
+type storageContainerImpl struct {
+	path string
+	dev  uint64
+}
+
+// Dev implements [StorageContainer.Dev].
+func (c *storageContainerImpl) Dev() uint64 {
+	return c.dev
+}
+
+// ActiveVolumeName implements [StorageContainer.ActiveVolumeName].
+func (c *storageContainerImpl) ActiveVolumeName(ctx context.Context) (string, error) {
+	// To determine if this container is associated with an active volume,
+	// and in order to obtain the volume name, we need to iterate over
+	// the existing device mapper volumes to find any that are backed by
+	// this storage container.
+	dmDevices, err := filepath.Glob(filepath.Join(devRoot, "dm-*"))
+	if err != nil {
+		return "", fmt.Errorf("cannot build list of active dm devices: %w", err)
+	}
+
+	// Iterate over the list of active DM volumes.
+	for _, path := range dmDevices {
+		// Obtain a source device path from this DM volume path.
+		sourcePath, err := sourceDeviceFromDMDevice(ctx, path)
+		if err == errUnsupportedTargetType {
+			// The table for this DM volume has a target type that we
+			// don't recognize, so ignore it.
+			continue
+		}
+		if err != nil {
+			// We don't expect any other error here.
+			return "", fmt.Errorf("cannot obtain source device path for dm volume %s: %w", path, err)
+		}
+
+		// We have a source block device path for this DM volume. Is it this StorageContainer?
+		var st unix.Stat_t
+		if err := unixStat(sourcePath, &st); err != nil {
+			return "", &os.PathError{Op: "stat", Path: sourcePath, Err: err}
+		}
+		if st.Rdev != c.dev {
+			// The source path for this DM volume is not related to this container
+			// because they have different device numbers, so continue and try the
+			// next DM volume.
+			continue
+		}
+
+		// We've found a DM volume that is backed by this StorageContainer. Obtain
+		// the name of the volume from sysfs.
+		name, err := os.ReadFile(filepath.Join(sysfsRoot, "devices/virtual/block", filepath.Base(path), "dm/name"))
+		if err != nil {
+			return "", fmt.Errorf("cannot read volume name for %s: %w", path, err)
+		}
+		volumeName := strings.TrimRight(string(name), "\n") // The kernel adds a newline
+		if volumeName == "" {
+			// This should never happen as it's an invalid name, but, just in case...
+			return "", fmt.Errorf("invalid empty volume name for %s", path)
+		}
+
+		// There should only ever be one DM volume backed by this storage container,
+		// and this is enforced by libcryptsetup, so return the first one we find.
+		return volumeName, nil
+	}
+
+	// There are no active DM volumes that are backed by this storage container.
+	return "", secboot.ErrStorageContainerNotActive
+}
+
+// Path implements [secboot.StorageContainer.Path]
+func (c *storageContainerImpl) Path() string {
+	return c.path
+}
+
+// BackendName implements [secboot.StorageContainer.BackendName]
+func (c *storageContainerImpl) BackendName() string {
+	return storageContainerBackendName
+}
+
+// Activate implements [secboot.StorageContainer.Activate]
+func (c *storageContainerImpl) Activate(ctx context.Context, ki secboot.KeyslotInfo, key []byte, opts ...secboot.ActivateOption) error {
+	// TODO: Activate should require a temporary read lock (equivalent to OpenRead).
+	optsCtx := make(activateOptions)
+	for _, opt := range opts {
+		opt.ApplyTo(optsCtx)
+	}
+
+	vn, exists := optsCtx[volumeNameKey]
+	if !exists {
+		// TODO: Relax this requirement and autogenerate a volume name.
+		return errors.New("missing WithVolumeName option for LUKS2 container")
+	}
+	volumeName, ok := vn.(string)
+	if !ok {
+		return errors.New("invalid volume name")
+	}
+
+	slot := luks2.AnySlot
+	if ki != nil {
+		lki, ok := ki.(*keyslotInfoImpl)
+		if !ok {
+			return errors.New("invalid keyslotInfo type")
+		}
+		slot = lki.keyslotId
+	}
+
+	if err := luks2Ops.Activate(volumeName, c.path, key, slot); err != nil {
+		return fmt.Errorf("cannot activate container %s with volume name %q: %w", c.path, volumeName, err)
+	}
+	return nil
+}
+
+// Deactivate implements [secboot.StorageContainer.Deactivate]
+func (c *storageContainerImpl) Deactivate(ctx context.Context) error {
+	// TODO: Deactivate should require a temporary read lock (equivalent to OpenRead).
+
+	// The StorageContainer only references the LUKS2 source device path
+	// and source device number. We need the volume name in order to
+	// deactivate it.
+	volumeName, err := c.ActiveVolumeName(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot obtain volume name: %w", err)
+	}
+
+	if err := luks2Ops.Deactivate(volumeName); err != nil {
+		return fmt.Errorf("cannot deactivate volume %q: %w", volumeName, err)
+	}
+
+	return nil
+}
+
+// OpenRead implements [secboot.StorageContainer.OpenRead]
+func (c *storageContainerImpl) OpenRead(ctx context.Context) (secboot.StorageContainerReader, error) {
+	// TODO: Implment locking here, especially when we have the OpenReadWriter API. The locking
+	// must prevent any readers being opened if a read/writer is open, and it must prevent more
+	// than one read/writer being open at a time. Multiple readers can be open in parallel.
+	return &storageContainerReader{
+		impl: &storageContainerReadWriterImpl{container: c},
+	}, nil
+}

--- a/luks2/container.go
+++ b/luks2/container.go
@@ -192,8 +192,8 @@ func (c *storageContainerImpl) Activate(ctx context.Context, ki secboot.KeyslotI
 
 	slot := luks2.AnySlot
 	if ki != nil {
-		if lki, ok := ki.(*keyslotInfoImpl); ok {
-			slot = lki.keyslotId
+		if lki, ok := ki.(KeyslotInfo); ok {
+			slot = lki.KeyslotID()
 		}
 	}
 

--- a/luks2/container.go
+++ b/luks2/container.go
@@ -182,11 +182,9 @@ func (c *storageContainerImpl) Activate(ctx context.Context, ki secboot.KeyslotI
 
 	slot := luks2.AnySlot
 	if ki != nil {
-		lki, ok := ki.(*keyslotInfoImpl)
-		if !ok {
-			return errors.New("invalid keyslotInfo type")
+		if lki, ok := ki.(*keyslotInfoImpl); ok {
+			slot = lki.keyslotId
 		}
-		slot = lki.keyslotId
 	}
 
 	if err := luks2Ops.Activate(volumeName, c.path, key, slot); err != nil {

--- a/luks2/container_test.go
+++ b/luks2/container_test.go
@@ -150,7 +150,7 @@ func (s *containerSuite) addDMDevice(c *C, num int, volumeName, sourceDevicePath
 	c.Assert(os.WriteFile(filepath.Join(dir, "name"), []byte(volumeName+"\n"), 0644), IsNil)
 }
 
-func (s *containerSuite) addFile(path string, st unix.Stat_t) {
+func (s *containerSuite) addFileInfo(path string, st unix.Stat_t) {
 	s.info[path] = st
 }
 
@@ -303,7 +303,7 @@ func (s *containerSuite) TestContainerActivateError(c *C) {
 func (s *containerSuite) TestContainerActiveVolumeName(c *C) {
 	// Test that StorageContainer.ActiveVolumeName works.
 	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	name, err := container.ActiveVolumeName(context.Background())
@@ -315,7 +315,7 @@ func (s *containerSuite) TestContainerActiveVolumeNameDifferentName(c *C) {
 	// Test that StorageContainer.ActiveVolumeName works with
 	// a different volume name.
 	s.addDMDevice(c, 0, "save", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	name, err := container.ActiveVolumeName(context.Background())
@@ -327,7 +327,7 @@ func (s *containerSuite) TestContainerActiveVolumeNameDifferentDMDevice(c *C) {
 	// Test that StorageContainer.ActiveVolumeName works with
 	// a different DM volume path
 	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	name, err := container.ActiveVolumeName(context.Background())
@@ -339,8 +339,8 @@ func (s *containerSuite) TestContainerActiveVolumeNameIgnoreUnrelatedDMDevice1(c
 	// Test that StorageContainer.ActivateVolumeName ignores unrelated DM volumes.
 	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
 	s.addDMDevice(c, 1, "bar", "/dev/sda1")
-	s.addFile("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	name, err := container.ActiveVolumeName(context.Background())
@@ -352,8 +352,8 @@ func (s *containerSuite) TestContainerActiveVolumeNameIgnoreUnrelatedDMDevices2(
 	// Test that StorageContainer.ActivateVolumeName ignores unrelated DM volumes.
 	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
 	s.addDMDevice(c, 1, "bar", "/dev/sda1")
-	s.addFile("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
 	name, err := container.ActiveVolumeName(context.Background())
@@ -366,7 +366,7 @@ func (s *containerSuite) TestContainerActiveVolumeNameSourceDeviceforDMDeviceUne
 	// if sourceDeviceForDMDevice returns an unexpected error.
 	s.addDMDeviceErr(c, 0, errors.New("some error"))
 	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	_, err := container.ActiveVolumeName(context.Background())
@@ -378,7 +378,7 @@ func (s *containerSuite) TestContainerActiveVolumeNameSourceDeviceforDMDeviceUns
 	// that indicate an unrecognized target type.
 	s.addDMDeviceErr(c, 0, ErrUnsupportedTargetType)
 	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	name, err := container.ActiveVolumeName(context.Background())
@@ -390,7 +390,7 @@ func (s *containerSuite) TestContainerActiveVolumeNameInactive(c *C) {
 	// Test that StorageContainer.ActiveVolumeName returns an appropriate
 	// error if it isn't active.
 	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
 	_, err := container.ActiveVolumeName(context.Background())
@@ -400,7 +400,7 @@ func (s *containerSuite) TestContainerActiveVolumeNameInactive(c *C) {
 func (s *containerSuite) TestContainerDeactivate(c *C) {
 	// Test that StorageContainer.Deactivate works.
 	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	c.Check(container.Deactivate(context.Background()), IsNil)
@@ -412,7 +412,7 @@ func (s *containerSuite) TestContainerDeactivate(c *C) {
 func (s *containerSuite) TestContainerDeactivateDifferentVolumeName(c *C) {
 	// Test that StorageContainer.Deactivate works with a different volume name
 	s.addDMDevice(c, 0, "save", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	c.Check(container.Deactivate(context.Background()), IsNil)
@@ -426,9 +426,9 @@ func (s *containerSuite) TestContainerDeactivateNoActiveDevice(c *C) {
 	// if there is nothing to deactivate.
 	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
 	s.addDMDevice(c, 1, "bar", "/dev/sda1")
-	s.addFile("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
-	s.addFile("/dev/nvme0n1p2", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 2)})
+	s.addFileInfo("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p2", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 2)})
 
 	container := NewStorageContainer("/dev/nvme0n1p2", unix.Mkdev(259, 2))
 	err := container.Deactivate(context.Background())
@@ -442,7 +442,7 @@ func (s *containerSuite) TestContainerDeactivateActiveVolumeNameErr(c *C) {
 	// error if ActiveVolumeName fails.
 	s.addDMDeviceErr(c, 0, errors.New("some error"))
 	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	c.Check(container.Deactivate(context.Background()), ErrorMatches, `cannot obtain volume name: cannot obtain source device path for dm volume /.*/dm-0: some error`)
@@ -451,7 +451,7 @@ func (s *containerSuite) TestContainerDeactivateActiveVolumeNameErr(c *C) {
 
 func (s *containerSuite) TestContainerDeactivateErr(c *C) {
 	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
-	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFileInfo("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
 	s.deactivateErr = errors.New("some error")
 
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))

--- a/luks2/container_test.go
+++ b/luks2/container_test.go
@@ -1,0 +1,450 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/snapcore/secboot"
+	internal_luks2 "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/testutil"
+	. "github.com/snapcore/secboot/luks2"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+	"golang.org/x/sys/unix"
+	. "gopkg.in/check.v1"
+)
+
+type mockKeyslotData struct {
+	slot int
+}
+
+func (d *mockKeyslotData) ReadableName() string { return "" }
+
+func (d *mockKeyslotData) KeyslotID() int {
+	return d.slot
+}
+
+func (d *mockKeyslotData) Priority() int              { return 0 }
+func (d *mockKeyslotData) Read(p []byte) (int, error) { return 0, io.EOF }
+
+type containerSuite struct {
+	snapd_testutil.BaseTest
+
+	sysfsRoot    string
+	devRoot      string
+	dmDeviceErrs map[string]error
+	dmDevices    map[string]string
+	info         map[string]unix.Stat_t
+
+	commands []string
+
+	activateErr   error
+	deactivateErr error
+}
+
+func (s *containerSuite) SetUpTest(c *C) {
+	restore := MockLUKS2Ops(&Luks2Api{
+		Activate:   s.activate,
+		Deactivate: s.deactivate,
+	})
+	s.AddCleanup(restore)
+
+	s.sysfsRoot = c.MkDir()
+	restore = MockSysfsRoot(s.sysfsRoot)
+	s.AddCleanup(restore)
+
+	s.devRoot = c.MkDir()
+	restore = MockDevRoot(s.devRoot)
+	s.AddCleanup(restore)
+
+	s.dmDeviceErrs = make(map[string]error)
+	s.dmDevices = make(map[string]string)
+	restore = MockSourceDeviceFromDMDevice(func(ctx context.Context, path string) (string, error) {
+		err, exists := s.dmDeviceErrs[path]
+		if exists {
+			return "", err
+		}
+		sourcePath, exists := s.dmDevices[path]
+		if !exists {
+			return "", ErrNotDMBlockDevice
+		}
+		return sourcePath, nil
+	})
+	s.AddCleanup(restore)
+
+	s.info = make(map[string]unix.Stat_t)
+	restore = MockUnixStat(func(path string, st *unix.Stat_t) error {
+		s, exists := s.info[path]
+		if !exists {
+			return syscall.ENOENT
+		}
+		*st = s
+		return nil
+	})
+	s.AddCleanup(restore)
+
+	s.commands = nil
+
+	s.activateErr = nil
+	s.deactivateErr = nil
+}
+
+func (s *containerSuite) activate(volumeName, sourceDevicePath string, key []byte, slot int) error {
+	s.commands = append(s.commands, fmt.Sprintf("Activate(%s,%s,%x,%d)", volumeName, sourceDevicePath, key, slot))
+	return s.activateErr
+}
+
+func (s *containerSuite) deactivate(volumeName string) error {
+	s.commands = append(s.commands, fmt.Sprintf("Deactivate(%s)", volumeName))
+	return s.deactivateErr
+}
+
+func (s *containerSuite) addDMDeviceErr(c *C, num int, e error) {
+	// Create the DM volume device node
+	path := filepath.Join(s.devRoot, fmt.Sprintf("dm-%d", num))
+	f, err := os.Create(path)
+	c.Assert(err, IsNil)
+	c.Assert(f.Close(), IsNil)
+
+	s.dmDeviceErrs[path] = e
+}
+
+func (s *containerSuite) addDMDevice(c *C, num int, volumeName, sourceDevicePath string) {
+	// Create the DM volume device node
+	path := filepath.Join(s.devRoot, fmt.Sprintf("dm-%d", num))
+	f, err := os.Create(path)
+	c.Assert(err, IsNil)
+	c.Assert(f.Close(), IsNil)
+
+	// Create a mapping of the DM volume node to the source device.
+	s.dmDevices[path] = sourceDevicePath
+
+	// Create a unix.Stat_t for the DM volume.
+	//s.info[path] = unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, num)}
+
+	// Create a mapping of DM volume to volume name in sysfs
+	dir := filepath.Join(s.sysfsRoot, "devices/virtual/block", fmt.Sprintf("dm-%d", num), "dm")
+	c.Assert(os.MkdirAll(dir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "name"), []byte(volumeName+"\n"), 0644), IsNil)
+}
+
+func (s *containerSuite) addFile(path string, st unix.Stat_t) {
+	s.info[path] = st
+}
+
+var _ = Suite(&containerSuite{})
+
+func (s *containerSuite) TestContainerOpenRead(c *C) {
+	// Test that OpenRead returns a StorageContainerReader
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+	c.Check(r, testutil.ConvertibleTo, &StorageContainerReader{})
+}
+
+func (s *containerSuite) TestContainerOpenReadReturnsDifferentReaders(c *C) {
+	// Test that OpenRead returns a new StorageContainerReader for
+	// each call.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	r1, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+	c.Assert(r1, NotNil)
+
+	r2, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+	c.Check(r2, Not(Equals), r1)
+}
+
+func (s *containerSuite) TestContainerDev1(c *C) {
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	c.Check(container.Dev(), Equals, unix.Mkdev(259, 3))
+}
+
+func (s *containerSuite) TestContainerDev2(c *C) {
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	c.Check(container.Dev(), Equals, unix.Mkdev(8, 1))
+}
+
+func (s *containerSuite) TestContainerActivatePlatform(c *C) {
+	// Test the StorageContainer.Activate implementation.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
+	})
+}
+
+func (s *containerSuite) TestContainerActivatePlatformDifferentPath(c *C) {
+	// Test the StorageContainer.Activate implementation with a
+	// different device path.
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/sda1,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
+	})
+}
+
+func (s *containerSuite) TestContainerActivatePlatformDifferentVolume(c *C) {
+	// Test the StorageContainer.Activate implementation with a
+	// different volume name.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("save"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(save,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
+	})
+}
+
+func (s *containerSuite) TestContainerActivatePlatformDifferentKey(c *C) {
+	// Test the StorageContainer.Activate implementation with a different key.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "dcb4b6cfc0d9671e096a149f172978c587e9d7a0c7c1436e87fc45db9715777e")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/nvme0n1p3,dcb4b6cfc0d9671e096a149f172978c587e9d7a0c7c1436e87fc45db9715777e,2)",
+	})
+}
+
+func (s *containerSuite) TestContainerActivatePlatformDifferentKeyslot(c *C) {
+	// Test the StorageContainer.Activate implementation with a different LUKS2 keyslot ID.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 1, 0, nil), key, WithVolumeName("data"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,1)",
+	})
+}
+
+func (s *containerSuite) TestContainerActivatePlatformNoKeyslotInfo(c *C) {
+	// Test the StorageContainer.Activate implementation with a nil KeyslotInfo.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	err := container.Activate(context.Background(), nil, key, WithVolumeName("data"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,-1)",
+	})
+}
+
+func (s *containerSuite) TestContainerActivateRecovery(c *C) {
+	// Test the StorageContainer.Activate implementation with a recovery keyslot type.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "4e4dcf55c272e78b5141f43d76b6beb3")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypeRecovery, "foo", internal_luks2.AnySlot, 0, nil), key, WithVolumeName("data"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/nvme0n1p3,4e4dcf55c272e78b5141f43d76b6beb3,-1)",
+	})
+}
+
+func (s *containerSuite) TestContainerActivatePlatformMissingVolumeName(c *C) {
+	// Test that StorageContainer.Activate fails if the WithVolumeName option is missing.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key)
+	c.Check(err, ErrorMatches, `missing WithVolumeName option for LUKS2 container`)
+}
+
+func (s *containerSuite) TestContainerActivateError(c *C) {
+	// Test that StorageContainer.Activate fails if the call to internal_luks2.Activate fails.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	s.activateErr = errors.New("some error")
+	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	c.Check(err, ErrorMatches, `cannot activate container /dev/nvme0n1p3 with volume name "data": some error`)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
+	})
+}
+
+func (s *containerSuite) TestContainerActiveVolumeName(c *C) {
+	// Test that StorageContainer.ActiveVolumeName works.
+	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	name, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, IsNil)
+	c.Check(name, Equals, "data")
+}
+
+func (s *containerSuite) TestContainerActiveVolumeNameDifferentName(c *C) {
+	// Test that StorageContainer.ActiveVolumeName works with
+	// a different volume name.
+	s.addDMDevice(c, 0, "save", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	name, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, IsNil)
+	c.Check(name, Equals, "save")
+}
+
+func (s *containerSuite) TestContainerActiveVolumeNameDifferentDMDevice(c *C) {
+	// Test that StorageContainer.ActiveVolumeName works with
+	// a different DM volume path
+	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	name, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, IsNil)
+	c.Check(name, Equals, "data")
+}
+
+func (s *containerSuite) TestContainerActiveVolumeNameIgnoreUnrelatedDMDevice1(c *C) {
+	// Test that StorageContainer.ActivateVolumeName ignores unrelated DM volumes.
+	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
+	s.addDMDevice(c, 1, "bar", "/dev/sda1")
+	s.addFile("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	name, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, IsNil)
+	c.Check(name, Equals, "data")
+}
+
+func (s *containerSuite) TestContainerActiveVolumeNameIgnoreUnrelatedDMDevices2(c *C) {
+	// Test that StorageContainer.ActivateVolumeName ignores unrelated DM volumes.
+	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
+	s.addDMDevice(c, 1, "bar", "/dev/sda1")
+	s.addFile("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	name, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, IsNil)
+	c.Check(name, Equals, "bar")
+}
+
+func (s *containerSuite) TestContainerActiveVolumeNameSourceDeviceforDMDeviceUnexpectedErr(c *C) {
+	// Test that StorageContainer.ActiveVolumeName returns an appropriate error
+	// if sourceDeviceForDMDevice returns an unexpected error.
+	s.addDMDeviceErr(c, 0, errors.New("some error"))
+	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	_, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, ErrorMatches, `cannot obtain source device path for dm volume /.*/dm-0: some error`)
+}
+
+func (s *containerSuite) TestContainerActiveVolumeNameSourceDeviceforDMDeviceUnsupportedTarget(c *C) {
+	// Test that StorageContainer.ActiveVolumeName ignores errors from sourceDeviceForDMDevice
+	// that indicate an unrecognized target type.
+	s.addDMDeviceErr(c, 0, ErrUnsupportedTargetType)
+	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	name, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, IsNil)
+	c.Check(name, Equals, "data")
+}
+
+func (s *containerSuite) TestContainerActiveVolumeNameInactive(c *C) {
+	// Test that StorageContainer.ActiveVolumeName returns an appropriate
+	// error if it isn't active.
+	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	_, err := container.ActiveVolumeName(context.Background())
+	c.Check(err, Equals, secboot.ErrStorageContainerNotActive)
+}
+
+func (s *containerSuite) TestContainerDeactivate(c *C) {
+	// Test that StorageContainer.Deactivate works.
+	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	c.Check(container.Deactivate(context.Background()), IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Deactivate(data)",
+	})
+}
+
+func (s *containerSuite) TestContainerDeactivateDifferentVolumeName(c *C) {
+	// Test that StorageContainer.Deactivate works with a different volume name
+	s.addDMDevice(c, 0, "save", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	c.Check(container.Deactivate(context.Background()), IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Deactivate(save)",
+	})
+}
+
+func (s *containerSuite) TestContainerDeactivateNoActiveDevice(c *C) {
+	// Test that StorageContainer.Deactivate returns an appropriate error
+	// if there is nothing to deactivate.
+	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
+	s.addDMDevice(c, 1, "bar", "/dev/sda1")
+	s.addFile("/dev/sda1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(8, 1)})
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.addFile("/dev/nvme0n1p2", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 2)})
+
+	container := NewStorageContainer("/dev/nvme0n1p2", unix.Mkdev(259, 2))
+	err := container.Deactivate(context.Background())
+	c.Check(err, ErrorMatches, `cannot obtain volume name: storage container is not active`)
+	c.Check(errors.Is(err, secboot.ErrStorageContainerNotActive), testutil.IsTrue)
+	c.Check(s.commands, DeepEquals, []string(nil))
+}
+
+func (s *containerSuite) TestContainerDeactivateActiveVolumeNameErr(c *C) {
+	// Test that StorageContainer.Deactivate returns an appropriate
+	// error if ActiveVolumeName fails.
+	s.addDMDeviceErr(c, 0, errors.New("some error"))
+	s.addDMDevice(c, 1, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	c.Check(container.Deactivate(context.Background()), ErrorMatches, `cannot obtain volume name: cannot obtain source device path for dm volume /.*/dm-0: some error`)
+	c.Check(s.commands, DeepEquals, []string(nil))
+}
+
+func (s *containerSuite) TestContainerDeactivateErr(c *C) {
+	s.addDMDevice(c, 0, "data", "/dev/nvme0n1p3")
+	s.addFile("/dev/nvme0n1p3", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 3)})
+	s.deactivateErr = errors.New("some error")
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	c.Check(container.Deactivate(context.Background()), ErrorMatches, `cannot deactivate volume "data": some error`)
+	c.Check(s.commands, DeepEquals, []string{
+		"Deactivate(data)",
+	})
+}

--- a/luks2/container_test.go
+++ b/luks2/container_test.go
@@ -257,6 +257,18 @@ func (s *containerSuite) TestContainerActivatePlatformNoKeyslotInfo(c *C) {
 	})
 }
 
+func (s *containerSuite) TestContainerActivatePlatformUnrecognizedKeyslotInfoType(c *C) {
+	// Test the StorageContainer.Activate implementation with a KeyslotInfo implementation
+	// other than the LUKS2 one. This will test the "external key data file" case with
+	// the eventual new activation API, as these will get their own KeyslotInfo type.
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
+	err := container.Activate(context.Background(), new(mockExternalKeyslotInfo), key, WithVolumeName("data"))
+	c.Check(err, IsNil)
+	c.Check(s.commands, DeepEquals, []string{
+		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,-1)",
+	})
+}
 func (s *containerSuite) TestContainerActivateRecovery(c *C) {
 	// Test the StorageContainer.Activate implementation with a recovery keyslot type.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))

--- a/luks2/container_test.go
+++ b/luks2/container_test.go
@@ -192,7 +192,7 @@ func (s *containerSuite) TestContainerActivatePlatform(c *C) {
 	// Test the StorageContainer.Activate implementation.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
@@ -204,7 +204,7 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentPath(c *C) {
 	// different device path.
 	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/sda1,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
@@ -216,7 +216,7 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentVolume(c *C) {
 	// different volume name.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("save"))
+	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("save"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(save,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
@@ -227,7 +227,7 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentKey(c *C) {
 	// Test the StorageContainer.Activate implementation with a different key.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "dcb4b6cfc0d9671e096a149f172978c587e9d7a0c7c1436e87fc45db9715777e")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,dcb4b6cfc0d9671e096a149f172978c587e9d7a0c7c1436e87fc45db9715777e,2)",
@@ -238,7 +238,7 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentKeyslot(c *C) {
 	// Test the StorageContainer.Activate implementation with a different LUKS2 keyslot ID.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 1, 0, nil), key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 1}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,1)",
@@ -269,22 +269,11 @@ func (s *containerSuite) TestContainerActivatePlatformUnrecognizedKeyslotInfoTyp
 	})
 }
 
-func (s *containerSuite) TestContainerActivateRecovery(c *C) {
-	// Test the StorageContainer.Activate implementation with a recovery keyslot type.
-	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
-	key := testutil.DecodeHexString(c, "4e4dcf55c272e78b5141f43d76b6beb3")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypeRecovery, "foo", 3, 0, nil), key, WithVolumeName("data"))
-	c.Check(err, IsNil)
-	c.Check(s.commands, DeepEquals, []string{
-		"Activate(data,/dev/nvme0n1p3,4e4dcf55c272e78b5141f43d76b6beb3,3)",
-	})
-}
-
 func (s *containerSuite) TestContainerActivatePlatformMissingVolumeName(c *C) {
 	// Test that StorageContainer.Activate fails if the WithVolumeName option is missing.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key)
+	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key)
 	c.Check(err, ErrorMatches, `missing WithVolumeName option for LUKS2 container`)
 }
 
@@ -293,7 +282,7 @@ func (s *containerSuite) TestContainerActivateError(c *C) {
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
 	s.activateErr = errors.New("some error")
-	err := container.Activate(context.Background(), NewKeyslotInfo(secboot.KeyslotTypePlatform, "foo", 2, 0, nil), key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, ErrorMatches, `cannot activate container /dev/nvme0n1p3 with volume name "data": some error`)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",

--- a/luks2/container_test.go
+++ b/luks2/container_test.go
@@ -192,7 +192,7 @@ func (s *containerSuite) TestContainerActivatePlatform(c *C) {
 	// Test the StorageContainer.Activate implementation.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslot{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
@@ -204,7 +204,7 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentPath(c *C) {
 	// different device path.
 	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslot{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/sda1,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
@@ -216,7 +216,7 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentVolume(c *C) {
 	// different volume name.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("save"))
+	err := container.Activate(context.Background(), &mockKeyslot{keyslotId: 2}, key, WithVolumeName("save"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(save,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",
@@ -227,7 +227,7 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentKey(c *C) {
 	// Test the StorageContainer.Activate implementation with a different key.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "dcb4b6cfc0d9671e096a149f172978c587e9d7a0c7c1436e87fc45db9715777e")
-	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslot{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,dcb4b6cfc0d9671e096a149f172978c587e9d7a0c7c1436e87fc45db9715777e,2)",
@@ -238,15 +238,15 @@ func (s *containerSuite) TestContainerActivatePlatformDifferentKeyslot(c *C) {
 	// Test the StorageContainer.Activate implementation with a different LUKS2 keyslot ID.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 1}, key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslot{keyslotId: 1}, key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,1)",
 	})
 }
 
-func (s *containerSuite) TestContainerActivatePlatformNoKeyslotInfo(c *C) {
-	// Test the StorageContainer.Activate implementation with a nil KeyslotInfo.
+func (s *containerSuite) TestContainerActivatePlatformNoKeyslot(c *C) {
+	// Test the StorageContainer.Activate implementation with a nil Keyslot.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
 	err := container.Activate(context.Background(), nil, key, WithVolumeName("data"))
@@ -256,13 +256,13 @@ func (s *containerSuite) TestContainerActivatePlatformNoKeyslotInfo(c *C) {
 	})
 }
 
-func (s *containerSuite) TestContainerActivatePlatformUnrecognizedKeyslotInfoType(c *C) {
-	// Test the StorageContainer.Activate implementation with a KeyslotInfo implementation
+func (s *containerSuite) TestContainerActivatePlatformUnrecognizedKeyslotType(c *C) {
+	// Test the StorageContainer.Activate implementation with a Keyslot implementation
 	// other than the LUKS2 one. This will test the "external key data file" case with
-	// the eventual new activation API, as these will get their own KeyslotInfo type.
+	// the eventual new activation API, as these will get their own Keyslot type.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), new(mockExternalKeyslotInfo), key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), new(mockExternalKeyslot), key, WithVolumeName("data"))
 	c.Check(err, IsNil)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,-1)",
@@ -273,7 +273,7 @@ func (s *containerSuite) TestContainerActivatePlatformMissingVolumeName(c *C) {
 	// Test that StorageContainer.Activate fails if the WithVolumeName option is missing.
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
-	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key)
+	err := container.Activate(context.Background(), &mockKeyslot{keyslotId: 2}, key)
 	c.Check(err, ErrorMatches, `missing WithVolumeName option for LUKS2 container`)
 }
 
@@ -282,7 +282,7 @@ func (s *containerSuite) TestContainerActivateError(c *C) {
 	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
 	key := testutil.DecodeHexString(c, "a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56")
 	s.activateErr = errors.New("some error")
-	err := container.Activate(context.Background(), &mockKeyslotInfo{keyslotId: 2}, key, WithVolumeName("data"))
+	err := container.Activate(context.Background(), &mockKeyslot{keyslotId: 2}, key, WithVolumeName("data"))
 	c.Check(err, ErrorMatches, `cannot activate container /dev/nvme0n1p3 with volume name "data": some error`)
 	c.Check(s.commands, DeepEquals, []string{
 		"Activate(data,/dev/nvme0n1p3,a7bfa9a642b897bc13c58b84cf8237d7d1b224b2e63cb3dc10414ff1f9052c56,2)",

--- a/luks2/dm_helper.go
+++ b/luks2/dm_helper.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	errNotDMBlockDevice      = errors.New("path does not correspond to a device mapper block device")
+	errUnsupportedTargetType = errors.New("unsupported target type")
+)
+
+// sourceDeviceFromDMDevice obtains the path of the source device that backs
+// the supplied DM device, if the supplied path references a DM device. If
+// the supplied path is not a DM device or block device, this function returns
+// ("", nil). It only supports walking linear and crypt tables, which should be
+// sufficient for our requirements for now.
+//
+// TODO: Make sur that this works with the layout of DM devices that we have
+// during re-encryption.
+//
+// TODO: Replace this with a package that talks directly to /dev/mapper/control.
+// It has an easy to use, well-documented ioctl based API and is preferable to
+// parsing the output of dmsetup.
+var sourceDeviceFromDMDevice = func(ctx context.Context, path string) (string, error) {
+	// Is the supplied path a block device?
+	var st unix.Stat_t
+	if err := unixStat(path, &st); err != nil {
+		return "", &os.PathError{Op: "stat", Path: path, Err: err}
+	}
+	if st.Mode&unix.S_IFBLK == 0 {
+		// Ignore paths that aren't block devices - another backend
+		// might handle this.
+		return "", errNotDMBlockDevice
+	}
+
+	// Is the supplied block device path a DM device. It should have a "dm"
+	// directory in /sys/dev/block/<major>:<minor>
+	if _, err := osStat(filepath.Join(sysfsRoot, "dev/block", fmt.Sprintf("%d:%d", unix.Major(st.Rdev), unix.Minor(st.Rdev)), "dm")); err != nil {
+		if os.IsNotExist(err) {
+			// This is not a DM device. Ignore it because another
+			// backend might handle it.
+			return "", errNotDMBlockDevice
+		}
+		return "", err
+	}
+
+	// The supplied path is a device mapper device. Obtain the table using dmsetup.
+	cmd := exec.CommandContext(ctx, "dmsetup", "table", path)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("cannot obtain dm table for %s: %w", path, err)
+	}
+
+	// We have a table that we can split by whitespace. The table format is:
+	// <logical_start_sector> <num_sectors> <target_type> <target_args>...
+	tbl := strings.Split(string(out), " ")
+	if len(tbl) < 3 {
+		return "", fmt.Errorf("invalid dm table: unexpected number of arguments (%d) - expected at least 3", len(tbl))
+	}
+
+	var dev string
+
+	targetType := tbl[2]
+	switch targetType {
+	case "crypt":
+		// For crypt device, we expect the following extra args:
+		// <cipher> <key> <iv_offset> <device> <offset> <features>...
+		if len(tbl) < 8 {
+			return "", fmt.Errorf("invalid dm table: unexpected number of arguments (%d) for device with crypt target: expected at least 8", len(tbl))
+		}
+
+		dev = tbl[6]
+	case "linear":
+		// For linear device, we expect the following extra args:
+		// <device> <offset>
+		if len(tbl) < 5 {
+			return "", fmt.Errorf("invalid dm table: unexpected number of arguments (%d) for device with linear target: expected at least 5", len(tbl))
+		}
+
+		dev = tbl[3]
+	default:
+		return "", errUnsupportedTargetType
+	}
+
+	// XXX: Is the device always identified by device number? Can it be referenced
+	// by its device node path (in which case, this code needs some readjustment)?
+	// Resolve the sysfs path using the device number.
+	resolvedDev, err := filepathEvalSymlinks(filepath.Join(sysfsRoot, "dev/block", dev))
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve symlink for block device %s: %w", dev, err)
+	}
+
+	// Return the device node path, which uses the basename of the sysfs dir.
+	return filepath.Join("/dev", filepath.Base(resolvedDev)), nil
+}

--- a/luks2/dm_helper_test.go
+++ b/luks2/dm_helper_test.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/snapcore/secboot/internal/testutil"
 	. "github.com/snapcore/secboot/luks2"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 	"golang.org/x/sys/unix"
@@ -45,18 +46,17 @@ func (*fileInfo) Sys() any           { return nil }
 type dmHelperSuite struct {
 	snapd_testutil.BaseTest
 
-	symlinks map[string]string
-	info     map[string]unix.Stat_t
-	tables   string
-	cmd      *snapd_testutil.MockCmd
+	info   map[string]unix.Stat_t
+	sysfs  string
+	tables string
+	cmd    *snapd_testutil.MockCmd
 }
 
 func (s *dmHelperSuite) SetUpTest(c *C) {
-	s.symlinks = make(map[string]string)
 	s.info = make(map[string]unix.Stat_t)
 
-	restore := MockFilepathEvalSymlinks(s.symlinks)
-	s.AddCleanup(restore)
+	s.sysfs = c.MkDir()
+	restore := MockSysfsRoot(s.sysfs)
 
 	restore = MockOsStat(func(path string) (os.FileInfo, error) {
 		_, exists := s.info[path]
@@ -83,11 +83,12 @@ func (s *dmHelperSuite) SetUpTest(c *C) {
 	s.AddCleanup(s.cmd.Restore)
 }
 
-func (s *dmHelperSuite) addSymlink(target, link string) {
-	s.symlinks[link] = target
+func (s *dmHelperSuite) addSysfsFileContents(c *C, path string, contents []byte) {
+	c.Assert(os.MkdirAll(filepath.Dir(filepath.Join(s.sysfs, path)), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.sysfs, path), contents, 0644), IsNil)
 }
 
-func (s *dmHelperSuite) addFile(path string, st unix.Stat_t) {
+func (s *dmHelperSuite) addFileInfo(path string, st unix.Stat_t) {
 	s.info[path] = st
 }
 
@@ -98,10 +99,78 @@ func (s *dmHelperSuite) addTable(c *C, path, table string) {
 
 var _ = Suite(&dmHelperSuite{})
 
+func (s *dmHelperSuite) TestDecodeKernelSysfsUeventAttr1(c *C) {
+	s.addSysfsFileContents(c, "dev/block/252:0/uevent", []byte(`MAJOR=252
+MINOR=0
+DEVNAME=dm-0
+DEVTYPE=disk
+DISKSEQ=10
+`))
+
+	env, err := DecodeKernelSysfsUeventAttr("dev/block/252:0")
+	c.Assert(err, IsNil)
+	c.Check(env, DeepEquals, map[string]string{
+		"DEVNAME": "dm-0",
+		"DEVTYPE": "disk",
+		"DISKSEQ": "10",
+		"MAJOR":   "252",
+		"MINOR":   "0",
+	})
+}
+
+func (s *dmHelperSuite) TestDecodeKernelSysfsUeventAttr2(c *C) {
+	s.addSysfsFileContents(c, "dev/block/259:3/uevent", []byte(`MAJOR=259
+MINOR=3
+DEVNAME=nvme0n1p3
+DEVTYPE=partition
+DISKSEQ=9
+PARTN=3
+PARTUUID=4ec529c3-02c9-4f0d-a73f-f1036b8cf1fb
+`))
+
+	env, err := DecodeKernelSysfsUeventAttr("dev/block/259:3")
+	c.Assert(err, IsNil)
+	c.Check(env, DeepEquals, map[string]string{
+		"DEVNAME":  "nvme0n1p3",
+		"DEVTYPE":  "partition",
+		"DISKSEQ":  "9",
+		"MAJOR":    "259",
+		"MINOR":    "3",
+		"PARTN":    "3",
+		"PARTUUID": "4ec529c3-02c9-4f0d-a73f-f1036b8cf1fb",
+	})
+}
+
+func (s *dmHelperSuite) TestDecodeKernelSysfsUeventAttrNotExist(c *C) {
+	_, err := DecodeKernelSysfsUeventAttr("devices/pci0000:00/0000:00:0e.0/pci10000:e0/10000:e0:06.0/10000:e1:00.0/nvme/")
+	c.Check(os.IsNotExist(err), testutil.IsTrue)
+}
+
+func (s *dmHelperSuite) TestDecodeKernelSysfsUeventAttrInvalidEntry(c *C) {
+	s.addSysfsFileContents(c, "dev/block/259:3/uevent", []byte(`MAJOR=259
+MINOR=3
+DEVNAME=nvmen01p3
+DEVTYPE=disk
+DISKSEQ=10
+PARTN=3
+PARTUUID
+`))
+
+	_, err := DecodeKernelSysfsUeventAttr("dev/block/259:3")
+	c.Assert(err, ErrorMatches, `invalid entry 6: \"PARTUUID\"`)
+}
+
 func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceCrypt(c *C) {
-	s.addSymlink("/sys/devices/pci0000:00/0000:00:0e.0/pci10000:e0/10000:e0:06.0/10000:e1:00.0/nvme/nvme0/nvme0n1/nvme0n1p3", "/sys/dev/block/259:3")
-	s.addFile("/sys/dev/block/252:0/dm", unix.Stat_t{})
-	s.addFile("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
+	s.addSysfsFileContents(c, "dev/block/259:3/uevent", []byte(`MAJOR=259
+MINOR=3
+DEVNAME=nvme0n1p3
+DEVTYPE=disk
+DISKSEQ=10
+PARTN=3
+PARTUUID=4ec529c3-02c9-4f0d-a73f-f1036b8cf1fb
+`))
+	s.addFileInfo(filepath.Join(s.sysfs, "dev/block/252:0/dm"), unix.Stat_t{})
+	s.addFileInfo("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
 	s.addTable(c, "/dev/dm-0", "0 7807602688 crypt aes-xts-plain64 :64:logon:cryptsetup:ef2d659a-179b-4949-9caf-bd81f0e85272-d0 0 259:3 32768")
 
 	path, err := SourceDeviceFromDMDevice(context.Background(), "/dev/dm-0")
@@ -113,9 +182,14 @@ func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceCrypt(c *C) {
 }
 
 func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceLinear(c *C) {
-	s.addSymlink("/sys/devices/virtual/block/dm-0", "/sys/dev/block/252:0")
-	s.addFile("/sys/dev/block/252:1/dm", unix.Stat_t{})
-	s.addFile("/dev/dm-1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 1)})
+	s.addSysfsFileContents(c, "dev/block/252:0/uevent", []byte(`MAJOR=252
+MINOR=0
+DEVNAME=dm-0
+DEVTYPE=disk
+DISKSEQ=10
+`))
+	s.addFileInfo(filepath.Join(s.sysfs, "dev/block/252:1/dm"), unix.Stat_t{})
+	s.addFileInfo("/dev/dm-1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 1)})
 	s.addTable(c, "/dev/dm-1", "0 7807598592 linear 252:0 2048")
 
 	path, err := SourceDeviceFromDMDevice(context.Background(), "/dev/dm-1")
@@ -127,12 +201,24 @@ func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceLinear(c *C) {
 }
 
 func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceStackedLinearAndCrypt(c *C) {
-	s.addSymlink("/sys/devices/virtual/block/dm-0", "/sys/dev/block/252:0")
-	s.addSymlink("/sys/devices/pci0000:00/0000:00:0e.0/pci10000:e0/10000:e0:06.0/10000:e1:00.0/nvme/nvme0/nvme0n1/nvme0n1p3", "/sys/dev/block/259:3")
-	s.addFile("/sys/dev/block/252:0/dm", unix.Stat_t{})
-	s.addFile("/sys/dev/block/252:1/dm", unix.Stat_t{})
-	s.addFile("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
-	s.addFile("/dev/dm-1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 1)})
+	s.addSysfsFileContents(c, "dev/block/252:0/uevent", []byte(`MAJOR=252
+MINOR=0
+DEVNAME=dm-0
+DEVTYPE=disk
+DISKSEQ=10
+`))
+	s.addSysfsFileContents(c, "dev/block/259:3/uevent", []byte(`MAJOR=259
+MINOR=3
+DEVNAME=nvme0n1p3
+DEVTYPE=disk
+DISKSEQ=10
+PARTN=3
+PARTUUID=4ec529c3-02c9-4f0d-a73f-f1036b8cf1fb
+`))
+	s.addFileInfo(filepath.Join(s.sysfs, "dev/block/252:0/dm"), unix.Stat_t{})
+	s.addFileInfo(filepath.Join(s.sysfs, "dev/block/252:1/dm"), unix.Stat_t{})
+	s.addFileInfo("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
+	s.addFileInfo("/dev/dm-1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 1)})
 	s.addTable(c, "/dev/dm-0", "0 7807602688 crypt aes-xts-plain64 :64:logon:cryptsetup:ef2d659a-179b-4949-9caf-bd81f0e85272-d0 0 259:3 32768")
 	s.addTable(c, "/dev/dm-1", "0 7807598592 linear 252:0 2048")
 
@@ -151,22 +237,22 @@ func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceStackedLinearAndCrypt(c *C) 
 }
 
 func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceNotBlockDev(c *C) {
-	s.addFile("/dev/null", unix.Stat_t{Mode: unix.S_IFCHR, Rdev: unix.Mkdev(1, 3)})
+	s.addFileInfo("/dev/null", unix.Stat_t{Mode: unix.S_IFCHR, Rdev: unix.Mkdev(1, 3)})
 
 	_, err := SourceDeviceFromDMDevice(context.Background(), "/dev/null")
 	c.Check(err, Equals, ErrNotDMBlockDevice)
 }
 
 func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceNotDMDevice(c *C) {
-	s.addFile("/dev/nvme0n1p2", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 2)})
+	s.addFileInfo("/dev/nvme0n1p2", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 2)})
 
 	_, err := SourceDeviceFromDMDevice(context.Background(), "/dev/nvme0n1p2")
 	c.Check(err, Equals, ErrNotDMBlockDevice)
 }
 
 func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceUnrecognizedTarget(c *C) {
-	s.addFile("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
-	s.addFile("/sys/dev/block/252:0/dm", unix.Stat_t{})
+	s.addFileInfo("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
+	s.addFileInfo(filepath.Join(s.sysfs, "dev/block/252:0/dm"), unix.Stat_t{})
 	s.addTable(c, "/dev/dm-0", "0 7807602688 flakey 259:3 0 60 1")
 
 	_, err := SourceDeviceFromDMDevice(context.Background(), "/dev/dm-0")

--- a/luks2/dm_helper_test.go
+++ b/luks2/dm_helper_test.go
@@ -1,0 +1,177 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	. "github.com/snapcore/secboot/luks2"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+	"golang.org/x/sys/unix"
+	. "gopkg.in/check.v1"
+)
+
+type fileInfo struct{}
+
+func (*fileInfo) Name() string       { return "" }
+func (*fileInfo) Size() int64        { return 0 }
+func (*fileInfo) Mode() os.FileMode  { return 0 }
+func (*fileInfo) ModTime() time.Time { return time.Time{} }
+func (*fileInfo) IsDir() bool        { return false }
+func (*fileInfo) Sys() any           { return nil }
+
+type dmHelperSuite struct {
+	snapd_testutil.BaseTest
+
+	symlinks map[string]string
+	info     map[string]unix.Stat_t
+	tables   string
+	cmd      *snapd_testutil.MockCmd
+}
+
+func (s *dmHelperSuite) SetUpTest(c *C) {
+	s.symlinks = make(map[string]string)
+	s.info = make(map[string]unix.Stat_t)
+
+	restore := MockFilepathEvalSymlinks(s.symlinks)
+	s.AddCleanup(restore)
+
+	restore = MockOsStat(func(path string) (os.FileInfo, error) {
+		_, exists := s.info[path]
+		if !exists {
+			return nil, &os.PathError{Op: "stat", Path: path, Err: syscall.ENOENT}
+		}
+		return new(fileInfo), nil
+	})
+	s.AddCleanup(restore)
+
+	restore = MockUnixStat(func(path string, st *unix.Stat_t) error {
+		s, exists := s.info[path]
+		if !exists {
+			return syscall.ENOENT
+		}
+		*st = s
+		return nil
+	})
+	s.AddCleanup(restore)
+
+	s.tables = c.MkDir()
+
+	s.cmd = snapd_testutil.MockCommand(c, "dmsetup", fmt.Sprintf(`cat %s/"$2"`, s.tables))
+	s.AddCleanup(s.cmd.Restore)
+}
+
+func (s *dmHelperSuite) addSymlink(target, link string) {
+	s.symlinks[link] = target
+}
+
+func (s *dmHelperSuite) addFile(path string, st unix.Stat_t) {
+	s.info[path] = st
+}
+
+func (s *dmHelperSuite) addTable(c *C, path, table string) {
+	c.Assert(os.MkdirAll(filepath.Dir(filepath.Join(s.tables, path)), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.tables, path), []byte(table), 0644), IsNil)
+}
+
+var _ = Suite(&dmHelperSuite{})
+
+func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceCrypt(c *C) {
+	s.addSymlink("/sys/devices/pci0000:00/0000:00:0e.0/pci10000:e0/10000:e0:06.0/10000:e1:00.0/nvme/nvme0/nvme0n1/nvme0n1p3", "/sys/dev/block/259:3")
+	s.addFile("/sys/dev/block/252:0/dm", unix.Stat_t{})
+	s.addFile("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
+	s.addTable(c, "/dev/dm-0", "0 7807602688 crypt aes-xts-plain64 :64:logon:cryptsetup:ef2d659a-179b-4949-9caf-bd81f0e85272-d0 0 259:3 32768")
+
+	path, err := SourceDeviceFromDMDevice(context.Background(), "/dev/dm-0")
+	c.Check(err, IsNil)
+	c.Check(path, Equals, "/dev/nvme0n1p3")
+
+	c.Assert(s.cmd.Calls(), HasLen, 1)
+	c.Check(s.cmd.Calls()[0], DeepEquals, []string{"dmsetup", "table", "/dev/dm-0"})
+}
+
+func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceLinear(c *C) {
+	s.addSymlink("/sys/devices/virtual/block/dm-0", "/sys/dev/block/252:0")
+	s.addFile("/sys/dev/block/252:1/dm", unix.Stat_t{})
+	s.addFile("/dev/dm-1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 1)})
+	s.addTable(c, "/dev/dm-1", "0 7807598592 linear 252:0 2048")
+
+	path, err := SourceDeviceFromDMDevice(context.Background(), "/dev/dm-1")
+	c.Check(err, IsNil)
+	c.Check(path, Equals, "/dev/dm-0")
+
+	c.Assert(s.cmd.Calls(), HasLen, 1)
+	c.Check(s.cmd.Calls()[0], DeepEquals, []string{"dmsetup", "table", "/dev/dm-1"})
+}
+
+func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceStackedLinearAndCrypt(c *C) {
+	s.addSymlink("/sys/devices/virtual/block/dm-0", "/sys/dev/block/252:0")
+	s.addSymlink("/sys/devices/pci0000:00/0000:00:0e.0/pci10000:e0/10000:e0:06.0/10000:e1:00.0/nvme/nvme0/nvme0n1/nvme0n1p3", "/sys/dev/block/259:3")
+	s.addFile("/sys/dev/block/252:0/dm", unix.Stat_t{})
+	s.addFile("/sys/dev/block/252:1/dm", unix.Stat_t{})
+	s.addFile("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
+	s.addFile("/dev/dm-1", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 1)})
+	s.addTable(c, "/dev/dm-0", "0 7807602688 crypt aes-xts-plain64 :64:logon:cryptsetup:ef2d659a-179b-4949-9caf-bd81f0e85272-d0 0 259:3 32768")
+	s.addTable(c, "/dev/dm-1", "0 7807598592 linear 252:0 2048")
+
+	path, err := SourceDeviceFromDMDevice(context.Background(), "/dev/dm-1")
+	c.Check(err, IsNil)
+	c.Check(path, Equals, "/dev/dm-0")
+
+	path, err = SourceDeviceFromDMDevice(context.Background(), path)
+	c.Check(err, IsNil)
+	c.Check(path, Equals, "/dev/nvme0n1p3")
+
+	c.Check(s.cmd.Calls(), DeepEquals, [][]string{
+		[]string{"dmsetup", "table", "/dev/dm-1"},
+		[]string{"dmsetup", "table", "/dev/dm-0"},
+	})
+}
+
+func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceNotBlockDev(c *C) {
+	s.addFile("/dev/null", unix.Stat_t{Mode: unix.S_IFCHR, Rdev: unix.Mkdev(1, 3)})
+
+	_, err := SourceDeviceFromDMDevice(context.Background(), "/dev/null")
+	c.Check(err, Equals, ErrNotDMBlockDevice)
+}
+
+func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceNotDMDevice(c *C) {
+	s.addFile("/dev/nvme0n1p2", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(259, 2)})
+
+	_, err := SourceDeviceFromDMDevice(context.Background(), "/dev/nvme0n1p2")
+	c.Check(err, Equals, ErrNotDMBlockDevice)
+}
+
+func (s *dmHelperSuite) TestSourceDeviceFromDMDeviceUnrecognizedTarget(c *C) {
+	s.addFile("/dev/dm-0", unix.Stat_t{Mode: unix.S_IFBLK, Rdev: unix.Mkdev(252, 0)})
+	s.addFile("/sys/dev/block/252:0/dm", unix.Stat_t{})
+	s.addTable(c, "/dev/dm-0", "0 7807602688 flakey 259:3 0 60 1")
+
+	_, err := SourceDeviceFromDMDevice(context.Background(), "/dev/dm-0")
+	c.Check(err, Equals, ErrUnsupportedTargetType)
+
+	c.Assert(s.cmd.Calls(), HasLen, 1)
+	c.Check(s.cmd.Calls()[0], DeepEquals, []string{"dmsetup", "table", "/dev/dm-0"})
+}

--- a/luks2/export_test.go
+++ b/luks2/export_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/snapcore/secboot"
 	"golang.org/x/sys/unix"
 )
 
@@ -36,7 +35,6 @@ var (
 )
 
 type (
-	KeyslotInfoImpl         = keyslotInfoImpl
 	Luks2Api                = luks2Api
 	Luks2KeyDataReader      = luks2KeyDataReader
 	LuksView                = luksView
@@ -112,16 +110,6 @@ func MockUnixStat(fn func(string, *unix.Stat_t) error) (restore func()) {
 	unixStat = fn
 	return func() {
 		unixStat = orig
-	}
-}
-
-func NewKeyslotInfo(keyslotType secboot.KeyslotType, name string, slot, priority int, data secboot.KeyDataReader) *KeyslotInfoImpl {
-	return &keyslotInfoImpl{
-		keyslotType:     keyslotType,
-		keyslotName:     name,
-		keyslotId:       slot,
-		keyslotPriority: priority,
-		keyslotData:     data,
 	}
 }
 

--- a/luks2/export_test.go
+++ b/luks2/export_test.go
@@ -31,7 +31,6 @@ var (
 	ErrNotDMBlockDevice        = errNotDMBlockDevice
 	ErrUnsupportedTargetType   = errUnsupportedTargetType
 	NewStorageContainerBackend = newStorageContainerBackend
-	ProbeDepthKey              = probeDepthKey
 	SourceDeviceFromDMDevice   = sourceDeviceFromDMDevice
 )
 

--- a/luks2/export_test.go
+++ b/luks2/export_test.go
@@ -28,10 +28,11 @@ import (
 )
 
 var (
-	ErrNotDMBlockDevice        = errNotDMBlockDevice
-	ErrUnsupportedTargetType   = errUnsupportedTargetType
-	NewStorageContainerBackend = newStorageContainerBackend
-	SourceDeviceFromDMDevice   = sourceDeviceFromDMDevice
+	DecodeKernelSysfsUeventAttr = decodeKernelSysfsUeventAttr
+	ErrNotDMBlockDevice         = errNotDMBlockDevice
+	ErrUnsupportedTargetType    = errUnsupportedTargetType
+	NewStorageContainerBackend  = newStorageContainerBackend
+	SourceDeviceFromDMDevice    = sourceDeviceFromDMDevice
 )
 
 type (

--- a/luks2/export_test.go
+++ b/luks2/export_test.go
@@ -1,0 +1,133 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"context"
+	"os"
+
+	"github.com/snapcore/secboot"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	ErrNotDMBlockDevice        = errNotDMBlockDevice
+	ErrUnsupportedTargetType   = errUnsupportedTargetType
+	NewStorageContainerBackend = newStorageContainerBackend
+	ProbeDepthKey              = probeDepthKey
+	SourceDeviceFromDMDevice   = sourceDeviceFromDMDevice
+)
+
+type (
+	KeyslotInfoImpl         = keyslotInfoImpl
+	Luks2Api                = luks2Api
+	Luks2KeyDataReader      = luks2KeyDataReader
+	LuksView                = luksView
+	StorageContainerBackend = storageContainerBackend
+	StorageContainerImpl    = storageContainerImpl
+	StorageContainerReader  = storageContainerReader
+)
+
+func MockDevRoot(path string) (restore func()) {
+	orig := devRoot
+	devRoot = path
+	return func() {
+		devRoot = orig
+	}
+}
+
+func MockFilepathEvalSymlinks(links map[string]string) (restore func()) {
+	orig := filepathEvalSymlinks
+	filepathEvalSymlinks = func(path string) (string, error) {
+		target, exists := links[path]
+		if !exists {
+			return path, nil
+		}
+		return target, nil
+	}
+	return func() {
+		filepathEvalSymlinks = orig
+	}
+}
+
+func MockLUKS2Ops(ops *Luks2Api) (restore func()) {
+	orig := luks2Ops
+	luks2Ops = ops
+	return func() {
+		luks2Ops = orig
+	}
+}
+
+func MockNewLuksView(fn func(context.Context, string) (LuksView, error)) (restore func()) {
+	orig := newLuksView
+	newLuksView = fn
+	return func() {
+		newLuksView = orig
+	}
+}
+
+func MockOsStat(fn func(string) (os.FileInfo, error)) (restore func()) {
+	orig := osStat
+	osStat = fn
+	return func() {
+		osStat = orig
+	}
+}
+
+func MockSourceDeviceFromDMDevice(fn func(context.Context, string) (string, error)) (restore func()) {
+	orig := sourceDeviceFromDMDevice
+	sourceDeviceFromDMDevice = fn
+	return func() {
+		sourceDeviceFromDMDevice = orig
+	}
+}
+
+func MockSysfsRoot(path string) (restore func()) {
+	orig := sysfsRoot
+	sysfsRoot = path
+	return func() {
+		sysfsRoot = orig
+	}
+}
+
+func MockUnixStat(fn func(string, *unix.Stat_t) error) (restore func()) {
+	orig := unixStat
+	unixStat = fn
+	return func() {
+		unixStat = orig
+	}
+}
+
+func NewKeyslotInfo(keyslotType secboot.KeyslotType, name string, slot, priority int, data secboot.KeyDataReader) *KeyslotInfoImpl {
+	return &keyslotInfoImpl{
+		keyslotType:     keyslotType,
+		keyslotName:     name,
+		keyslotId:       slot,
+		keyslotPriority: priority,
+		keyslotData:     data,
+	}
+}
+
+func NewStorageContainer(path string, dev uint64) *StorageContainerImpl {
+	return &storageContainerImpl{
+		path: path,
+		dev:  dev,
+	}
+}

--- a/luks2/keyslot.go
+++ b/luks2/keyslot.go
@@ -21,7 +21,7 @@ package luks2
 
 import "github.com/snapcore/secboot"
 
-type keyslotInfoImpl struct {
+type keyslotImpl struct {
 	keyslotType     secboot.KeyslotType
 	keyslotName     string
 	keyslotId       int
@@ -29,29 +29,29 @@ type keyslotInfoImpl struct {
 	keyslotData     secboot.KeyDataReader // This will eventually just be a io.Reader
 }
 
-func (i *keyslotInfoImpl) Type() secboot.KeyslotType {
+func (i *keyslotImpl) Type() secboot.KeyslotType {
 	return i.keyslotType
 }
 
-func (i *keyslotInfoImpl) Name() string {
+func (i *keyslotImpl) Name() string {
 	return i.keyslotName
 }
 
-func (i *keyslotInfoImpl) Priority() int {
+func (i *keyslotImpl) Priority() int {
 	return i.keyslotPriority
 }
 
-func (i *keyslotInfoImpl) Data() secboot.KeyDataReader {
+func (i *keyslotImpl) Data() secboot.KeyDataReader {
 	return i.keyslotData
 }
 
-func (i *keyslotInfoImpl) KeyslotID() int {
+func (i *keyslotImpl) KeyslotID() int {
 	return i.keyslotId
 }
 
-// KeyslotInfo provides information about a LUKS2 keyslot.
-type KeyslotInfo interface {
-	secboot.KeyslotInfo
+// Keyslot provides information about a LUKS2 keyslot.
+type Keyslot interface {
+	secboot.Keyslot
 
 	// KeyslotID returns the LUKS2 keyslot ID associated
 	// with this secboot keyslot.

--- a/luks2/keyslot_info.go
+++ b/luks2/keyslot_info.go
@@ -54,7 +54,6 @@ type KeyslotInfo interface {
 	secboot.KeyslotInfo
 
 	// KeyslotID returns the LUKS2 keyslot ID associated
-	// with this secboot keyslot. This will currently always
-	// return -1 for recovery keys.
+	// with this secboot keyslot.
 	KeyslotID() int
 }

--- a/luks2/keyslot_info.go
+++ b/luks2/keyslot_info.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import "github.com/snapcore/secboot"
+
+type keyslotInfoImpl struct {
+	keyslotType     secboot.KeyslotType
+	keyslotName     string
+	keyslotId       int
+	keyslotPriority int
+	keyslotData     secboot.KeyDataReader // This will eventually just be a io.Reader
+}
+
+func (i *keyslotInfoImpl) Type() secboot.KeyslotType {
+	return i.keyslotType
+}
+
+func (i *keyslotInfoImpl) Name() string {
+	return i.keyslotName
+}
+
+func (i *keyslotInfoImpl) Priority() int {
+	return i.keyslotPriority
+}
+
+func (i *keyslotInfoImpl) Data() secboot.KeyDataReader {
+	return i.keyslotData
+}
+
+func (i *keyslotInfoImpl) KeyslotID() int {
+	return i.keyslotId
+}
+
+// KeyslotInfo provides information about a LUKS2 keyslot.
+type KeyslotInfo interface {
+	secboot.KeyslotInfo
+
+	// KeyslotID returns the LUKS2 keyslot ID associated
+	// with this secboot keyslot. This will currently always
+	// return -1 for recovery keys.
+	KeyslotID() int
+}

--- a/luks2/luks2_test.go
+++ b/luks2/luks2_test.go
@@ -1,0 +1,124 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luksview"
+	. "github.com/snapcore/secboot/luks2"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type mockLuks2KeyDataReader struct {
+	name     string
+	slot     int
+	priority int
+	*bytes.Reader
+}
+
+func newMockLuks2KeyDataReader(name string, slot, priority int, data []byte) *mockLuks2KeyDataReader {
+	return &mockLuks2KeyDataReader{
+		name:     name,
+		slot:     slot,
+		priority: priority,
+		Reader:   bytes.NewReader(data),
+	}
+}
+
+func (r *mockLuks2KeyDataReader) ReadableName() string {
+	return r.name
+}
+
+func (r *mockLuks2KeyDataReader) KeyslotID() int {
+	return r.slot
+}
+
+func (r *mockLuks2KeyDataReader) Priority() int {
+	return r.priority
+}
+
+type mockContainerData struct {
+	recoveryKeyslots map[string]int
+	platformKeyslots map[string]Luks2KeyDataReader
+
+	listUnlockKeyNamesErr   error
+	listRecoveryKeyNamesErr error
+	newKeyDataReaderErr     error
+}
+
+func newMockContainerData() *mockContainerData {
+	return &mockContainerData{
+		recoveryKeyslots: make(map[string]int),
+		platformKeyslots: make(map[string]Luks2KeyDataReader),
+	}
+}
+
+type mockToken struct {
+	tokenType luks2.TokenType
+	keyslot   int
+	name      string
+}
+
+func (t *mockToken) Type() luks2.TokenType {
+	return t.tokenType
+}
+
+func (t *mockToken) Keyslots() []int {
+	return []int{t.keyslot}
+}
+
+func (t *mockToken) Name() string {
+	return t.name
+}
+
+type mockLuksView struct {
+	data *mockContainerData
+}
+
+func (v *mockLuksView) TokenByName(name string) (token luksview.NamedToken, id int, inUse bool) {
+	id, exists := v.data.recoveryKeyslots[name]
+	if exists {
+		return &mockToken{
+			tokenType: luksview.RecoveryTokenType,
+			keyslot:   id,
+			name:      name,
+		}, 0, true // We return 0 for all token IDs because the test doesn't use it.
+	}
+
+	r, exists := v.data.platformKeyslots[name]
+	if exists {
+		return &mockToken{
+			tokenType: luksview.KeyDataTokenType,
+			keyslot:   r.KeyslotID(),
+			name:      name,
+		}, 0, true // We return 0 for all token IDs because the test doesn't use it.
+	}
+
+	return nil, 0, false
+}
+
+func newMockLuksView(data *mockContainerData) LuksView {
+	return &mockLuksView{data: data}
+}

--- a/luks2/luks2_test.go
+++ b/luks2/luks2_test.go
@@ -51,6 +51,34 @@ func (*mockExternalKeyslotInfo) Data() secboot.KeyDataReader {
 	return nil
 }
 
+type mockKeyslotInfo struct {
+	keyslotType     secboot.KeyslotType
+	keyslotName     string
+	keyslotPriority int
+	keyslotData     secboot.KeyDataReader
+	keyslotId       int
+}
+
+func (i *mockKeyslotInfo) Type() secboot.KeyslotType {
+	return i.keyslotType
+}
+
+func (i *mockKeyslotInfo) Name() string {
+	return i.keyslotName
+}
+
+func (i *mockKeyslotInfo) Priority() int {
+	return i.keyslotPriority
+}
+
+func (i *mockKeyslotInfo) Data() secboot.KeyDataReader {
+	return i.keyslotData
+}
+
+func (i *mockKeyslotInfo) KeyslotID() int {
+	return i.keyslotId
+}
+
 type mockLuks2KeyDataReader struct {
 	name     string
 	slot     int

--- a/luks2/luks2_test.go
+++ b/luks2/luks2_test.go
@@ -32,26 +32,26 @@ import (
 
 func Test(t *testing.T) { TestingT(t) }
 
-type mockExternalKeyslotInfo struct {
+type mockExternalKeyslot struct {
 }
 
-func (*mockExternalKeyslotInfo) Type() secboot.KeyslotType {
+func (*mockExternalKeyslot) Type() secboot.KeyslotType {
 	return secboot.KeyslotTypePlatform
 }
 
-func (*mockExternalKeyslotInfo) Name() string {
+func (*mockExternalKeyslot) Name() string {
 	return "mock external keyslot"
 }
 
-func (*mockExternalKeyslotInfo) Priority() int {
+func (*mockExternalKeyslot) Priority() int {
 	return 0
 }
 
-func (*mockExternalKeyslotInfo) Data() secboot.KeyDataReader {
+func (*mockExternalKeyslot) Data() secboot.KeyDataReader {
 	return nil
 }
 
-type mockKeyslotInfo struct {
+type mockKeyslot struct {
 	keyslotType     secboot.KeyslotType
 	keyslotName     string
 	keyslotPriority int
@@ -59,23 +59,23 @@ type mockKeyslotInfo struct {
 	keyslotId       int
 }
 
-func (i *mockKeyslotInfo) Type() secboot.KeyslotType {
+func (i *mockKeyslot) Type() secboot.KeyslotType {
 	return i.keyslotType
 }
 
-func (i *mockKeyslotInfo) Name() string {
+func (i *mockKeyslot) Name() string {
 	return i.keyslotName
 }
 
-func (i *mockKeyslotInfo) Priority() int {
+func (i *mockKeyslot) Priority() int {
 	return i.keyslotPriority
 }
 
-func (i *mockKeyslotInfo) Data() secboot.KeyDataReader {
+func (i *mockKeyslot) Data() secboot.KeyDataReader {
 	return i.keyslotData
 }
 
-func (i *mockKeyslotInfo) KeyslotID() int {
+func (i *mockKeyslot) KeyslotID() int {
 	return i.keyslotId
 }
 

--- a/luks2/luks2_test.go
+++ b/luks2/luks2_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/luks2"
 	"github.com/snapcore/secboot/internal/luksview"
 	. "github.com/snapcore/secboot/luks2"
@@ -30,6 +31,25 @@ import (
 )
 
 func Test(t *testing.T) { TestingT(t) }
+
+type mockExternalKeyslotInfo struct {
+}
+
+func (*mockExternalKeyslotInfo) Type() secboot.KeyslotType {
+	return secboot.KeyslotTypePlatform
+}
+
+func (*mockExternalKeyslotInfo) Name() string {
+	return "mock external keyslot"
+}
+
+func (*mockExternalKeyslotInfo) Priority() int {
+	return 0
+}
+
+func (*mockExternalKeyslotInfo) Data() secboot.KeyDataReader {
+	return nil
+}
 
 type mockLuks2KeyDataReader struct {
 	name     string

--- a/luks2/reader.go
+++ b/luks2/reader.go
@@ -47,6 +47,15 @@ type storageContainerReadWriterImpl struct {
 	keyslots map[string]*keyslotImpl
 }
 
+// ensureKeyslotNames ensures that the names of keyslots are cached.
+// XXX: There is only read access for storage containers for now. Although there will
+// eventually be read/write access, snapd will continue to use the existing
+// [secboot.LUKS2KeyDataWriter] in the meantime. It is an error to modify the LUKS2
+// header with an open reader, and this package will ensure that a read/writer cannot
+// be opened whilst there are open readers when read/write access is supported.
+// Therefore, it is safe to assume that the cached information will not change for
+// now. When read/write access is implemented, writes will need to ensure that cached
+// data is properly refreshed and kept in sync.
 func (s *storageContainerReadWriterImpl) ensureKeyslotNames() error {
 	if s.keyslots != nil {
 		return nil
@@ -85,6 +94,16 @@ func (s *storageContainerReadWriterImpl) ensureKeyslotNames() error {
 	return nil
 }
 
+// ensureKeyslot ensures that the keyslot data for the keyslot with the specified name
+// is cached.
+// XXX: There is only read access for storage containers for now. Although there will
+// eventually be read/write access, snapd will continue to use the existing
+// [secboot.LUKS2KeyDataWriter] in the meantime. It is an error to modify the LUKS2
+// header with an open reader, and this package will ensure that a read/writer cannot
+// be opened whilst there are open readers when read/write access is supported.
+// Therefore, it is safe to assume that the cached information will not change for
+// now. When read/write access is implemented, writes will need to ensure that cached
+// data is properly refreshed and kept in sync.
 func (s *storageContainerReadWriterImpl) ensureKeyslot(ctx context.Context, name string) error {
 	if err := s.ensureKeyslotNames(); err != nil {
 		return err

--- a/luks2/reader.go
+++ b/luks2/reader.go
@@ -1,0 +1,192 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/secboot"
+)
+
+// storageContainerReadWriterImpl is the main implementation that backs
+// any StorageContainerReader and (eventually) StorageContainerReadWriter
+// interfaces.
+type storageContainerReadWriterImpl struct {
+	container *storageContainerImpl
+	keyslots  map[string]*keyslotInfoImpl
+}
+
+func (s *storageContainerReadWriterImpl) ensureKeyslotNames() error {
+	if s.keyslots != nil {
+		return nil
+	}
+
+	keyslots := make(map[string]*keyslotInfoImpl)
+
+	names, err := luks2Ops.ListUnlockKeyNames(s.container.Path())
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		keyslots[name] = &keyslotInfoImpl{
+			keyslotType: secboot.KeyslotTypePlatform,
+			keyslotName: name,
+		}
+	}
+
+	names, err = luks2Ops.ListRecoveryKeyNames(s.container.Path())
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		// The existing secboot API doesn't map keyslot names to LUKS2 keyslot
+		// IDs for recovery keyslots. We will eventually do that when this package
+		// natively supports LUKS2 rather than using the legacy secboot APIs.
+		keyslots[name] = &keyslotInfoImpl{
+			keyslotType: secboot.KeyslotTypeRecovery,
+			keyslotName: name,
+		}
+	}
+
+	s.keyslots = keyslots
+	return nil
+}
+
+func (s *storageContainerReadWriterImpl) Container() secboot.StorageContainer {
+	return s.container
+}
+
+func (s *storageContainerReadWriterImpl) Close() error {
+	// TODO: This does nothing for now but will eventually release a lock (see the
+	// comment in storageContainer.OpenRead).
+	return nil
+}
+
+func (s *storageContainerReadWriterImpl) ListKeyslotNames(ctx context.Context) ([]string, error) {
+	if err := s.ensureKeyslotNames(); err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for name := range s.keyslots {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names, nil
+}
+
+func (s *storageContainerReadWriterImpl) ReadKeyslot(ctx context.Context, name string) (secboot.KeyslotInfo, error) {
+	if err := s.ensureKeyslotNames(); err != nil {
+		return nil, err
+	}
+
+	info, exists := s.keyslots[name]
+	if !exists {
+		return nil, secboot.ErrKeyslotNotFound
+	}
+
+	switch info.keyslotType {
+	case secboot.KeyslotTypeRecovery:
+		// The existing secboot API doesn't expose the LUKS2 keyslot ID so we
+		// use the luksview package directly, via a bit of an abstraction so that
+		// it can be mocked in unit tests. This will all be cleaned up eventually
+		// once all of this functionality is implemented natively in this package.
+		view, err := newLuksView(ctx, s.container.Path())
+		if err != nil {
+			return nil, fmt.Errorf("cannot obtain new luksview.View: %w", err)
+		}
+		token, _, inUse := view.TokenByName(name)
+		if !inUse {
+			return nil, fmt.Errorf("no metadata for keyslot %q", name)
+		}
+		info.keyslotId = token.Keyslots()[0] // luksview guarantees there is always 1 keyslot here.
+	case secboot.KeyslotTypePlatform:
+		r, err := luks2Ops.NewKeyDataReader(s.container.Path(), name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot obtain reader for %q: %w", name, err)
+		}
+		info.keyslotId = r.KeyslotID()
+		info.keyslotPriority = r.Priority()
+		info.keyslotData = r
+	default:
+		panic("not reached")
+	}
+
+	return info, nil
+}
+
+// closedStorageContainerReadWriterImpl is an implementation of StorageContainerReader
+// and (eventually) StorageContainerReadWriter that just returns
+// secboot.ErrStorageContainerClosed for every method.
+type closedStorageContainerReadWriterImpl struct{}
+
+func (*closedStorageContainerReadWriterImpl) Container() secboot.StorageContainer {
+	return nil
+}
+
+func (*closedStorageContainerReadWriterImpl) Close() error {
+	return secboot.ErrStorageContainerClosed
+}
+
+func (*closedStorageContainerReadWriterImpl) ListKeyslotNames(_ context.Context) ([]string, error) {
+	return nil, secboot.ErrStorageContainerClosed
+}
+
+func (*closedStorageContainerReadWriterImpl) ReadKeyslot(_ context.Context, _ string) (secboot.KeyslotInfo, error) {
+	return nil, secboot.ErrStorageContainerClosed
+}
+
+// storageContainerReader is an implementation of [secboot.StorageContainerReader].
+type storageContainerReader struct {
+	// impl is an extra indirection that permits us to block access
+	// the real container after it's been closed and any associated
+	// lock has been released - it does this by having the io.Closer
+	// implementation swapping impl with an instance that returns a
+	// secboot.ErrStorageContainerClosed error for each method.
+	impl secboot.StorageContainerReader
+}
+
+// Container implements [secboot.StorageContainerReader.Container].
+func (s *storageContainerReader) Container() secboot.StorageContainer {
+	return s.impl.Container()
+}
+
+// Close implements [io.Closer].
+func (s *storageContainerReader) Close() error {
+	if err := s.impl.Close(); err != nil {
+		return err
+	}
+
+	s.impl = new(closedStorageContainerReadWriterImpl)
+	return nil
+}
+
+// ListKeyslotNames implements [secboot.StorageContainerReader.ListKeyslotNames].
+func (s *storageContainerReader) ListKeyslotNames(ctx context.Context) ([]string, error) {
+	return s.impl.ListKeyslotNames(ctx)
+}
+
+// ReadKeyslot implements [secboot.StorageContainerReader.ListKeyslotNames].
+func (s *storageContainerReader) ReadKeyslot(ctx context.Context, name string) (secboot.KeyslotInfo, error) {
+	return s.impl.ReadKeyslot(ctx, name)
+}

--- a/luks2/reader_test.go
+++ b/luks2/reader_test.go
@@ -247,20 +247,20 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatform(c *C) {
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default")
+	ks, err := r.ReadKeyslot(context.Background(), "default")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
-	c.Check(ki.Name(), Equals, "default")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ks.Name(), Equals, "default")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
-	data, err := io.ReadAll(ki.Data())
+	c.Check(ks.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ks.Data())
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 0)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentName(c *C) {
@@ -271,20 +271,20 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentName(c *C) 
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default-fallback")
+	ks, err := r.ReadKeyslot(context.Background(), "default-fallback")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
-	c.Check(ki.Name(), Equals, "default-fallback")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ks.Name(), Equals, "default-fallback")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default-fallback")
-	data, err := io.ReadAll(ki.Data())
+	c.Check(ks.Data().ReadableName(), Equals, "/dev/sda1:default-fallback")
+	data, err := io.ReadAll(ks.Data())
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 0)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentDevice(c *C) {
@@ -294,20 +294,20 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentDevice(c *C
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default")
+	ks, err := r.ReadKeyslot(context.Background(), "default")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
-	c.Check(ki.Name(), Equals, "default")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ks.Name(), Equals, "default")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data().ReadableName(), Equals, "/dev/nvme0n1p3:default")
-	data, err := io.ReadAll(ki.Data())
+	c.Check(ks.Data().ReadableName(), Equals, "/dev/nvme0n1p3:default")
+	data, err := io.ReadAll(ks.Data())
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 0)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotRecovery(c *C) {
@@ -318,17 +318,17 @@ func (s *readerSuite) TestContainerReaderReadKeyslotRecovery(c *C) {
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default-recovery")
+	ks, err := r.ReadKeyslot(context.Background(), "default-recovery")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypeRecovery)
-	c.Check(ki.Name(), Equals, "default-recovery")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypeRecovery)
+	c.Check(ks.Name(), Equals, "default-recovery")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data(), IsNil)
+	c.Check(ks.Data(), IsNil)
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 1)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryDifferentKeyslotID(c *C) {
@@ -339,17 +339,17 @@ func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryDifferentKeyslotID(c
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default-recovery")
+	ks, err := r.ReadKeyslot(context.Background(), "default-recovery")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypeRecovery)
-	c.Check(ki.Name(), Equals, "default-recovery")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypeRecovery)
+	c.Check(ks.Name(), Equals, "default-recovery")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data(), IsNil)
+	c.Check(ks.Data(), IsNil)
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 3)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 3)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentPriority(c *C) {
@@ -359,20 +359,20 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentPriority(c 
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default")
+	ks, err := r.ReadKeyslot(context.Background(), "default")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
-	c.Check(ki.Name(), Equals, "default")
-	c.Check(ki.Priority(), Equals, 2)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ks.Name(), Equals, "default")
+	c.Check(ks.Priority(), Equals, 2)
 
-	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
-	data, err := io.ReadAll(ki.Data())
+	c.Check(ks.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ks.Data())
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 0)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentKeyslotID(c *C) {
@@ -383,20 +383,20 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentKeyslotID(c
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default")
+	ks, err := r.ReadKeyslot(context.Background(), "default")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
-	c.Check(ki.Name(), Equals, "default")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ks.Name(), Equals, "default")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
-	data, err := io.ReadAll(ki.Data())
+	c.Check(ks.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ks.Data())
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 1)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentData(c *C) {
@@ -407,20 +407,20 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentData(c *C) 
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default")
+	ks, err := r.ReadKeyslot(context.Background(), "default")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
-	c.Check(ki.Name(), Equals, "default")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ks.Name(), Equals, "default")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
-	data, err := io.ReadAll(ki.Data())
+	c.Check(ks.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ks.Data())
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, []byte("dummy keyslot metadata2"))
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 0)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformCached(c *C) {
@@ -430,20 +430,20 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformCached(c *C) {
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default")
+	ks, err := r.ReadKeyslot(context.Background(), "default")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
-	c.Check(ki.Name(), Equals, "default")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ks.Name(), Equals, "default")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
-	data, err := io.ReadAll(ki.Data())
+	c.Check(ks.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ks.Data())
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 0)
 
 	restore := MockLUKS2Ops(&Luks2Api{
 		ListUnlockKeyNames: func(_ string) ([]string, error) {
@@ -461,9 +461,9 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformCached(c *C) {
 	})
 	defer restore()
 
-	ki2, err := r.ReadKeyslot(context.Background(), "default")
+	ks2, err := r.ReadKeyslot(context.Background(), "default")
 	c.Check(err, IsNil)
-	c.Check(ki2, Equals, ki)
+	c.Check(ks2, Equals, ks)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryCached(c *C) {
@@ -474,17 +474,17 @@ func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryCached(c *C) {
 	r, err := container.OpenRead(context.Background())
 	c.Assert(err, IsNil)
 
-	ki, err := r.ReadKeyslot(context.Background(), "default-recovery")
+	ks, err := r.ReadKeyslot(context.Background(), "default-recovery")
 	c.Assert(err, IsNil)
-	c.Check(ki.Type(), Equals, secboot.KeyslotTypeRecovery)
-	c.Check(ki.Name(), Equals, "default-recovery")
-	c.Check(ki.Priority(), Equals, 0)
+	c.Check(ks.Type(), Equals, secboot.KeyslotTypeRecovery)
+	c.Check(ks.Name(), Equals, "default-recovery")
+	c.Check(ks.Priority(), Equals, 0)
 
-	c.Check(ki.Data(), IsNil)
+	c.Check(ks.Data(), IsNil)
 
-	var tmpl KeyslotInfo
-	c.Assert(ki, Implements, &tmpl)
-	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
+	var tmpl Keyslot
+	c.Assert(ks, Implements, &tmpl)
+	c.Check(ks.(Keyslot).KeyslotID(), Equals, 1)
 
 	restore := MockLUKS2Ops(&Luks2Api{
 		ListUnlockKeyNames: func(_ string) ([]string, error) {
@@ -502,9 +502,9 @@ func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryCached(c *C) {
 	})
 	defer restore()
 
-	ki2, err := r.ReadKeyslot(context.Background(), "default-recovery")
+	ks2, err := r.ReadKeyslot(context.Background(), "default-recovery")
 	c.Check(err, IsNil)
-	c.Check(ki2, Equals, ki)
+	c.Check(ks2, Equals, ks)
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotNotFound(c *C) {

--- a/luks2/reader_test.go
+++ b/luks2/reader_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/snapcore/secboot"
 	internal_luks2 "github.com/snapcore/secboot/internal/luks2"
-	"github.com/snapcore/secboot/internal/testutil"
 	. "github.com/snapcore/secboot/luks2"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 	"golang.org/x/sys/unix"
@@ -262,8 +261,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatform(c *C) {
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentName(c *C) {
@@ -288,8 +285,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentName(c *C) 
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentDevice(c *C) {
@@ -313,8 +308,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentDevice(c *C
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotRecovery(c *C) {
@@ -336,8 +329,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotRecovery(c *C) {
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryDifferentKeyslotID(c *C) {
@@ -359,8 +350,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryDifferentKeyslotID(c
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 3)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentPriority(c *C) {
@@ -384,8 +373,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentPriority(c 
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentKeyslotID(c *C) {
@@ -410,8 +397,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentKeyslotID(c
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentData(c *C) {
@@ -436,8 +421,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentData(c *C) 
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 }
 
 func (s *readerSuite) TestContainerReaderReadKeyslotPlatformCached(c *C) {
@@ -461,8 +444,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotPlatformCached(c *C) {
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 
 	restore := MockLUKS2Ops(&Luks2Api{
 		ListUnlockKeyNames: func(_ string) ([]string, error) {
@@ -504,8 +485,6 @@ func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryCached(c *C) {
 	var tmpl KeyslotInfo
 	c.Assert(ki, Implements, &tmpl)
 	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
-
-	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
 
 	restore := MockLUKS2Ops(&Luks2Api{
 		ListUnlockKeyNames: func(_ string) ([]string, error) {

--- a/luks2/reader_test.go
+++ b/luks2/reader_test.go
@@ -1,0 +1,424 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/snapcore/secboot"
+	internal_luks2 "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/testutil"
+	. "github.com/snapcore/secboot/luks2"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+	"golang.org/x/sys/unix"
+	. "gopkg.in/check.v1"
+)
+
+type readerSuite struct {
+	snapd_testutil.BaseTest
+
+	containerData map[string]*mockContainerData
+}
+
+func (s *readerSuite) SetUpTest(c *C) {
+	restore := MockLUKS2Ops(&Luks2Api{
+		ListUnlockKeyNames:   s.listLUKS2ContainerUnlockKeyNames,
+		ListRecoveryKeyNames: s.listLUKS2ContainerRecoveryKeyNames,
+		NewKeyDataReader:     s.newLUKS2KeyDataReader,
+	})
+	s.AddCleanup(restore)
+
+	s.containerData = make(map[string]*mockContainerData)
+
+	restore = MockNewLuksView(func(ctx context.Context, path string) (LuksView, error) {
+		data, exists := s.containerData[path]
+		if !exists {
+			return nil, fmt.Errorf("error with binary header: %w", internal_luks2.ErrInvalidMagic)
+		}
+		return newMockLuksView(data), nil
+	})
+	s.AddCleanup(restore)
+}
+
+func (s *readerSuite) listLUKS2ContainerUnlockKeyNames(devicePath string) ([]string, error) {
+	data, exists := s.containerData[devicePath]
+	if !exists {
+		return nil, errors.New("unrecognized device path")
+	}
+
+	if data.listUnlockKeyNamesErr != nil {
+		return nil, data.listUnlockKeyNamesErr
+	}
+
+	var out []string
+	for name := range data.platformKeyslots {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *readerSuite) listLUKS2ContainerRecoveryKeyNames(devicePath string) ([]string, error) {
+	data, exists := s.containerData[devicePath]
+	if !exists {
+		return nil, errors.New("unrecognized device path")
+	}
+
+	if data.listRecoveryKeyNamesErr != nil {
+		return nil, data.listRecoveryKeyNamesErr
+	}
+
+	var out []string
+	for name := range data.recoveryKeyslots {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *readerSuite) newLUKS2KeyDataReader(devicePath, name string) (Luks2KeyDataReader, error) {
+	data, exists := s.containerData[devicePath]
+	if !exists {
+		return nil, errors.New("unrecognized device path")
+	}
+
+	r, exists := data.platformKeyslots[name]
+	if !exists {
+		return nil, errors.New("unrecognized platform keyslot name")
+	}
+
+	return r, nil
+}
+
+func (s *readerSuite) ensureContainerData(path string) {
+	if _, exists := s.containerData[path]; exists {
+		return
+	}
+
+	s.containerData[path] = newMockContainerData()
+}
+
+func (s *readerSuite) addRecoveryKeyslot(path, name string, slot int) {
+	s.ensureContainerData(path)
+	s.containerData[path].recoveryKeyslots[name] = slot
+}
+
+func (s *readerSuite) addUnlockKeyslot(path, name string, r Luks2KeyDataReader) {
+	s.ensureContainerData(path)
+	s.containerData[path].platformKeyslots[name] = r
+}
+
+var _ = Suite(&readerSuite{})
+
+func (s *readerSuite) TestContainerReaderContainer(c *C) {
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Check(r.Container(), Equals, container)
+}
+
+func (s *readerSuite) TestContainerReaderContainerClosed(c *C) {
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Assert(r.Close(), IsNil)
+
+	c.Check(r.Container(), IsNil)
+}
+
+func (s *readerSuite) TestContainerReaderClose(c *C) {
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Check(r.Close(), IsNil)
+	c.Check(r.Close(), Equals, secboot.ErrStorageContainerClosed)
+}
+
+func (s *readerSuite) TestContainerReaderListKeyslotNames(c *C) {
+	s.addRecoveryKeyslot("/dev/sda1", "default-recovery", 2)
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("", 0, 0, []byte("dummy keyslot metadata1")))
+	s.addUnlockKeyslot("/dev/sda1", "default-fallback", newMockLuks2KeyDataReader("", 1, 0, []byte("dummy keyslot metadata2")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	names, err := r.ListKeyslotNames(context.Background())
+	c.Check(err, IsNil)
+	c.Check(names, DeepEquals, []string{"default", "default-fallback", "default-recovery"})
+}
+
+func (s *readerSuite) TestContainerReaderListKeyslotNamesDifferentPath(c *C) {
+	s.addRecoveryKeyslot("/dev/nvme0n1p3", "default-recovery", 2)
+	s.addUnlockKeyslot("/dev/nvme0n1p3", "default", newMockLuks2KeyDataReader("", 0, 0, []byte("dummy keyslot metadata1")))
+	s.addUnlockKeyslot("/dev/nvme0n1p3", "default-fallback", newMockLuks2KeyDataReader("", 1, 0, []byte("dummy keyslot metadata2")))
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	names, err := r.ListKeyslotNames(context.Background())
+	c.Check(err, IsNil)
+	c.Check(names, DeepEquals, []string{"default", "default-fallback", "default-recovery"})
+}
+
+func (s *readerSuite) TestContainerReaderListKeyslotNamesDifferentNames(c *C) {
+	s.addRecoveryKeyslot("/dev/sda1", "recovery-1", 2)
+	s.addUnlockKeyslot("/dev/sda1", "normal-1", newMockLuks2KeyDataReader("", 0, 0, []byte("dummy keyslot metadata1")))
+	s.addUnlockKeyslot("/dev/sda1", "normal-2", newMockLuks2KeyDataReader("", 1, 0, []byte("dummy keyslot metadata2")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	names, err := r.ListKeyslotNames(context.Background())
+	c.Check(err, IsNil)
+	c.Check(names, DeepEquals, []string{"normal-1", "normal-2", "recovery-1"})
+}
+
+func (s *readerSuite) TestContainerReaderListKeyslotNamesClosed(c *C) {
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Assert(r.Close(), IsNil)
+
+	_, err = r.ListKeyslotNames(context.Background())
+	c.Check(err, Equals, secboot.ErrStorageContainerClosed)
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotPlatform(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default", 0, 0, []byte("dummy keyslot metadata1")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ki.Name(), Equals, "default")
+	c.Check(ki.Priority(), Equals, 0)
+
+	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ki.Data())
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentName(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default-fallback", newMockLuks2KeyDataReader("/dev/sda1:default-fallback", 0, 0, []byte("dummy keyslot metadata1")))
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default-", 1, 0, []byte("dummy keyslot metadata2")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default-fallback")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ki.Name(), Equals, "default-fallback")
+	c.Check(ki.Priority(), Equals, 0)
+
+	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default-fallback")
+	data, err := io.ReadAll(ki.Data())
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentDevice(c *C) {
+	s.addUnlockKeyslot("/dev/nvme0n1p3", "default", newMockLuks2KeyDataReader("/dev/nvme0n1p3:default", 0, 0, []byte("dummy keyslot metadata1")))
+
+	container := NewStorageContainer("/dev/nvme0n1p3", unix.Mkdev(259, 3))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ki.Name(), Equals, "default")
+	c.Check(ki.Priority(), Equals, 0)
+
+	c.Check(ki.Data().ReadableName(), Equals, "/dev/nvme0n1p3:default")
+	data, err := io.ReadAll(ki.Data())
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotRecovery(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default", 0, 0, []byte("dummy keyslot metadata1")))
+	s.addRecoveryKeyslot("/dev/sda1", "default-recovery", 1)
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default-recovery")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypeRecovery)
+	c.Check(ki.Name(), Equals, "default-recovery")
+	c.Check(ki.Priority(), Equals, 0)
+
+	c.Check(ki.Data(), IsNil)
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotRecoveryDifferentKeyslotID(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default", 0, 0, []byte("dummy keyslot metadata1")))
+	s.addRecoveryKeyslot("/dev/sda1", "default-recovery", 3)
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default-recovery")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypeRecovery)
+	c.Check(ki.Name(), Equals, "default-recovery")
+	c.Check(ki.Priority(), Equals, 0)
+
+	c.Check(ki.Data(), IsNil)
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 3)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentPriority(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default", 0, 2, []byte("dummy keyslot metadata1")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ki.Name(), Equals, "default")
+	c.Check(ki.Priority(), Equals, 2)
+
+	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ki.Data())
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentKeyslotID(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default", 1, 0, []byte("dummy keyslot metadata1")))
+	s.addUnlockKeyslot("/dev/sda1", "default-fallback", newMockLuks2KeyDataReader("/dev/sda1:default", 0, 0, []byte("dummy keyslot metadata2")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ki.Name(), Equals, "default")
+	c.Check(ki.Priority(), Equals, 0)
+
+	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ki.Data())
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, []byte("dummy keyslot metadata1"))
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 1)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotPlatformDifferentData(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default-fallback", newMockLuks2KeyDataReader("/dev/sda1:default-fallback", 1, 0, []byte("dummy keyslot metadata1")))
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default", 0, 0, []byte("dummy keyslot metadata2")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	ki, err := r.ReadKeyslot(context.Background(), "default")
+	c.Assert(err, IsNil)
+	c.Check(ki.Type(), Equals, secboot.KeyslotTypePlatform)
+	c.Check(ki.Name(), Equals, "default")
+	c.Check(ki.Priority(), Equals, 0)
+
+	c.Check(ki.Data().ReadableName(), Equals, "/dev/sda1:default")
+	data, err := io.ReadAll(ki.Data())
+	c.Check(err, IsNil)
+	c.Check(data, DeepEquals, []byte("dummy keyslot metadata2"))
+
+	var tmpl KeyslotInfo
+	c.Assert(ki, Implements, &tmpl)
+	c.Check(ki.(KeyslotInfo).KeyslotID(), Equals, 0)
+
+	c.Check(ki, testutil.ConvertibleTo, &KeyslotInfoImpl{})
+}
+
+func (s *readerSuite) TestContainerReaderReadKeyslotClosed(c *C) {
+	s.addUnlockKeyslot("/dev/sda1", "default", newMockLuks2KeyDataReader("/dev/sda1:default", 0, 0, []byte("dummy keyslot metadata1")))
+
+	container := NewStorageContainer("/dev/sda1", unix.Mkdev(8, 1))
+	r, err := container.OpenRead(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Assert(r.Close(), IsNil)
+
+	_, err = r.ReadKeyslot(context.Background(), "default")
+	c.Check(err, Equals, secboot.ErrStorageContainerClosed)
+}

--- a/storage.go
+++ b/storage.go
@@ -29,14 +29,15 @@ import (
 // container.
 type StorageContainerBackend interface {
 	// Probe returns a StorageContainer instance for the supplied
-	// path if it can be handled by this backend, else it returns
-	// (nil, nil).
+	// path to a storage container source if it can be handled by this
+	// backend, else it returns (nil, nil).
 	//
 	// Implementations should always return the same StorageContainer
 	// instance for the same container referenced by the supplied path -
 	// the implementation should at least handle the cases of symbolic
-	// links and maybe any other cases where the supplied path has some
-	// indirect relationship to a storage container.
+	// links. It should also be the same instance as the one returned
+	// via the ProbeActivated method with a path to the corresponding
+	// activate storage container.
 	//
 	// Implementations of this must be safe to call from any goroutine.
 	//
@@ -44,6 +45,26 @@ type StorageContainerBackend interface {
 	// depending on how the backend works - there may be backends in the
 	// future that don't use block devices for storage containers.
 	Probe(ctx context.Context, path string) (StorageContainer, error)
+
+	// ProbeActivated returns a StorageContainer instance for the
+	// supplied path to an activated storage container if it can be
+	// handled by this backend, else it returns (nil, nil). An activated
+	// storage container is one that is backed by some source that can
+	// be returned via the Probe method using the path to the source
+	// instead.
+	//
+	// Implementations should always return the same StorageContainer
+	// instance for the same container referenced by the supplied path -
+	// the implementation should at least handle the cases of symbolic
+	// links. It should also be the same instance as the one returned
+	// via the Probe method with the corresponding source path.
+	//
+	// Implementations of this must be safe to call from any goroutine.
+	//
+	// The supplied path may or may not be a path to a block device,
+	// depending on how the backend works - there may be backends in the
+	// future that don't use block devices for storage containers.
+	ProbeActivated(ctx context.Context, path string) (StorageContainer, error)
 }
 
 var (

--- a/storage_test.go
+++ b/storage_test.go
@@ -47,7 +47,7 @@ func (c *mockStorageContainer) BackendName() string {
 	return mockStorageContainerType
 }
 
-func (c *mockStorageContainer) Activate(ctx context.Context, keyslotInfo KeyslotInfo, key []byte, opts ...ActivateOption) error {
+func (c *mockStorageContainer) Activate(ctx context.Context, keyslot Keyslot, key []byte, opts ...ActivateOption) error {
 	return errors.New("not supported")
 }
 


### PR DESCRIPTION
This provides an initial LUKS2 implementation of
`StorageContainerBackend`, with read-only, activate and deactivate support
for now, and the initial implementation largely just wrapping around the
existing secboot APIs.

Plans for the future for this package:
- Adding an implementation of `StorageContainerReadWriter` once it's
  defined in secboot.
- Introduction of locking to serialize access to implementations of
  `StorageContainerReader` and `StorageContainerReadWriter`.
- Moving LUKS2 functionality from the code secboot package and
  `internal/luksview` into this package, and deleting the existing code.