### PR TITLE
preinstall: Fix PR412 on go1.18

### DIFF
--- a/efi/preinstall/checks.go
+++ b/efi/preinstall/checks.go
@@ -313,9 +313,9 @@ func RunChecks(ctx context.Context, flags CheckFlags, loadedImages []secboot_efi
 				return nil, &HostSecurityError{err}
 			}
 			for _, e := range ce.Unwrap() {
-				if errors.Is(err, ErrInsufficientDMAProtection) && flags&PermitInsufficientDMAProtection > 0 {
+				if errors.Is(e, ErrInsufficientDMAProtection) && flags&PermitInsufficientDMAProtection > 0 {
 					result.Flags |= InsufficientDMAProtectionDetected
-				} else if errors.Is(err, ErrNoKernelIOMMU) && flags&PermitInsufficientDMAProtection > 0 {
+				} else if errors.Is(e, ErrNoKernelIOMMU) && flags&PermitInsufficientDMAProtection > 0 {
 					warnings = append(warnings, err)
 				} else {
 					deferredErrs = append(deferredErrs, &HostSecurityError{e})


### PR DESCRIPTION
I landed PR412 without noticing that the tests are failing on go 1.18,
but passing with a newer go. It looks like it's because the test of each
error value returned from `checkHostSecurity` is being performed on the
wrong error value - it works with newer go versions because it has
native support for `[]error` with `errors.Is`.