### PR TITLE
preinstall: Add ActionProceed action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ./run_argon2
+./test_efi_fde_compat
 vendor/*/

--- a/cmd/test_efi_fde_compat/main.go
+++ b/cmd/test_efi_fde_compat/main.go
@@ -35,6 +35,8 @@ type options struct {
 		NoDiscreteTPMResetMitigation   bool `long:"no-discrete-tpm-reset-mitigation" description:"Disable mitigations against discrete TPM reset attacks where appropriate"`
 	} `group:"PCR profile options"`
 
+	Action preinstall.Action `long:"action" description:"What action to run"`
+
 	Positional struct {
 		BootImages []string `positional-arg-name:"ordered paths to the EFI boot components for the current boot"`
 	} `positional-args:"true"`
@@ -118,7 +120,13 @@ func run() error {
 
 	ctx := preinstall.NewRunChecksContext(checkFlags, bootImages, pcrFlags)
 	result, err := ctx.Run(context.Background(), preinstall.ActionNone)
-	if err != nil {
+	switch {
+	case err != nil && opts.Action != preinstall.ActionNone:
+		result, err = ctx.Run(context.Background(), opts.Action)
+		if err != nil {
+			return err
+		}
+	case err != nil:
 		return err
 	}
 

--- a/cmd/test_efi_fde_compat/main.go
+++ b/cmd/test_efi_fde_compat/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+	secboot_efi "github.com/snapcore/secboot/efi"
+	"github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/snapd/snap/snapdir"
+	"github.com/snapcore/snapd/snap/squashfs"
+)
+
+type options struct {
+	Check struct {
+		PostInstall                         bool `long:"post-install" description:"Run the checks post-install rather than pre-install"`
+		PermitVM                            bool `long:"permit-vm" description:"Permit running inside of a virtual machine"`
+		PermitWeakPCRBanks                  bool `long:"permit-weak-pcr-banks" description:"Permit selecting a weak PCR bank if no others are available"`
+		PermitEmptyPCRBanks                 bool `long:"permit-empty-pcr-banks" description:"Allow the platform firmware to leave one or more PCR banks empty. This potentially compromises remote attestation"`
+		PermitNoDiscreteTPMResetMitigation  bool `long:"permit-no-discrete-tpm-reset-mitigation" description:"Permit not enabling a mitigation for reset attacks against discrete TPM devices. The mitigation prevents replaying PCR values from software"`
+		PermitVARSuppliedDrivers            bool `long:"permit-var-supplied-drivers" description:"Allow value-added-retailer supplied drivers to be running. This increases fragility of profiles that include PCR2, and potentially PCR7"`
+		PermitSysPrepApplications           bool `long:"permit-sys-prep-apps" description:"Allow system preparation applications to load before the OS. This increases fragility of profiles that include PCR4, and potentially PCR7"`
+		PermitAbsolute                      bool `long:"permit-absolute" description:"Allow the Absolute endpoint management component to be running. This increases fragility of profiles that include PCR4"`
+		PermitWeakSecureBootAlgorithms      bool `long:"permit-weak-secure-boot-algs" description:"Permit secure boot verification using weak algorithms"`
+		PermitPreOSVerificationUsingDigests bool `long:"permit-preos-verification-using-digests" description:"Allow pre-OS components to be verified by including a digest in db. This increases fragility of profiles that include PCR7"`
+	} `group:"Initial check options"`
+
+	Profile struct {
+		MostSecure                     bool `long:"most-secure" description:"Select the most secure PCR profile"`
+		TrustCAsForBootCode            bool `long:"trust-authorities-for-boot-code" description:"Trust the secure boot CAs used to authenticate code on this system to authenticate any boot code (definitely not advisable for the Microsoft UEFI CA)"`
+		TrustCAsForVARSuppliedDrivers  bool `long:"trust-authorities-for-var-supplied-drivers" description:"Trust the secure boot CAs used to authenticate code on this system to authenticate any value-added-retailer supplied firmware driver (most likely not advisable for the Microsoft UEFI CA)"`
+		DistrustVARSuppliedNonHostCode bool `long:"distrust-var-supplied-nonhost-code" description:"Distrust code running in value-added-retailer supplied embedded controllers. This code doesn't run on the CPU and isn't part of the trust chain, but can potentially still affect trust"`
+		PermitNoSecureBoot             bool `long:"permit-no-secure-boot" description:"Permit profiles that don't include the secure boot policy"`
+		NoDiscreteTPMResetMitigation   bool `long:"no-discrete-tpm-reset-mitigation" description:"Disable mitigations against discrete TPM reset attacks where appropriate"`
+	} `group:"PCR profile options"`
+
+	Positional struct {
+		BootImages []string `positional-arg-name:"ordered paths to the EFI boot components for the current boot"`
+	} `positional-args:"true"`
+}
+
+var opts options
+
+func run() error {
+	if _, err := flags.Parse(&opts); err != nil {
+		return err
+	}
+
+	var checkFlags preinstall.CheckFlags
+	if opts.Check.PostInstall {
+		checkFlags |= preinstall.PostInstallChecks
+	}
+	if opts.Check.PermitVM {
+		checkFlags |= preinstall.PermitVirtualMachine
+	}
+	if opts.Check.PermitWeakPCRBanks {
+		checkFlags |= preinstall.PermitWeakPCRBanks
+	}
+	if opts.Check.PermitEmptyPCRBanks {
+		checkFlags |= preinstall.PermitEmptyPCRBanks
+	}
+	if opts.Check.PermitNoDiscreteTPMResetMitigation {
+		checkFlags |= preinstall.PermitNoDiscreteTPMResetMitigation
+	}
+	if opts.Check.PermitVARSuppliedDrivers {
+		checkFlags |= preinstall.PermitVARSuppliedDrivers
+	}
+	if opts.Check.PermitSysPrepApplications {
+		checkFlags |= preinstall.PermitSysPrepApplications
+	}
+	if opts.Check.PermitAbsolute {
+		checkFlags |= preinstall.PermitAbsoluteComputrace
+	}
+	if opts.Check.PermitWeakSecureBootAlgorithms {
+		checkFlags |= preinstall.PermitWeakSecureBootAlgorithms
+	}
+	if opts.Check.PermitPreOSVerificationUsingDigests {
+		checkFlags |= preinstall.PermitPreOSVerificationUsingDigests
+	}
+
+	var bootImages []secboot_efi.Image
+	for _, img := range opts.Positional.BootImages {
+		var snapPath string
+		var filePath string
+		if n, err := fmt.Sscanf("squashfs:%s(%s)", img, &snapPath, &filePath); err == nil && n == 2 {
+			container := squashfs.New(snapPath)
+			bootImages = append(bootImages, secboot_efi.NewSnapFileImage(container, filePath))
+		} else if n, err := fmt.Sscanf("snapdir:%s(%s)", img, &snapPath, filePath); err == nil && n == 2 {
+			container := snapdir.New(snapPath)
+			bootImages = append(bootImages, secboot_efi.NewSnapFileImage(container, filePath))
+		} else {
+			bootImages = append(bootImages, secboot_efi.NewFileImage(img))
+		}
+	}
+
+	var pcrFlags preinstall.PCRProfileOptionsFlags
+	if opts.Profile.MostSecure {
+		pcrFlags |= preinstall.PCRProfileOptionMostSecure
+	}
+	if opts.Profile.TrustCAsForBootCode {
+		pcrFlags |= preinstall.PCRProfileOptionTrustCAsForBootCode
+	}
+	if opts.Profile.TrustCAsForVARSuppliedDrivers {
+		pcrFlags |= preinstall.PCRProfileOptionTrustCAsForVARSuppliedDrivers
+	}
+	if opts.Profile.DistrustVARSuppliedNonHostCode {
+		pcrFlags |= preinstall.PCRProfileOptionDistrustVARSuppliedNonHostCode
+	}
+	if opts.Profile.PermitNoSecureBoot {
+		pcrFlags |= preinstall.PCRProfileOptionPermitNoSecureBootPolicyProfile
+	}
+	if opts.Profile.NoDiscreteTPMResetMitigation {
+		pcrFlags |= preinstall.PCRProfileOptionNoDiscreteTPMResetMitigation
+	}
+
+	fmt.Println("Testing this platform for compatibility with EFI based TPM protected FDE")
+
+	ctx := preinstall.NewRunChecksContext(checkFlags, bootImages, pcrFlags)
+	result, err := ctx.Run(context.Background(), preinstall.ActionNone)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%v\n", result)
+
+	profile := preinstall.WithAutoTCGPCRProfile(result, pcrFlags)
+	pcrs, err := profile.PCRs()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("Selected TCG PCRs:", pcrs)
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		switch e := err.(type) {
+		case *flags.Error:
+			// flags already prints this
+			if e.Type != flags.ErrHelp {
+				os.Exit(1)
+			}
+		default:
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "This platform is not suitable for FDE:", err)
+		}
+	}
+}

--- a/efi/preinstall/actions.go
+++ b/efi/preinstall/actions.go
@@ -65,6 +65,21 @@ const (
 	// because of a bug in the OS. It is a pseudo-action and cannnot be performed
 	// by this package.
 	ActionContactOSVendor Action = "contact-os-vendor"
+
+	// ActionEnableTPMViaFirmware tells RunChecksContext.Run to enable the TPM
+	// via the physical presence interface. If successful, this action will
+	// respond with ErrorKindShutdown or ErrorKindReboot.
+	ActionEnableTPMViaFirmware Action = "enable-tpm-via-firmware"
+
+	// ActionEnableAndClearTPMViaFirmware tells RunChecksContext.Run to enable
+	// and clear the TPM via the physical presence interface. If successful, this
+	// action will respond with ErrorKindShutdown or ErrorKindReboot.
+	ActionEnableAndClearTPMViaFirmware Action = "enable-and-clear-tpm-via-firmware"
+
+	// ActionClearTPMViaFirmware tells RunChecksContext.Run to clear the TPM
+	// via the physical presence interface. If successful, this action will
+	// respond with ErrorKindShutdown or ErrorKindReboot.
+	ActionClearTPMViaFirmware Action = "clear-tpm-via-firmware"
 )
 
 // IsExternalAction will return true if the action cannot actually be executed by

--- a/efi/preinstall/actions.go
+++ b/efi/preinstall/actions.go
@@ -80,6 +80,18 @@ const (
 	// via the physical presence interface. If successful, this action will
 	// respond with ErrorKindShutdown or ErrorKindReboot.
 	ActionClearTPMViaFirmware Action = "clear-tpm-via-firmware"
+
+	// ActionProceed tells RunChecksContext.Run to turn on the appropriate
+	// CheckFlags so that the corresponding error is ignored. If multiple errors
+	// are returned with this action in a single call, then calling
+	// RunChecksContext.Run with it will result in all of those errors being
+	// ignored. This provides the user with an opportunity to evaluate and
+	// accept any risk associated with ignoring the returned errors, before
+	// proceeding.
+	//
+	// Some errors that support this action may also still support other actions
+	// that offer a way to rectify the error.
+	ActionProceed Action = "proceed"
 )
 
 // IsExternalAction will return true if the action cannot actually be executed by

--- a/efi/preinstall/actions_ppi.go
+++ b/efi/preinstall/actions_ppi.go
@@ -1,0 +1,183 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/ppi"
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+var (
+	obtainTPMDevicePPI = obtainTPMDevicePPIFallback
+)
+
+func obtainTPMDevicePPIFallback(dev tpm2.TPMDevice) (ppi.PPI, error) {
+	return nil, errors.New("physical presence interface not supported")
+}
+
+// runPPIAction submits the PPI operation associated with the supplied action
+// to the platform firmware. On success, the state transition action is returned,
+// which tells the caller how to transition back to the platform firmware in
+// order to process the submitted operation.
+func runPPIAction(env internal_efi.HostEnvironment, action Action) (ppi.StateTransitionAction, error) {
+	dev, err := env.TPMDevice()
+	if err != nil {
+		return 0, err
+	}
+	p, err := obtainTPMDevicePPI(dev)
+	if err != nil {
+		return 0, fmt.Errorf("cannot obtain physical presence interface: %w", err)
+	}
+	if p == nil {
+		return 0, ppi.ErrOperationUnsupported
+	}
+
+	switch action {
+	case ActionEnableTPMViaFirmware:
+		if err := p.EnableTPM(); err != nil {
+			return 0, fmt.Errorf("cannot submit request to enable the TPM: %w", err)
+		}
+	case ActionEnableAndClearTPMViaFirmware:
+		if err := p.EnableAndClearTPM(); err != nil {
+			return 0, fmt.Errorf("cannot submit request to enable and clear the TPM: %w", err)
+		}
+	case ActionClearTPMViaFirmware:
+		if err := p.ClearTPM(); err != nil {
+			return 0, fmt.Errorf("cannot submit request to clear the TPM: %w", err)
+		}
+	default:
+		return 0, fmt.Errorf("invalid PPI action %q", action)
+	}
+
+	sta, err := p.StateTransitionAction()
+	if err != nil {
+		return 0, fmt.Errorf("cannot obtain action required to transition to pre-OS environment: %w", err)
+	}
+	switch sta {
+	case ppi.StateTransitionShutdownRequired:
+		// ok
+	case ppi.StateTransitionRebootRequired:
+		// ok
+	default:
+		return 0, fmt.Errorf("unsupported state transition action %q", sta)
+	}
+	return sta, nil
+}
+
+// isPPIActionAvailable checks whether the PPI operation associated with the supplied
+// action is avaiable. An action is considered to be available regardless of whether
+// physical presence is required or not. An operation may be unavailable either because
+// it ins't implemented, it is a firmware only operation, or it is currently blocked
+// because of the firmware settings.
+func isPPIActionAvailable(env internal_efi.HostEnvironment, action Action) (bool, error) {
+	dev, err := env.TPMDevice()
+	if err != nil {
+		return false, err
+	}
+	p, err := obtainTPMDevicePPI(dev)
+	if err != nil {
+		return false, fmt.Errorf("cannot obtain physical presence interface: %w", err)
+	}
+	if p == nil {
+		return false, nil
+	}
+
+	var operation ppi.OperationId
+	switch action {
+	case ActionEnableTPMViaFirmware:
+		operation = ppi.OperationEnableTPM
+	case ActionEnableAndClearTPMViaFirmware:
+		operation = ppi.OperationEnableAndClearTPM
+	case ActionClearTPMViaFirmware:
+		operation = ppi.OperationClearTPM
+	default:
+		return false, errors.New("invalid PPI action")
+	}
+
+	status, err := p.OperationStatus(operation)
+	if err != nil {
+		return false, fmt.Errorf("cannot obtain operation status for action: %w", err)
+	}
+	switch status {
+	case ppi.OperationPPRequired, ppi.OperationPPNotRequired:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// pendingPPIAction determines if there is a pending PPI operation. If there is, and
+// the operation has a corresponding Action, then that action is returned along with
+// the state transition action, which tells the caller how to transition back to the
+// platform firmware in order to process the submitted operation.
+// If there is no pending PPI operation, or it doesn't have a corresponding action,
+// then ActionNone is returned.
+//
+// XXX(chrisccoulson): This currently only returns ActionNone because ppi.PPI does
+// not provide a way to determine if there is a pending PPI operation. It will
+// require an update to go-tpm2.
+func pendingPPIAction(env internal_efi.HostEnvironment) (Action, ppi.StateTransitionAction, error) {
+	dev, err := env.TPMDevice()
+	if err != nil {
+		return ActionNone, 0, err
+	}
+	p, err := obtainTPMDevicePPI(dev)
+	if err != nil {
+		return ActionNone, 0, fmt.Errorf("cannot obtain physical presence interface: %w", err)
+	}
+	if p == nil {
+		return ActionNone, 0, nil
+	}
+
+	sta, err := p.StateTransitionAction()
+	if err != nil {
+		return ActionNone, 0, fmt.Errorf("cannot obtain action required to transition to pre-OS environment: %w", err)
+	}
+	switch sta {
+	case ppi.StateTransitionShutdownRequired:
+		// ok
+	case ppi.StateTransitionRebootRequired:
+		// ok
+	default:
+		return ActionNone, 0, fmt.Errorf("unsupported state transition action %q", sta)
+	}
+	// TODO(chrisccoulson): Actually implement this once we can obtain the
+	// pending operation from the ppi.PPI instance. For now, assume that
+	// there is no pending operation, which is the most benign case.
+	op := ppi.NoOperation
+
+	switch op {
+	case ppi.NoOperation:
+		return ActionNone, 0, nil
+	case ppi.OperationEnableTPM:
+		return ActionEnableTPMViaFirmware, sta, nil
+	case ppi.OperationEnableAndClearTPM:
+		return ActionEnableAndClearTPMViaFirmware, sta, nil
+	case ppi.OperationClearTPM:
+		return ActionClearTPMViaFirmware, sta, nil
+	default:
+		// not submiited from this package
+		return ActionNone, 0, nil
+	}
+}

--- a/efi/preinstall/actions_ppi_linux.go
+++ b/efi/preinstall/actions_ppi_linux.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"errors"
+
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/linux"
+	"github.com/canonical/go-tpm2/ppi"
+)
+
+func init() {
+	obtainTPMDevicePPI = obtainTPMDevicePPILinux
+}
+
+var (
+	linuxRawDevicePhysicalPresenceInterface = (*linux.RawDevice).PhysicalPresenceInterface
+	linuxRMDeviceRawDevice                  = (*linux.RMDevice).RawDevice
+)
+
+func obtainTPMDevicePPILinux(dev tpm2.TPMDevice) (ppi.PPI, error) {
+	var ppi ppi.PPI
+	var err error
+	switch d := dev.(type) {
+	case *linux.RawDevice:
+		ppi, err = linuxRawDevicePhysicalPresenceInterface(d)
+	case *linux.RMDevice:
+		ppi, err = linuxRawDevicePhysicalPresenceInterface(linuxRMDeviceRawDevice(d))
+	default:
+		return nil, errors.New("not a linux tpm2.TPMDevice")
+	}
+
+	switch {
+	case errors.Is(err, linux.ErrNoPhysicalPresenceInterface):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	default:
+		return ppi, nil
+	}
+}

--- a/efi/preinstall/actions_ppi_linux_test.go
+++ b/efi/preinstall/actions_ppi_linux_test.go
@@ -1,0 +1,129 @@
+//go:build linux
+
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	"errors"
+
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/linux"
+	"github.com/canonical/go-tpm2/ppi"
+	. "github.com/snapcore/secboot/efi/preinstall"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type actionsPpiLinuxSuite struct {
+	snapd_testutil.BaseTest
+
+	rmToRawMap  map[*linux.RMDevice]*linux.RawDevice
+	rawToPPIMap map[*linux.RawDevice]ppi.PPI
+	ppiErr      error
+}
+
+func (s *actionsPpiLinuxSuite) SetUpTest(c *C) {
+	s.rmToRawMap = make(map[*linux.RMDevice]*linux.RawDevice)
+	s.rawToPPIMap = make(map[*linux.RawDevice]ppi.PPI)
+	s.ppiErr = nil
+
+	restore := MockLinuxRawDevicePhysicalPresenceInterface(func(d *linux.RawDevice) (ppi.PPI, error) {
+		if s.ppiErr != nil {
+			return nil, s.ppiErr
+		}
+		p, exists := s.rawToPPIMap[d]
+		if !exists {
+			return nil, linux.ErrNoPhysicalPresenceInterface
+		}
+		return p, nil
+	})
+	s.AddCleanup(restore)
+
+	restore = MockLinuxRMDeviceRawDevice(func(d *linux.RMDevice) *linux.RawDevice {
+		return s.rmToRawMap[d]
+	})
+	s.AddCleanup(restore)
+}
+
+var _ = Suite(&actionsPpiLinuxSuite{})
+
+func (s *actionsPpiLinuxSuite) TestObtainTPMDevicePPILinuxRawDevice(c *C) {
+	expectedPPI := new(mockPPI)
+	dev := new(linux.RawDevice)
+	s.rawToPPIMap[dev] = expectedPPI
+
+	p, err := ObtainTPMDevicePPILinux(dev)
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, expectedPPI)
+}
+
+func (s *actionsPpiLinuxSuite) TestObtainTPMDevicePPILinuxRMDevice(c *C) {
+	expectedPPI := new(mockPPI)
+	rawDev := new(linux.RawDevice)
+	s.rawToPPIMap[rawDev] = expectedPPI
+
+	dev := new(linux.RMDevice)
+	s.rmToRawMap[dev] = rawDev
+
+	p, err := ObtainTPMDevicePPILinux(dev)
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, expectedPPI)
+}
+
+func (s *actionsPpiLinuxSuite) TestObtainTPMDevicePPILinuxInvalidDevice(c *C) {
+	expectedPPI := new(mockPPI)
+	dev := new(linux.RawDevice)
+	s.rawToPPIMap[dev] = expectedPPI
+
+	_, err := ObtainTPMDevicePPILinux(tpm2.TPMDevice(nil))
+	c.Assert(err, ErrorMatches, `not a linux tpm2.TPMDevice`)
+}
+
+func (s *actionsPpiLinuxSuite) TestObtainTPMDevicePPILinuxRawDeviceNoPPI(c *C) {
+	p, err := ObtainTPMDevicePPILinux(new(linux.RawDevice))
+	c.Check(err, IsNil)
+	c.Check(p, IsNil)
+}
+
+func (s *actionsPpiLinuxSuite) TestObtainTPMDevicePPILinuxRMDeviceNoPPI(c *C) {
+	dev := new(linux.RMDevice)
+	s.rmToRawMap[dev] = new(linux.RawDevice)
+
+	p, err := ObtainTPMDevicePPILinux(dev)
+	c.Check(err, IsNil)
+	c.Check(p, IsNil)
+}
+
+func (s *actionsPpiLinuxSuite) TestObtainTPMDevicePPILinuxRawDeviceErr(c *C) {
+	s.ppiErr = errors.New("some error")
+
+	_, err := ObtainTPMDevicePPILinux(new(linux.RawDevice))
+	c.Check(err, ErrorMatches, `some error`)
+}
+
+func (s *actionsPpiLinuxSuite) TestObtainTPMDevicePPILinuxRMDeviceErr(c *C) {
+	dev := new(linux.RMDevice)
+	s.rmToRawMap[dev] = new(linux.RawDevice)
+	s.ppiErr = errors.New("some error")
+
+	_, err := ObtainTPMDevicePPILinux(dev)
+	c.Check(err, ErrorMatches, `some error`)
+}

--- a/efi/preinstall/actions_ppi_test.go
+++ b/efi/preinstall/actions_ppi_test.go
@@ -1,0 +1,306 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	"errors"
+
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/ppi"
+	. "github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/secboot/internal/efitest"
+	"github.com/snapcore/secboot/internal/testutil"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type mockPPI struct {
+	sta    ppi.StateTransitionAction
+	ops    map[ppi.OperationId]ppi.OperationStatus
+	called []string
+}
+
+func (*mockPPI) Type() ppi.Type {
+	return ppi.ACPI
+}
+
+func (*mockPPI) Version() ppi.Version {
+	return ppi.Version13
+}
+
+func (p *mockPPI) StateTransitionAction() (ppi.StateTransitionAction, error) {
+	return p.sta, nil
+}
+
+func (p *mockPPI) OperationStatus(op ppi.OperationId) (ppi.OperationStatus, error) {
+	s, exists := p.ops[op]
+	if !exists {
+		return ppi.OperationNotImplemented, nil
+	}
+	return s, nil
+}
+
+func (p *mockPPI) EnableTPM() error {
+	p.called = append(p.called, "EnableTPM()")
+	return nil
+}
+
+func (*mockPPI) DisableTPM() error {
+	return ppi.ErrOperationUnsupported
+}
+
+func (p *mockPPI) ClearTPM() error {
+	p.called = append(p.called, "ClearTPM()")
+	return nil
+}
+
+func (p *mockPPI) EnableAndClearTPM() error {
+	p.called = append(p.called, "EnableAndClearTPM()")
+	return nil
+}
+
+func (*mockPPI) SetPCRBanks(algs ...tpm2.HashAlgorithmId) error {
+	return ppi.ErrOperationUnsupported
+}
+
+func (*mockPPI) ChangeEPS() error {
+	return ppi.ErrOperationUnsupported
+}
+
+func (*mockPPI) LogAllDigests() error {
+	return ppi.ErrOperationUnsupported
+}
+
+func (*mockPPI) DisableEndorsementAndEnableStorageHierarchy() error {
+	return ppi.ErrOperationUnsupported
+}
+
+func (*mockPPI) SetPPRequiredForOperation(op ppi.OperationId) error {
+	return ppi.ErrOperationUnsupported
+}
+
+func (*mockPPI) ClearPPRequiredForOperation(op ppi.OperationId) error {
+	return ppi.ErrOperationUnsupported
+}
+
+func (*mockPPI) OperationResponse() (*ppi.OperationResponse, error) {
+	return nil, nil
+}
+
+type mockTpm2Device struct {
+	_ byte
+}
+
+func (*mockTpm2Device) Open() (tpm2.Transport, error) {
+	return nil, errors.New("not supported")
+}
+
+func (*mockTpm2Device) String() string {
+	return "mock TPM2 device"
+}
+
+type actionsPpiSuite struct {
+	snapd_testutil.BaseTest
+
+	devToPPIMap map[tpm2.TPMDevice]ppi.PPI
+	ppiErr      error
+}
+
+func (s *actionsPpiSuite) SetUpTest(c *C) {
+	s.devToPPIMap = make(map[tpm2.TPMDevice]ppi.PPI)
+	s.ppiErr = nil
+
+	restore := MockObtainTPMDevicePPI(func(dev tpm2.TPMDevice) (ppi.PPI, error) {
+		if s.ppiErr != nil {
+			return nil, s.ppiErr
+		}
+		return s.devToPPIMap[dev], nil
+	})
+	s.AddCleanup(restore)
+}
+
+var _ = Suite(&actionsPpiSuite{})
+
+func (s *actionsPpiSuite) TestRunPPIActionEnableTPM(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{sta: ppi.StateTransitionRebootRequired}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	sta, err := RunPPIAction(env, ActionEnableTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(sta, Equals, ppi.StateTransitionRebootRequired)
+	c.Check(p.called, DeepEquals, []string{"EnableTPM()"})
+}
+
+func (s *actionsPpiSuite) TestRunPPIActionEnableAndClearTPM(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{sta: ppi.StateTransitionRebootRequired}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	sta, err := RunPPIAction(env, ActionEnableAndClearTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(sta, Equals, ppi.StateTransitionRebootRequired)
+	c.Check(p.called, DeepEquals, []string{"EnableAndClearTPM()"})
+}
+
+func (s *actionsPpiSuite) TestRunPPIActionClearTPM(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{sta: ppi.StateTransitionRebootRequired}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	sta, err := RunPPIAction(env, ActionClearTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(sta, Equals, ppi.StateTransitionRebootRequired)
+	c.Check(p.called, DeepEquals, []string{"ClearTPM()"})
+}
+
+func (s *actionsPpiSuite) TestRunPPIActionEnableTPMWithShutdownSTA(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{sta: ppi.StateTransitionShutdownRequired}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	sta, err := RunPPIAction(env, ActionEnableTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(sta, Equals, ppi.StateTransitionShutdownRequired)
+	c.Check(p.called, DeepEquals, []string{"EnableTPM()"})
+}
+
+func (s *actionsPpiSuite) TestRunPPIActionInvalidAction(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{sta: ppi.StateTransitionRebootRequired}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	_, err := RunPPIAction(env, ActionRebootToFWSettings)
+	c.Check(err, ErrorMatches, `invalid PPI action "reboot-to-fw-settings"`)
+}
+
+func (s *actionsPpiSuite) TestRunPPIActionInvalidSTA(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{sta: ppi.StateTransitionActionOSVendorSpecific}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	_, err := RunPPIAction(env, ActionEnableTPMViaFirmware)
+	c.Check(err, ErrorMatches, `unsupported state transition action "OS Vendor-specific"`)
+}
+
+func (s *actionsPpiSuite) TestRunPPIActionNoPPI(c *C) {
+	dev := new(mockTpm2Device)
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	_, err := RunPPIAction(env, ActionEnableTPMViaFirmware)
+	c.Check(err, Equals, ppi.ErrOperationUnsupported)
+}
+
+func (s *actionsPpiSuite) TestRunPPIActionPPIErr(c *C) {
+	s.ppiErr = errors.New("some error")
+	dev := new(mockTpm2Device)
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	_, err := RunPPIAction(env, ActionEnableTPMViaFirmware)
+	c.Check(err, ErrorMatches, `cannot obtain physical presence interface: some error`)
+}
+
+func (s *actionsPpiSuite) TestIsPPIActionAvailableEnableTPM(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{ops: map[ppi.OperationId]ppi.OperationStatus{
+		ppi.OperationEnableTPM: ppi.OperationPPRequired,
+	}}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	avail, err := IsPPIActionAvailable(env, ActionEnableTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(avail, testutil.IsTrue)
+}
+
+func (s *actionsPpiSuite) TestIsPPIActionAvailableEnableAndClearTPM(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{ops: map[ppi.OperationId]ppi.OperationStatus{
+		ppi.OperationEnableAndClearTPM: ppi.OperationPPRequired,
+	}}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	avail, err := IsPPIActionAvailable(env, ActionEnableAndClearTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(avail, testutil.IsTrue)
+}
+
+func (s *actionsPpiSuite) TestIsPPIActionAvailableClearTPM(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{ops: map[ppi.OperationId]ppi.OperationStatus{
+		ppi.OperationClearTPM: ppi.OperationPPRequired,
+	}}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	avail, err := IsPPIActionAvailable(env, ActionClearTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(avail, testutil.IsTrue)
+}
+
+func (s *actionsPpiSuite) TestIsPPIActionAvailableEnableTPMNotAvailable(c *C) {
+	dev := new(mockTpm2Device)
+	p := &mockPPI{}
+	s.devToPPIMap[dev] = p
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	avail, err := IsPPIActionAvailable(env, ActionEnableTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(avail, testutil.IsFalse)
+}
+
+func (s *actionsPpiSuite) TestIsPPIActionAvailableEnableTPMNoPPI(c *C) {
+	dev := new(mockTpm2Device)
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	avail, err := IsPPIActionAvailable(env, ActionEnableTPMViaFirmware)
+	c.Check(err, IsNil)
+	c.Check(avail, testutil.IsFalse)
+}
+
+func (s *actionsPpiSuite) TestIsPPIActionAvailableEnableTPMPPIErr(c *C) {
+	s.ppiErr = errors.New("some error")
+	dev := new(mockTpm2Device)
+
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+
+	_, err := IsPPIActionAvailable(env, ActionEnableTPMViaFirmware)
+	c.Check(err, ErrorMatches, `cannot obtain physical presence interface: some error`)
+}

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/ppi"
 	secboot_efi "github.com/snapcore/secboot/efi"
 	internal_efi "github.com/snapcore/secboot/internal/efi"
 )
@@ -54,27 +55,35 @@ func init() {
 			ActionContactOEM,
 		},
 		ErrorKindTPMDeviceDisabled: []Action{
-			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to enable the TPM
-			// TODO: Add actions to enable the TPM via the PPI
+			ActionRebootToFWSettings,           // suggest rebooting to the firmware settings UI to enable the TPM
+			ActionEnableTPMViaFirmware,         // suggest enabling the TPM via the PPI
+			ActionEnableAndClearTPMViaFirmware, // suggest enabling and clearing the TPM via the PPI
 		},
 		ErrorKindTPMHierarchiesOwned: []Action{
-			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to clear the TPM
-			// TODO: Add actions to clear the TPM, either directly if possible or via the PPI
+			ActionRebootToFWSettings,           // suggest rebooting to the firmware settings UI to clear the TPM
+			ActionClearTPMViaFirmware,          // suggest clearing the TPM via the PPI
+			ActionEnableAndClearTPMViaFirmware, // suggest enabling and clearing the TPM via the PPI
+			// TODO: Add action to clear the TPM directly.
 			// TODO: Add action to clear the authorization values / policies
 		},
 		ErrorKindTPMDeviceLockout: []Action{
-			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to clear the TPM
-			// TODO: Add actions to clear the TPM, either directly if possible or via the PPI
+			ActionRebootToFWSettings,           // suggest rebooting to the firmware settings UI to clear the TPM
+			ActionClearTPMViaFirmware,          // suggest clearing the TPM via the PPI
+			ActionEnableAndClearTPMViaFirmware, // suggest enabling and clearing the TPM via the PPI
+			// TODO: Add action to clear the TPM directly.
 			// TODO: Add action to clear the lockout.
 		},
 		ErrorKindTPMDeviceLockoutLockedOut: []Action{
-			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to clear the TPM
-			// TODO: Add actions to clear the TPM via the PPI - there will be no option to clear it directly because the lockout hierarchy is unavailable.
+			ActionRebootToFWSettings,           // suggest rebooting to the firmware settings UI to clear the TPM
+			ActionClearTPMViaFirmware,          // suggest clearing the TPM via the PPI
+			ActionEnableAndClearTPMViaFirmware, // suggest enabling and clearing the TPM via the PPI
 			// There will be no option to clear the lockout as there isn't a mechanism to do this.
 		},
 		ErrorKindInsufficientTPMStorage: []Action{
-			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to clear the TPM
-			// TODO: Add actions to clear the TPM, either directly if possible or via the PPI
+			ActionRebootToFWSettings,           // suggest rebooting to the firmware settings UI to clear the TPM
+			ActionClearTPMViaFirmware,          // suggest clearing the TPM via the PPI
+			ActionEnableAndClearTPMViaFirmware, // suggest enabling and clearing the TPM via the PPI
+			// TODO: Add action to clear the TPM directly.
 		},
 		ErrorKindNoSuitablePCRBank: []Action{
 			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to enable other PCR banks
@@ -202,7 +211,12 @@ func (c *RunChecksContext) testActionAvailable(action Action) error {
 	available := false
 
 	switch action {
-	// TODO: Populate with actions to test as we add them later on.
+	case ActionEnableTPMViaFirmware, ActionEnableAndClearTPMViaFirmware, ActionClearTPMViaFirmware:
+		var err error
+		available, err = isPPIActionAvailable(c.env, action)
+		if err != nil {
+			return err
+		}
 	}
 
 	c.availableActions[action] = available
@@ -487,6 +501,30 @@ func (c *RunChecksContext) runAction(action Action, args ...any) error {
 	case ActionNone:
 		// ok, do nothing
 		return nil
+	case ActionEnableTPMViaFirmware, ActionEnableAndClearTPMViaFirmware, ActionClearTPMViaFirmware: // PPI actions
+		result, err := runPPIAction(c.env, action)
+		if err != nil {
+			return NewWithKindAndActionsError(
+				ErrorKindActionFailed,
+				nil, nil, // args, actions
+				err,
+			)
+		}
+
+		// TODO: This uses an error to indicate partial success where a shutdown
+		//  or reboot is required to complete the action. It needs a bit more
+		//  thought because an error doesn't feel appropriate.
+		var kind ErrorKind
+		switch result {
+		case ppi.StateTransitionShutdownRequired:
+			kind = ErrorKindShutdownRequired
+			err = errors.New("a shutdown is required to complete the action")
+		case ppi.StateTransitionRebootRequired:
+			kind = ErrorKindRebootRequired
+			err = errors.New("a reboot is required to complete the action")
+		}
+
+		return NewWithKindAndActionsError(kind, nil, errorKindToActions[kind], err)
 	default:
 		return NewWithKindAndActionsError(
 			ErrorKindUnexpectedAction,

--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -36,6 +36,10 @@ import (
 // be executed to attempt to resolve the associated error kind.
 var errorKindToActions map[ErrorKind][]Action
 
+// errorKindToProceedFlag maps an error kind to a flag that can be set
+// to ignore the error. Not all errors can be ignored in this way.
+var errorKindToProceedFlag map[ErrorKind]CheckFlags
+
 func init() {
 	errorKindToActions = map[ErrorKind][]Action{
 		ErrorKindShutdownRequired: []Action{
@@ -44,14 +48,11 @@ func init() {
 		ErrorKindRebootRequired: []Action{
 			ActionReboot,
 		},
-		ErrorKindRunningInVM: []Action{
-			// TODO: Add action to add PermitVirtualMachine to CheckFlags
-		},
 		ErrorKindEFIVariableAccess: []Action{
 			ActionContactOEM,
 		},
 		ErrorKindTPMDeviceFailure: []Action{
-			ActionReboot,
+			ActionReboot, // suggest rebooting to see if it clears the failure
 			ActionContactOEM,
 		},
 		ErrorKindTPMDeviceDisabled: []Action{
@@ -91,22 +92,19 @@ func init() {
 			// TODO: Add an action to reconfigure PCR banks via the PPI.
 		},
 		ErrorKindEmptyPCRBanks: []Action{
-			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to disable the empty PCR bank
-			ActionContactOEM,         // suggest contacting the OEM because of a firmware bug
+			ActionContactOEM, // suggest contacting the OEM because of a firmware bug
 			// TODO: Add an action to reconfigure PCR banks via the PPI
-			// TODO: Add an action to add PermitEmptyPCRBanks to CheckFlags if the user is ok with accepting this.
 		},
 		ErrorKindUEFIDebuggingEnabled: []Action{
 			ActionContactOEM, // suggest contacting the OEM because of a firmware bug
 		},
 		ErrorKindInsufficientDMAProtection: []Action{
+			ActionContactOEM,         // suggest contacting the OEM because of a firmware bug.
 			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to enable DMA protection.
 		},
 		ErrorKindNoKernelIOMMU: []Action{
-			ActionContactOSVendor, // suggest contacting the OS vendor to supply a kernel with this feature enabled.
-		},
-		ErrorKindTPMStartupLocalityNotProtected: []Action{
-			// TODO: Add an action to add PermitNoDiscreteTPMResetMitigation to CheckFlags
+			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to enable DMA protection.
+			ActionContactOSVendor,    // suggest contacting the OS vendor to supply a kernel with this feature enabled.
 		},
 		ErrorKindHostSecurity: []Action{
 			ActionContactOEM, // suggest contacting the OEM because of a firmware bug or misconfigured root-of-trust
@@ -115,20 +113,14 @@ func init() {
 			ActionContactOEM, // suggest contacting the OEM because of a firmware bug
 		},
 		ErrorKindVARSuppliedDriversPresent: []Action{
-			// TODO: Add action to add PermitVARSuppliedDrivers to CheckFlags if they're necessary - this gives the
-			// user the chance to be aware of their existence.
 			// TODO: If the drivers are being loaded from BDS using DriverOrder and DriverXXXX variables, add action to delete these
 		},
 		ErrorKindSysPrepApplicationsPresent: []Action{
-			// TODO: Add action to add PermitSysPrepApplications to CheckFlags if the user wants to keep them -
-			// this gives the user the chance to be aware of their existence.
 			// TODO: Add an action to just disable these by erasing the SysPrepOrder and SysPrepXXXX variables
 		},
 		ErrorKindAbsolutePresent: []Action{
 			ActionContactOEM,         // suggest contacting the OEM if there's no way to disable it.
 			ActionRebootToFWSettings, // suggest rebooting to the firmware settings UI to disable it.
-			// TODO: Add action to add PermitAbsoluteComputrace to CheckFlags if the user doesn't want to
-			// or can't disable it. This gives the user the chance to be aware of their existence.
 			// TODO: Add an action to just disable this automatically on supported platforms (eg, Dell via the WMI interface)
 		},
 		ErrorKindInvalidSecureBootMode: []Action{
@@ -142,6 +134,19 @@ func init() {
 		ErrorKindPreOSDigestVerificationDetected: []Action{
 			// TODO: Add action to add PermitPreOSVerificationUsingDigests to CheckFlags.
 		},
+	}
+
+	errorKindToProceedFlag = map[ErrorKind]CheckFlags{
+		ErrorKindRunningInVM:                      PermitVirtualMachine,
+		ErrorKindEmptyPCRBanks:                    PermitEmptyPCRBanks,
+		ErrorKindInsufficientDMAProtection:        PermitInsufficientDMAProtection,
+		ErrorKindNoKernelIOMMU:                    PermitInsufficientDMAProtection,
+		ErrorKindTPMStartupLocalityNotProtected:   PermitNoDiscreteTPMResetMitigation,
+		ErrorKindVARSuppliedDriversPresent:        PermitVARSuppliedDrivers,
+		ErrorKindSysPrepApplicationsPresent:       PermitSysPrepApplications,
+		ErrorKindAbsolutePresent:                  PermitAbsoluteComputrace,
+		ErrorKindWeakSecureBootAlgorithmsDetected: PermitWeakSecureBootAlgorithms,
+		ErrorKindPreOSDigestVerificationDetected:  PermitPreOSVerificationUsingDigests,
 	}
 }
 
@@ -163,7 +168,15 @@ type RunChecksContext struct {
 	// - unavailable (a value of false).
 	// - available (a value of true).
 	availableActions map[Action]bool
-	expectedActions  []Action
+
+	// expectedActions contains a slice of actions that are expected on a subsequent call
+	// to Run. Trying to execute an action that is not in here will result in an error
+	// being returned.
+	expectedActions []Action
+
+	// proceedFlags indicates the CheckFlags that will be enabled if Run is called
+	// with ActionProceed.
+	proceedFlags CheckFlags
 }
 
 // NewRunChecksContext returns a new RunChecksContext instance with the initial flags for [RunChecks]
@@ -201,6 +214,7 @@ func NewRunChecksContext(initialFlags CheckFlags, loadedImages []secboot_efi.Ima
 			ActionRebootToFWSettings: true,
 			ActionContactOEM:         true,
 			ActionContactOSVendor:    true,
+			ActionProceed:            true,
 		},
 	}
 }
@@ -525,6 +539,8 @@ func (c *RunChecksContext) runAction(action Action, args ...any) error {
 		}
 
 		return NewWithKindAndActionsError(kind, nil, errorKindToActions[kind], err)
+	case ActionProceed:
+		c.flags |= c.proceedFlags
 	default:
 		return NewWithKindAndActionsError(
 			ErrorKindUnexpectedAction,
@@ -532,6 +548,8 @@ func (c *RunChecksContext) runAction(action Action, args ...any) error {
 			errors.New("specified action is invalid"),
 		)
 	}
+
+	return nil
 }
 
 // LastError returns the error from the last [RunChecks] invocation. If it completed
@@ -589,8 +607,20 @@ func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) 
 			// If RunChecks failed, save its error and return the appropriate error kinds.
 			c.errs = append(c.errs, err)
 
-			// Reset the list of expected actions
+			// Reset the list of expected actions.
 			c.expectedActions = nil
+
+			// Reset the flags that would be enabled if ActionProceed is used.
+			c.proceedFlags = 0
+
+			// Track whether ActionProceed can be added as an action to error
+			// kinds that support this. Is true until we encounter an error kind
+			// that doesn't permit it.
+			permitActionProceed := true
+
+			// Intermediate error slice so we can do a second pass over it, adding
+			// ActionProceed where appropriate.
+			var errsIntermediate []*WithKindAndActionsError
 
 			// Convert each error into WithKindAndActionsError
 			for _, e := range unwrapCompoundError(err) {
@@ -611,9 +641,31 @@ func (c *RunChecksContext) Run(ctx context.Context, action Action, args ...any) 
 						fmt.Errorf("cannot filter unavailable actions: %w", err),
 					)
 				}
+				if _, canProceed := errorKindToProceedFlag[kind]; !canProceed {
+					// This error kind doesn't support ActionProceed. Don't
+					// permit it at all for now, waiting until all of the errors
+					// we return support it.
+					permitActionProceed = false
+				}
 
-				errs = append(errs, NewWithKindAndActionsError(kind, args, actions, e))
+				errsIntermediate = append(errsIntermediate, NewWithKindAndActionsError(kind, args, actions, e))
 				c.expectedActions = append(c.expectedActions, actions...)
+			}
+
+			// Add ActionProceed to any error kinds that support it, if it is allowed
+			// right now.
+			for _, e := range errsIntermediate {
+				if permitActionProceed {
+					if flag, canProceed := errorKindToProceedFlag[e.Kind]; canProceed {
+						c.proceedFlags |= flag
+						e.Actions = append(e.Actions, ActionProceed)
+					}
+				}
+				errs = append(errs, e)
+			}
+
+			if c.proceedFlags != 0 {
+				c.expectedActions = append(c.expectedActions, ActionProceed)
 			}
 
 			break

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -202,8 +202,10 @@ func (s *runChecksContextSuite) testRun(c *C, params *testRunChecksContextRunPar
 	}
 	c.Assert(ctx.Errors(), HasLen, expectedErrsLen)
 
-	// Make sure that LastError() is the same as the last value returned from Errors()
-	if len(ctx.Errors()) > 0 {
+	// Make sure that LastError() is the same as the last value returned from Errors(),
+	// only if the last execution of the Run() loop failed else LastError() will
+	// return nil
+	if len(errs) > 0 && len(ctx.Errors()) > 0 {
 		c.Check(ctx.LastError(), Equals, ctx.Errors()[len(ctx.Errors())-1])
 	}
 
@@ -524,7 +526,263 @@ C7E003CB
 	c.Check(errs, HasLen, 0)
 }
 
-// TODO: Test a good case with an empty SHA-384 bank when we have an action to turn on the PermitEmptyPCRBanks flag
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitEmptyPCRBanks(c *C) {
+	// Test that ActionProceed turns on PermitEmptyPCRBanks.
+	s.RequireAlgorithm(c, tpm2.AlgorithmSHA384)
+
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA384},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsErrorForTest(
+					ErrorKindEmptyPCRBanks,
+					map[string]json.RawMessage{"algs": []byte("[12]")},
+					[]Action{ActionContactOEM, ActionProceed},
+					&EmptyPCRBanksError{Algs: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA384}},
+				))
+			}
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
+
+func (s *runChecksContextSuite) TestRunGoodPermitInsufficientDMAProtectionFromInitialFlags(c *C) {
+	// Test case where there is an empty PCR bank, but it is permitted by
+	// supplying PermitInsufficientDMAProtection as an initial flag.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:            []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				DMAProtectionDisabled: efitest.DMAProtectionDisabled,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		initialFlags: PermitInsufficientDMAProtection,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | InsufficientDMAProtectionDetected,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Assert(errs, HasLen, 0)
+}
+
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitInsufficientDMAProtection(c *C) {
+	// Test that ActionProceed enables PermitInsufficientDMAProtection.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:            []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				DMAProtectionDisabled: efitest.DMAProtectionDisabled,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindInsufficientDMAProtection,
+					nil,
+					[]Action{ActionContactOEM, ActionRebootToFWSettings, ActionProceed},
+					errs[0].Unwrap(),
+				))
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | InsufficientDMAProtectionDetected,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Assert(errs, HasLen, 0)
+}
 
 func (s *runChecksContextSuite) TestRunGoodPostInstall(c *C) {
 	// Test good post-install scenario on a fTPM, which skips some tests related to
@@ -724,9 +982,248 @@ C7E003CB
 	c.Check(errs, HasLen, 0)
 }
 
-// TODO: Test a good case with a VM setup when we have an action to turn on the PermitVirtualMachine flag.
-//
-// TODO: Test a good case with a discrete TPM where the startup locality is 0, when we have an action to turn on the PermitNoDiscreteTPMResetMitigation flag.
+func (s *runChecksContextSuite) TestRunGoodPermitVirtualMachineFromInitialFlags(c *C) {
+	// Test on a virtual machine, wehere PermitVirtualMachine is supplied via
+	// the initial flags to permit it.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode("qemu", internal_efi.DetectVirtModeVM),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		initialFlags: PermitVirtualMachine,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts:               PCRProfileOptionsDefault,
+		actions:                   []actionAndArgs{{action: ActionNone}},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- virtual machine environment detected
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
+
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitVirtualMachine(c *C) {
+	// Test that ActionProceed turns on PermitVirtualMachine.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode("qemu", internal_efi.DetectVirtModeVM),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindRunningInVM,
+					nil,
+					[]Action{ActionProceed},
+					ErrVirtualMachineDetected,
+				))
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- virtual machine environment detected
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
+
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitNoDiscreteTPMResetMitigationDiscreteTPMDetectedSL0(c *C) {
+	// Test that ActionProceed turns on PermitNoDiscreteTPMResetMitigation,
+	// for the case where we have a dTPM and the startup locality is 0.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (2 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport | DiscreteTPMDetected | StartupLocalityNotProtected,
+		expectedWarningsMatch: `3 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
 
 func (s *runChecksContextSuite) TestRunGoodDiscreteTPMDetectedSL3(c *C) {
 	// Test a good case on a dTPM where the startup locality is 3 and
@@ -1207,6 +1704,86 @@ C7E003CB
 
 // TODO: Test the above case without the initial flag when we have an action to set PermitVARSuppliedDrivers.
 
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitVARSuppliedDrivers(c *C) {
+	// Test that ActionProceed turns on PermitVARSuppliedDrivers.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:          []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				IncludeDriverLaunch: true,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- value added retailer supplied drivers were detected to be running
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
+
 func (s *runChecksContextSuite) TestRunGoodSysPrepAppsPresentFromInitialFlags(c *C) {
 	// Test good case on a fTPM where there are system preparation applications
 	// detected, and these are permitted with the PermitSysPrepApplications
@@ -1286,7 +1863,97 @@ C7E003CB
 	c.Check(errs, HasLen, 0)
 }
 
-// TODO: Test the above case without the initial flag when we have an action to set PermitSysPrepApplications.
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitSysPrepApplications(c *C) {
+	// Test that ActionProceed enables PermitSysPrepApplications.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:              []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				IncludeSysPrepAppLaunch: true,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindSysPrepApplicationsPresent,
+					nil,
+					[]Action{ActionProceed},
+					ErrSysPrepApplicationsPresent,
+				))
+			}
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- system preparation applications were detected to be running
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Assert(errs, HasLen, 0)
+}
 
 func (s *runChecksContextSuite) TestRunGoodAbsoluteActiveFromInitialFlags(c *C) {
 	// Test good case on a fTPM where Absolute is detected, and this is
@@ -1342,6 +2009,98 @@ C7E003CB
 		profileOpts:  PCRProfileOptionsDefault,
 		actions:      []actionAndArgs{{action: ActionNone}},
 		initialFlags: PermitAbsoluteComputrace,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `4 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- Absolute was detected to be active and it is advised that this is disabled
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
+
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitAbsolute(c *C) {
+	// Test that ActionProceed enables PermitAbsoluteComputrace.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:                        []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				IncludeOSPresentFirmwareAppLaunch: efi.MakeGUID(0x821aca26, 0x29ea, 0x4993, 0x839f, [...]byte{0x59, 0x7f, 0xc0, 0x21, 0x70, 0x8d}),
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		profileOpts:  PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Check(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindAbsolutePresent,
+					nil,
+					[]Action{ActionContactOEM, ActionRebootToFWSettings, ActionProceed},
+					ErrAbsoluteComputraceActive,
+				))
+			}
+		},
 		loadedImages: []secboot_efi.Image{
 			&mockImage{
 				contents: []byte("mock shim executable"),
@@ -1528,7 +2287,108 @@ C7E003CB
 	c.Check(errs, HasLen, 0)
 }
 
-// TODO: Test the above case without the initial flag when we have an action to set PermitPreOSVerificationUsingDigests.
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitPreOSVerificationUsingDigests(c *C) {
+	// Test that ActionProceed enables the PermitPreOSVerificationUsingDigests flag. As
+	// this test generates 2 errors, it also tests the case where ActionProceed can
+	// be used to ignore multiple errors.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:                   []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				IncludeDriverLaunch:          true,
+				PreOSVerificationUsesDigests: crypto.SHA256,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Check(errs, HasLen, 2)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindVARSuppliedDriversPresent,
+					nil,
+					[]Action{ActionProceed},
+					ErrVARSuppliedDriversPresent,
+				))
+
+				c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindPreOSDigestVerificationDetected,
+					nil,
+					[]Action{ActionProceed},
+					ErrPreOSVerificationUsingDigests,
+				))
+			}
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `5 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- value added retailer supplied drivers were detected to be running
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+- some pre-OS components were authenticated from the authorized signature database using an Authenticode digest
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
 
 func (s *runChecksContextSuite) TestRunGoodWeakSecureBootAlgsFromInitialFlags(c *C) {
 	// Test a good case on a fTPM where there are weak secure boot algorithms
@@ -1612,7 +2472,117 @@ C7E003CB
 	c.Check(errs, HasLen, 0)
 }
 
-// TODO: Test the above case without the initial flag when we have an action to set PermitWeakSecureBootAlgorithms.
+func (s *runChecksContextSuite) TestRunGoodActionProceedPermitWeakSecureBootAlgs(c *C) {
+	// Test that ActionProceed enables PermitWeakSecureBootAlgorithms. As
+	// this test generates 3 errors, it also tests the case where ActionProceed
+	// can be used to ignore multiple errors.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms:                   []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+				IncludeDriverLaunch:          true,
+				PreOSVerificationUsesDigests: crypto.SHA1,
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		iterations:   2,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionProceed},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Check(errs, HasLen, 3)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindVARSuppliedDriversPresent,
+					nil,
+					[]Action{ActionProceed},
+					ErrVARSuppliedDriversPresent,
+				))
+
+				c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindWeakSecureBootAlgorithmsDetected,
+					nil,
+					[]Action{ActionProceed},
+					ErrWeakSecureBootAlgorithmDetected,
+				))
+
+				c.Check(errs[2], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindPreOSDigestVerificationDetected,
+					nil,
+					[]Action{ActionProceed},
+					ErrPreOSVerificationUsingDigests,
+				))
+			}
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+		expectedWarningsMatch: `6 errors detected:
+- error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet
+- value added retailer supplied drivers were detected to be running
+- error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet
+- error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet
+- a weak cryptographic algorithm was detected during secure boot verification
+- some pre-OS components were authenticated from the authorized signature database using an Authenticode digest
+`,
+	})
+	c.Check(errs, HasLen, 0)
+}
+
 // TODO: Good test case for invalid secure boot config (eg, no DeployedMode) when PCRProfileOptionPermitNoSecureBootPolicyProfile is supported.
 
 // **End of good cases ** //
@@ -1670,7 +2640,12 @@ func (s *runChecksContextSuite) TestRunBadVirtualMachine(c *C) {
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Assert(errs[0], ErrorMatches, `virtual machine environment detected`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRunningInVM, nil, nil, ErrVirtualMachineDetected))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindRunningInVM,
+		nil,
+		[]Action{ActionProceed},
+		ErrVirtualMachineDetected,
+	))
 }
 
 func (s *runChecksContextSuite) TestRunBadNotEFI(c *C) {
@@ -3185,7 +4160,12 @@ C7E003CB
 	c.Assert(errs, HasLen, 1)
 
 	c.Check(errs[0], ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMStartupLocalityNotProtected, nil, nil, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindTPMStartupLocalityNotProtected,
+		nil,
+		[]Action{ActionProceed},
+		errs[0].Unwrap(),
+	))
 }
 
 // TODO: Test another bad case where PCR0 is mandatory but unusable, but is mandatory
@@ -3520,7 +4500,12 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `error with system security: the platform firmware indicates that DMA protections are insufficient`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindInsufficientDMAProtection, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindInsufficientDMAProtection,
+		nil,
+		[]Action{ActionContactOEM, ActionRebootToFWSettings, ActionProceed},
+		errs[0].Unwrap(),
+	))
 }
 
 func (s *runChecksContextSuite) TestRunBadNoKernelIOMMU(c *C) {
@@ -3563,7 +4548,12 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindNoKernelIOMMU,
+		nil,
+		[]Action{ActionRebootToFWSettings, ActionContactOSVendor, ActionProceed},
+		errs[0].Unwrap(),
+	))
 }
 
 func (s *runChecksContextSuite) TestRunBadStartupLocalityNotProtected(c *C) {
@@ -3611,11 +4601,18 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `error with system security: access to the discrete TPM's startup locality is available to platform firmware and privileged OS code, preventing any mitigation against reset attacks`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMStartupLocalityNotProtected, nil, nil, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindTPMStartupLocalityNotProtected,
+		nil,
+		[]Action{ActionProceed},
+		errs[0].Unwrap(),
+	))
 }
 
 func (s *runChecksContextSuite) TestRunChecksBadUEFIDebuggingEnabledAndNoKernelIOMMU(c *C) {
-	// Test case with more than one host security error.
+	// Test case with more than one host security error. This also tests the case
+	// where ActionProceed is suppressed because one of the returned errors
+	// doesn't permit it.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -3661,7 +4658,12 @@ C7E003CB
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindUEFIDebuggingEnabled, nil, []Action{ActionContactOEM}, errs[0].Unwrap()))
 
 	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
-	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
+	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindNoKernelIOMMU,
+		nil,
+		[]Action{ActionRebootToFWSettings, ActionContactOSVendor},
+		errs[1].Unwrap(),
+	))
 }
 
 func (s *runChecksContextSuite) TestRunBadHostSecurityError(c *C) {
@@ -4009,7 +5011,7 @@ C7E003CB
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsErrorForTest(
 		ErrorKindEmptyPCRBanks,
 		map[string]json.RawMessage{"algs": []byte("[12]")},
-		[]Action{ActionRebootToFWSettings, ActionContactOEM},
+		[]Action{ActionContactOEM, ActionProceed},
 		&EmptyPCRBanksError{Algs: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA384}},
 	))
 }
@@ -4082,7 +5084,12 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindVARSuppliedDriversPresent, nil, nil, ErrVARSuppliedDriversPresent))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindVARSuppliedDriversPresent,
+		nil,
+		[]Action{ActionProceed},
+		ErrVARSuppliedDriversPresent,
+	))
 }
 
 func (s *runChecksContextSuite) TestRunBadSysPrepAppsPresent(c *C) {
@@ -4153,7 +5160,12 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `system preparation applications were detected to be running`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindSysPrepApplicationsPresent, nil, nil, ErrSysPrepApplicationsPresent))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindSysPrepApplicationsPresent,
+		nil,
+		[]Action{ActionProceed},
+		ErrSysPrepApplicationsPresent,
+	))
 }
 
 func (s *runChecksContextSuite) TestRunBadAbsoluteActive(c *C) {
@@ -4224,7 +5236,12 @@ C7E003CB
 	})
 	c.Check(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `Absolute was detected to be active and it is advised that this is disabled`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindAbsolutePresent, nil, []Action{ActionContactOEM, ActionRebootToFWSettings}, ErrAbsoluteComputraceActive))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindAbsolutePresent,
+		nil,
+		[]Action{ActionContactOEM, ActionRebootToFWSettings, ActionProceed},
+		ErrAbsoluteComputraceActive,
+	))
 }
 
 func (s *runChecksContextSuite) TestRunBadNotAllBootManagerCodeDigestsVerified(c *C) {
@@ -4528,13 +5545,28 @@ C7E003CB
 	})
 	c.Check(errs, HasLen, 3)
 	c.Check(errs[0], ErrorMatches, `value added retailer supplied drivers were detected to be running`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindVARSuppliedDriversPresent, nil, nil, ErrVARSuppliedDriversPresent))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindVARSuppliedDriversPresent,
+		nil,
+		[]Action{ActionProceed},
+		ErrVARSuppliedDriversPresent,
+	))
 
 	c.Check(errs[1], ErrorMatches, `a weak cryptographic algorithm was detected during secure boot verification`)
-	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindWeakSecureBootAlgorithmsDetected, nil, nil, ErrWeakSecureBootAlgorithmDetected))
+	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindWeakSecureBootAlgorithmsDetected,
+		nil,
+		[]Action{ActionProceed},
+		ErrWeakSecureBootAlgorithmDetected,
+	))
 
 	c.Check(errs[2], ErrorMatches, `some pre-OS components were authenticated from the authorized signature database using an Authenticode digest`)
-	c.Check(errs[2], DeepEquals, NewWithKindAndActionsError(ErrorKindPreOSDigestVerificationDetected, nil, nil, ErrPreOSVerificationUsingDigests))
+	c.Check(errs[2], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindPreOSDigestVerificationDetected,
+		nil,
+		[]Action{ActionProceed},
+		ErrPreOSVerificationUsingDigests,
+	))
 }
 
 // TODO: This is disabled temporarily until a follow-up PR which adds warnings to the returned errors
@@ -4698,6 +5730,9 @@ C7E003CB
 //}
 
 func (s *runChecksContextSuite) TestRunChecksBadEmptyPCRBankAndNoKernelIOMMU(c *C) {
+	// Test with a system that has an empty PCR bank and no kernel IOMMU.
+	// As both errors support ActionProceed, it is a valid action for
+	// both of the returned errors.
 	s.RequireAlgorithm(c, tpm2.AlgorithmSHA384)
 
 	meiAttrs := map[string][]byte{
@@ -4760,10 +5795,20 @@ C7E003CB
 	c.Assert(errs, HasLen, 2)
 
 	c.Check(errs[0], ErrorMatches, `the PCR bank for TPM_ALG_SHA384 is missing from the TCG log but active and with one or more empty PCRs on the TPM`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindEmptyPCRBanks, &EmptyPCRBanksError{Algs: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA384}}, []Action{ActionRebootToFWSettings, ActionContactOEM}, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindEmptyPCRBanks,
+		&EmptyPCRBanksError{Algs: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA384}},
+		[]Action{ActionContactOEM, ActionProceed},
+		errs[0].Unwrap(),
+	))
 
 	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
-	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
+	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindNoKernelIOMMU,
+		nil,
+		[]Action{ActionRebootToFWSettings, ActionContactOSVendor, ActionProceed},
+		errs[1].Unwrap(),
+	))
 }
 
 func (s *runChecksContextSuite) TestRunChecksActionEnableTPMViaFirmwareNotAvailable(c *C) {

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -30,6 +30,7 @@ import (
 	efi "github.com/canonical/go-efilib"
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/objectutil"
+	"github.com/canonical/go-tpm2/ppi"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 	"github.com/canonical/tcglog-parser"
 	secboot_efi "github.com/snapcore/secboot/efi"
@@ -45,12 +46,26 @@ type runChecksContextSuite struct {
 	tpm2_testutil.TPMSimulatorTest
 	tpmPropertyModifierMixin
 	tcglogReplayMixin
+
+	devToPPIMap map[tpm2.TPMDevice]ppi.PPI
+	ppiErr      error
 }
 
 func (s *runChecksContextSuite) SetUpTest(c *C) {
 	s.TPMSimulatorTest.SetUpTest(c)
 	s.tpmPropertyModifierMixin.transport = s.Transport
 	s.tcglogReplayMixin.impl = s
+
+	s.devToPPIMap = make(map[tpm2.TPMDevice]ppi.PPI)
+	s.ppiErr = nil
+
+	restore := MockObtainTPMDevicePPI(func(dev tpm2.TPMDevice) (ppi.PPI, error) {
+		if s.ppiErr != nil {
+			return nil, s.ppiErr
+		}
+		return s.devToPPIMap[dev], nil
+	})
+	s.AddCleanup(restore)
 }
 
 func (s *runChecksContextSuite) Tpm() *tpm2.TPMContext {
@@ -68,6 +83,7 @@ type testRunChecksContextRunParams struct {
 	env                  internal_efi.HostEnvironment
 	tpmPropertyModifiers map[tpm2.Property]uint32
 	enabledBanks         []tpm2.HashAlgorithmId
+	ppi                  *mockPPI
 
 	initialFlags CheckFlags
 	loadedImages []secboot_efi.Image
@@ -85,7 +101,7 @@ type testRunChecksContextRunParams struct {
 }
 
 func (s *runChecksContextSuite) testRun(c *C, params *testRunChecksContextRunParams) (errs []*WithKindAndActionsError) {
-	_, err := params.env.TPMDevice()
+	dev, err := params.env.TPMDevice()
 	if err == nil {
 		s.allocatePCRBanks(c, params.enabledBanks...)
 		s.addTPMPropertyModifiers(c, params.tpmPropertyModifiers)
@@ -94,6 +110,23 @@ func (s *runChecksContextSuite) testRun(c *C, params *testRunChecksContextRunPar
 		if err == nil {
 			s.resetTPMAndReplayLog(c, log, log.Algorithms...)
 		}
+
+		p := params.ppi
+		if p == nil {
+			// Create a mockPPI if one wasn't supplied
+			p = &mockPPI{}
+		}
+		if p.ops == nil {
+			// Initialize an uninitialzed PPI. Supply the
+			// ops map to prevent this.
+			p.sta = ppi.StateTransitionRebootRequired
+			p.ops = map[ppi.OperationId]ppi.OperationStatus{
+				ppi.OperationEnableTPM:         ppi.OperationPPRequired,
+				ppi.OperationEnableAndClearTPM: ppi.OperationPPRequired,
+				ppi.OperationClearTPM:          ppi.OperationPPRequired,
+			}
+		}
+		s.devToPPIMap[dev] = p
 	}
 
 	restore := MockEfiComputePeImageDigest(func(alg crypto.Hash, r io.ReaderAt, sz int64) ([]byte, error) {
@@ -155,7 +188,7 @@ func (s *runChecksContextSuite) testRun(c *C, params *testRunChecksContextRunPar
 	}
 
 	// Make sure we don't leave any open TPM connections
-	dev, err := params.env.TPMDevice()
+	dev, err = params.env.TPMDevice()
 	if err == nil {
 		c.Assert(dev, testutil.ConvertibleTo, &tpm2_testutil.TransportBackedDevice{})
 		c.Check(dev.(*tpm2_testutil.TransportBackedDevice).NumberOpen(), Equals, 0)
@@ -1584,14 +1617,42 @@ C7E003CB
 
 // **End of good cases ** //
 
-func (s *runChecksContextSuite) TestRunBadUnexpexctedAction(c *C) {
+func (s *runChecksContextSuite) TestRunBadUnexpectedAction(c *C) {
 	errs := s.testRun(c, &testRunChecksContextRunParams{
 		env:         efitest.NewMockHostEnvironmentWithOpts(),
 		profileOpts: PCRProfileOptionsDefault,
-		actions:     []actionAndArgs{{action: "fake-action"}},
+		actions:     []actionAndArgs{{action: ActionClearTPMViaFirmware}},
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Assert(errs[0], ErrorMatches, `specified action is not expected`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindUnexpectedAction, nil, nil, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadExternalAction(c *C) {
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		profileOpts:  PCRProfileOptionsDefault,
+		iterations:   2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Disable owner and endorsement hierarchies
+				c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
+				c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionRebootToFWSettings},
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `specified action is not implemented directly by this package`)
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindUnexpectedAction, nil, nil, errs[0].Unwrap()))
 }
 
@@ -1775,7 +1836,93 @@ func (s *runChecksContextSuite) TestRunBadTPM2DeviceDisabled(c *C) {
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings, ActionEnableTPMViaFirmware, ActionEnableAndClearTPMViaFirmware}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPM2DeviceDisabledRunEnableTPMViaFirmwareAction(c *C) {
+	// Test the error case where the TPM has been disabled by firmware, and
+	// we run the ActionEnableTPMViaFirmware action.
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		profileOpts:  PCRProfileOptionsDefault,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Disable owner and endorsement hierarchies on the first iteration
+				c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
+				c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
+			}
+		},
+		iterations: 2,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionEnableTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings, ActionEnableTPMViaFirmware, ActionEnableAndClearTPMViaFirmware}, errs[0].Unwrap()))
+			}
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"EnableTPM()"})
+}
+
+func (s *runChecksContextSuite) TestRunBadTPM2DeviceDisabledRunEnableAndClearTPMViaFirmwareAction(c *C) {
+	// Test the error case where the TPM has been disabled by firmware, and
+	// we run the ActionEnableAndClearTPMViaFirmware action.
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		profileOpts:  PCRProfileOptionsDefault,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Disable owner and endorsement hierarchies on the first iteration
+				c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
+				c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
+			}
+		},
+		iterations: 2,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionEnableAndClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings, ActionEnableTPMViaFirmware, ActionEnableAndClearTPMViaFirmware}, errs[0].Unwrap()))
+			}
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"EnableAndClearTPM()"})
 }
 
 func (s *runChecksContextSuite) TestRunBadTPMHierarchiesOwned(c *C) {
@@ -1829,6 +1976,8 @@ C7E003CB
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 		profileOpts:  PCRProfileOptionsDefault,
 		prepare: func(_ int) {
+			// Set an authorization value for the lockout hierarchy and
+			// an authorization policy for the storage hierarchy.
 			s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
 			c.Check(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), make([]byte, 32), tpm2.HashAlgorithmSHA256, nil), IsNil)
 		},
@@ -1842,9 +1991,187 @@ C7E003CB
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindTPMHierarchiesOwned,
 		&TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}, WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
-		[]Action{ActionRebootToFWSettings},
+		[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
 		errs[0].Unwrap(),
 	))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMHierarchiesOwnedRunActionClearTPMViaFirmware(c *C) {
+	// Test the error case where one or more hierarchies of the TPM are already owned, and
+	// we run the ActionClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		profileOpts:  PCRProfileOptionsDefault,
+		iterations:   2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Set an authorization value for the lockout hierarchy and
+				// an authorization policy for the storage hierarchy on the
+				// first iteration.
+				s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
+				c.Check(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), make([]byte, 32), tpm2.HashAlgorithmSHA256, nil), IsNil)
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindTPMHierarchiesOwned,
+					&TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}, WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
+					[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+					errs[0].Unwrap(),
+				))
+			}
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"ClearTPM()"})
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMHierarchiesOwnedRunActionEnableAndClearTPMViaFirmware(c *C) {
+	// Test the error case where one or more hierarchies of the TPM are already owned, and
+	// we run the ActionEnableAndClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		profileOpts:  PCRProfileOptionsDefault,
+		iterations:   2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Set an authorization value for the lockout hierarchy and
+				// an authorization policy for the storage hierarchy on the
+				// first iteration.
+				s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
+				c.Check(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), make([]byte, 32), tpm2.HashAlgorithmSHA256, nil), IsNil)
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionEnableAndClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindTPMHierarchiesOwned,
+					&TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}, WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
+					[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+					errs[0].Unwrap(),
+				))
+			}
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"EnableAndClearTPM()"})
 }
 
 func (s *runChecksContextSuite) TestRunBadTPMDeviceLockedOut(c *C) {
@@ -1928,7 +2255,234 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceLockout, &TPMDeviceLockoutArgs{IntervalDuration: 2 * time.Hour, TotalDuration: 64 * time.Hour}, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindTPMDeviceLockout,
+		&TPMDeviceLockoutArgs{IntervalDuration: 2 * time.Hour, TotalDuration: 64 * time.Hour},
+		[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+		errs[0].Unwrap(),
+	))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMDeviceLockedOutRunActionClearTPMViaFirmware(c *C) {
+	// Test the error case where the TPM's DA protection has been tripped, and
+	// we run the ActionClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		profileOpts:  PCRProfileOptionsDefault,
+		iterations:   2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Trip the DA mechanism on the first iteration.
+				c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 32, 7200, 86400, nil), IsNil)
+				// Authorize the lockout hierarchy enough times with a bogus value to trip it
+				object, _, _, _, _, err := s.TPM.CreatePrimary(s.TPM.OwnerHandleContext(), &tpm2.SensitiveCreate{UserAuth: []byte("foo")}, objectutil.NewECCKeyTemplate(objectutil.UsageSign), nil, nil, nil)
+				c.Assert(err, IsNil)
+
+				object.SetAuthValue(nil)
+				digest := testutil.DecodeHexString(c, "fbde6a7fe0a4a95d2656f206437a3db64322a74822e581cf63b69f205c63ab6f")
+				scheme := &tpm2.SigScheme{
+					Scheme: tpm2.SigSchemeAlgECDSA,
+					Details: &tpm2.SigSchemeU{
+						ECDSA: &tpm2.SigSchemeECDSA{
+							HashAlg: tpm2.HashAlgorithmSHA256,
+						},
+					},
+				}
+
+				for i := 0; i < 32; i++ {
+					_, err := s.TPM.Sign(object, digest, scheme, nil, nil)
+					if tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandSign, 1) {
+						continue
+					}
+					if tpm2.IsTPMWarning(err, tpm2.WarningLockout, tpm2.CommandSign) {
+						break
+					}
+					c.Errorf("unexpected error: %v", err)
+				}
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindTPMDeviceLockout,
+					&TPMDeviceLockoutArgs{IntervalDuration: 2 * time.Hour, TotalDuration: 64 * time.Hour},
+					[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+					errs[0].Unwrap(),
+				))
+			}
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"ClearTPM()"})
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMDeviceLockedOutRunActionEnableAndClearTPMViaFirmware(c *C) {
+	// Test the error case where the TPM's DA protection has been tripped, and
+	// we run the ActionEnableAndClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		profileOpts:  PCRProfileOptionsDefault,
+		iterations:   2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Trip the DA mechanism on the first iteration.
+				c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 32, 7200, 86400, nil), IsNil)
+				// Authorize the lockout hierarchy enough times with a bogus value to trip it
+				object, _, _, _, _, err := s.TPM.CreatePrimary(s.TPM.OwnerHandleContext(), &tpm2.SensitiveCreate{UserAuth: []byte("foo")}, objectutil.NewECCKeyTemplate(objectutil.UsageSign), nil, nil, nil)
+				c.Assert(err, IsNil)
+
+				object.SetAuthValue(nil)
+				digest := testutil.DecodeHexString(c, "fbde6a7fe0a4a95d2656f206437a3db64322a74822e581cf63b69f205c63ab6f")
+				scheme := &tpm2.SigScheme{
+					Scheme: tpm2.SigSchemeAlgECDSA,
+					Details: &tpm2.SigSchemeU{
+						ECDSA: &tpm2.SigSchemeECDSA{
+							HashAlg: tpm2.HashAlgorithmSHA256,
+						},
+					},
+				}
+
+				for i := 0; i < 32; i++ {
+					_, err := s.TPM.Sign(object, digest, scheme, nil, nil)
+					if tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandSign, 1) {
+						continue
+					}
+					if tpm2.IsTPMWarning(err, tpm2.WarningLockout, tpm2.CommandSign) {
+						break
+					}
+					c.Errorf("unexpected error: %v", err)
+				}
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionEnableAndClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindTPMDeviceLockout,
+					&TPMDeviceLockoutArgs{IntervalDuration: 2 * time.Hour, TotalDuration: 64 * time.Hour},
+					[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+					errs[0].Unwrap(),
+				))
+			}
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"EnableAndClearTPM()"})
 }
 
 func (s *runChecksContextSuite) TestRunBadTPMDeviceLockoutLockedOut(c *C) {
@@ -2004,7 +2558,220 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM's lockout hierarchy is unavailable because it is locked out`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceLockoutLockedOut, TPMDeviceLockoutRecoveryArg(24*time.Hour), []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindTPMDeviceLockoutLockedOut,
+		TPMDeviceLockoutRecoveryArg(24*time.Hour),
+		[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+		errs[0].Unwrap(),
+	))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMDeviceLockoutLockedOutRunActionClearTPMViaFirmware(c *C) {
+	// Test the error case where the TPM's lockout hierarchy is locked out, and
+	// we run the ActionClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		iterations:  2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Disable the lockout hierarchy on the first iteration.
+				c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 32, 7200, 86400, nil), IsNil)
+
+				// Disable the lockout hierarchy by authorizing it incorrectly
+				s.TPM.LockoutHandleContext().SetAuthValue([]byte("1234"))
+				err := s.TPM.DictionaryAttackLockReset(s.TPM.LockoutHandleContext(), nil)
+				c.Check(tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandDictionaryAttackLockReset, 1), testutil.IsTrue)
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindTPMDeviceLockoutLockedOut,
+					TPMDeviceLockoutRecoveryArg(24*time.Hour),
+					[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+					errs[0].Unwrap(),
+				))
+
+			}
+		},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"ClearTPM()"})
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMDeviceLockoutLockedOutRunActionEnableAndClearTPMViaFirmware(c *C) {
+	// Test the error case where the TPM's lockout hierarchy is locked out, and
+	// we run the ActionEnableAndClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		iterations:  2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Disable the lockout hierarchy on the first iteration.
+				c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 32, 7200, 86400, nil), IsNil)
+
+				// Disable the lockout hierarchy by authorizing it incorrectly
+				s.TPM.LockoutHandleContext().SetAuthValue([]byte("1234"))
+				err := s.TPM.DictionaryAttackLockReset(s.TPM.LockoutHandleContext(), nil)
+				c.Check(tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandDictionaryAttackLockReset, 1), testutil.IsTrue)
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionEnableAndClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			switch i {
+			case 0:
+				c.Assert(errs, HasLen, 1)
+				c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+					ErrorKindTPMDeviceLockoutLockedOut,
+					TPMDeviceLockoutRecoveryArg(24*time.Hour),
+					[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+					errs[0].Unwrap(),
+				))
+
+			}
+		},
+		expectedPcrAlg: tpm2.HashAlgorithmSHA256,
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"EnableAndClearTPM()"})
 }
 
 func (s *runChecksContextSuite) TestRunBadTPMInsufficientCounters(c *C) {
@@ -2060,7 +2827,164 @@ C7E003CB
 	})
 	c.Assert(errs, HasLen, 1)
 	c.Check(errs[0], ErrorMatches, `error with TPM2 device: insufficient NV counters available`)
-	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindInsufficientTPMStorage, nil, []Action{ActionRebootToFWSettings}, errs[0].Unwrap()))
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindInsufficientTPMStorage,
+		nil,
+		[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+		errs[0].Unwrap(),
+	))
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMInsufficientCountersRunActionClearTPMViaFirmware(c *C) {
+	// Test the error case where there appears to be too few NV counters, and
+	// we run the ActionClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     6,
+			tpm2.PropertyNVCounters:        5,
+			tpm2.PropertyPSFamilyIndicator: 1,
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		iterations:   2,
+		profileOpts:  PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			c.Assert(errs, HasLen, 1)
+			c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+				ErrorKindInsufficientTPMStorage,
+				nil,
+				[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+				errs[0].Unwrap(),
+			))
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"ClearTPM()"})
+}
+
+func (s *runChecksContextSuite) TestRunBadTPMInsufficientCountersRunActionEnableAndClearTPMViaFirmware(c *C) {
+	// Test the error case where there appears to be too few NV counters, and
+	// we run the ActionEnableAndClearTPMViaFirmware action.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	p := new(mockPPI)
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     6,
+			tpm2.PropertyNVCounters:        5,
+			tpm2.PropertyPSFamilyIndicator: 1,
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi:          p,
+		iterations:   2,
+		profileOpts:  PCRProfileOptionsDefault,
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionEnableAndClearTPMViaFirmware},
+		},
+		checkIntermediateErrs: func(i int, errs []*WithKindAndActionsError) {
+			c.Assert(errs, HasLen, 1)
+			c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+				ErrorKindInsufficientTPMStorage,
+				nil,
+				[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
+				errs[0].Unwrap(),
+			))
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a reboot is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindRebootRequired, nil, []Action{ActionReboot}, errs[0].Unwrap()))
+
+	c.Check(p.called, DeepEquals, []string{"EnableAndClearTPM()"})
 }
 
 func (s *runChecksContextSuite) TestRunBadTPMHierarchiesOwnedAndLockedOut(c *C) {
@@ -2153,7 +3077,7 @@ C7E003CB
 	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindTPMHierarchiesOwned,
 		&TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}},
-		[]Action{ActionRebootToFWSettings},
+		[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
 		errs[0].Unwrap(),
 	))
 
@@ -2161,7 +3085,7 @@ C7E003CB
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(
 		ErrorKindTPMDeviceLockout,
 		&TPMDeviceLockoutArgs{IntervalDuration: 2 * time.Hour, TotalDuration: 64 * time.Hour},
-		[]Action{ActionRebootToFWSettings},
+		[]Action{ActionRebootToFWSettings, ActionClearTPMViaFirmware, ActionEnableAndClearTPMViaFirmware},
 		errs[1].Unwrap(),
 	))
 }
@@ -3840,4 +4764,182 @@ C7E003CB
 
 	c.Check(errs[1], ErrorMatches, `error with system security: no kernel IOMMU support was detected`)
 	c.Check(errs[1], DeepEquals, NewWithKindAndActionsError(ErrorKindNoKernelIOMMU, nil, []Action{ActionContactOSVendor}, errs[1].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunChecksActionEnableTPMViaFirmwareNotAvailable(c *C) {
+	// Generate an error that could be fixed by ActionEnableTPMViaFirmware when
+	// this action is not available.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi: &mockPPI{
+			sta: ppi.StateTransitionRebootRequired,
+			ops: map[ppi.OperationId]ppi.OperationStatus{
+				ppi.OperationEnableAndClearTPM: ppi.OperationPPRequired,
+				ppi.OperationClearTPM:          ppi.OperationPPRequired,
+			},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			// Disable owner and endorsement hierarchies
+			c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
+			c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
+		},
+		actions: []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings, ActionEnableAndClearTPMViaFirmware}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunChecksActionEnableAndClearTPMViaFirmwareNotAvailable(c *C) {
+	// Generate an error that could be fixed by ActionEnableAndClearTPMViaFirmware when
+	// this action is not available.
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi: &mockPPI{
+			sta: ppi.StateTransitionRebootRequired,
+			ops: map[ppi.OperationId]ppi.OperationStatus{
+				ppi.OperationEnableTPM: ppi.OperationPPRequired,
+				ppi.OperationClearTPM:  ppi.OperationPPRequired,
+			},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			// Disable owner and endorsement hierarchies
+			c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
+			c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
+		},
+		actions: []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindTPMDeviceDisabled, nil, []Action{ActionRebootToFWSettings, ActionEnableTPMViaFirmware}, errs[0].Unwrap()))
+}
+
+func (s *runChecksContextSuite) TestRunChecksActionClearTPMViaFirmwareNotAvailable(c *C) {
+	// Generate an error that could be fixed by ActionClearTPMViaFirmware when this action
+	// is not available.
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{
+				Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+			})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0x13a: (3 << 1), 0xc80: 0x40000000}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi: &mockPPI{
+			sta: ppi.StateTransitionRebootRequired,
+			ops: map[ppi.OperationId]ppi.OperationStatus{
+				ppi.OperationEnableTPM:         ppi.OperationPPRequired,
+				ppi.OperationEnableAndClearTPM: ppi.OperationPPRequired,
+			},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		prepare: func(_ int) {
+			// Set an authorization value for the lockout hierarchy and
+			// an authorization policy for the storage hierarchy.
+			s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
+			c.Check(s.TPM.SetPrimaryPolicy(s.TPM.OwnerHandleContext(), make([]byte, 32), tpm2.HashAlgorithmSHA256, nil), IsNil)
+		},
+		actions: []actionAndArgs{{action: ActionNone}},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
+- TPM_RH_LOCKOUT has an authorization value
+- TPM_RH_OWNER has an authorization policy
+`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(
+		ErrorKindTPMHierarchiesOwned,
+		&TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}, WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
+		[]Action{ActionRebootToFWSettings, ActionEnableAndClearTPMViaFirmware},
+		errs[0].Unwrap(),
+	))
+}
+
+func (s *runChecksContextSuite) TestRunChecksPPIActionWithShutdownTransition(c *C) {
+	// Generate an error that can be resolve using a PPI action, with the
+	// state transition action being "shutdown" rather than the more common
+	// "reboot".
+	errs := s.testRun(c, &testRunChecksContextRunParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithMockVars(efitest.MockVars{}.SetSecureBoot(false)),
+		),
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		ppi: &mockPPI{
+			sta: ppi.StateTransitionShutdownRequired,
+			ops: map[ppi.OperationId]ppi.OperationStatus{
+				ppi.OperationEnableTPM:         ppi.OperationPPRequired,
+				ppi.OperationEnableAndClearTPM: ppi.OperationPPRequired,
+				ppi.OperationClearTPM:          ppi.OperationPPRequired,
+			},
+		},
+		profileOpts: PCRProfileOptionsDefault,
+		iterations:  2,
+		prepare: func(i int) {
+			switch i {
+			case 0:
+				// Disable owner and endorsement hierarchies on the first iteration
+				c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
+				c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
+			}
+		},
+		actions: []actionAndArgs{
+			{action: ActionNone},
+			{action: ActionEnableTPMViaFirmware},
+		},
+	})
+	c.Assert(errs, HasLen, 1)
+	c.Check(errs[0], ErrorMatches, `a shutdown is required to complete the action`)
+	c.Check(errs[0], DeepEquals, NewWithKindAndActionsError(ErrorKindShutdownRequired, nil, []Action{ActionShutdown}, errs[0].Unwrap()))
 }

--- a/efi/preinstall/error_kinds.go
+++ b/efi/preinstall/error_kinds.go
@@ -65,6 +65,10 @@ const (
 	// - "reason": A string indicating the reason - invalid "type" or "value".
 	ErrorKindInvalidArgument ErrorKind = "invalid-argument"
 
+	// ErrorKindActionFailed indicates that the supplied action did not
+	// succeed for some reason.
+	ErrorKindActionFailed ErrorKind = "action-failed"
+
 	// ErrorKindRunningInVM indicates that the current environment is a
 	// virtal machine.
 	ErrorKindRunningInVM ErrorKind = "running-in-vm"

--- a/efi/preinstall/export_linux_test.go
+++ b/efi/preinstall/export_linux_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"github.com/canonical/go-tpm2/linux"
+	"github.com/canonical/go-tpm2/ppi"
+)
+
+var (
+	ObtainTPMDevicePPILinux = obtainTPMDevicePPILinux
+)
+
+func MockLinuxRawDevicePhysicalPresenceInterface(fn func(*linux.RawDevice) (ppi.PPI, error)) (restore func()) {
+	orig := linuxRawDevicePhysicalPresenceInterface
+	linuxRawDevicePhysicalPresenceInterface = fn
+	return func() {
+		linuxRawDevicePhysicalPresenceInterface = orig
+	}
+}
+
+func MockLinuxRMDeviceRawDevice(fn func(*linux.RMDevice) *linux.RawDevice) (restore func()) {
+	orig := linuxRMDeviceRawDevice
+	linuxRMDeviceRawDevice = fn
+	return func() {
+		linuxRMDeviceRawDevice = orig
+	}
+}

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -25,6 +25,8 @@ import (
 	"io"
 
 	efi "github.com/canonical/go-efilib"
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/ppi"
 	internal_efi "github.com/snapcore/secboot/internal/efi"
 	pe "github.com/snapcore/secboot/internal/pe1.14"
 )
@@ -85,6 +87,7 @@ var (
 	DetectVirtualization                                  = detectVirtualization
 	DetermineCPUVendor                                    = determineCPUVendor
 	IsLaunchedFromLoadOption                              = isLaunchedFromLoadOption
+	IsPPIActionAvailable                                  = isPPIActionAvailable
 	IsTPMDiscrete                                         = isTPMDiscrete
 	IsTPMDiscreteFromIntelBootGuard                       = isTPMDiscreteFromIntelBootGuard
 	JoinErrors                                            = joinErrors
@@ -94,6 +97,7 @@ var (
 	ReadIntelHFSTSRegistersFromMEISysfs                   = readIntelHFSTSRegistersFromMEISysfs
 	ReadIntelMEVersionFromMEISysfs                        = readIntelMEVersionFromMEISysfs
 	ReadLoadOptionFromLog                                 = readLoadOptionFromLog
+	RunPPIAction                                          = runPPIAction
 	UnwrapCompoundError                                   = unwrapCompoundError
 )
 
@@ -118,6 +122,14 @@ func MockKnownCAs(set AuthorityTrustDataSet) (restore func()) {
 	knownCAs = set
 	return func() {
 		knownCAs = orig
+	}
+}
+
+func MockObtainTPMDevicePPI(fn func(tpm2.TPMDevice) (ppi.PPI, error)) (restore func()) {
+	orig := obtainTPMDevicePPI
+	obtainTPMDevicePPI = fn
+	return func() {
+		obtainTPMDevicePPI = orig
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
 	github.com/canonical/go-tpm2 v1.13.0
 	github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981
+	github.com/jessevdk/go-flags v1.5.0
 	github.com/snapcore/snapd v0.0.0-20220714152900-4a1f4c93fc85
 	golang.org/x/crypto v0.23.0
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzr
 github.com/gorilla/mux v1.7.4-0.20190701202633-d83b6ffe499a/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gvalkov/golang-evdev v0.0.0-20191114124502-287e62b94bcb/go.mod h1:SAzVFKCRezozJTGavF3GX8MBUruETCqzivVLYiywouA=
 github.com/jessevdk/go-flags v1.4.1-0.20180927143258-7309ec74f752/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -62,6 +64,7 @@ golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=


### PR DESCRIPTION
There are some error kinds that don't necessarily have to be resolved
and don't have to prevent FDE from being enabled, but can be used to
provide information to a user so that they can evaluate them and
determine whether they would like to proceed at their own risk. Eg, if
the system is executing third party code before the OS and the user
cannot or does not want to disable it, then there is an increased risk
of PCR fragility as a result of those third party components being
updated by something other than the OS. If an error indicates that
pre-boot DMA remapping is disabled and the user cannot enable it, then
there is an increased risk of a locally present adversary obtaining
secrets or altering code execution via external ports.

This introduces a new action - `ActionProceed`, which can be executed only
if all of the previously returned error kinds permit this action. When
used, a CheckFlags flag will be added for each unresolved error kind,
which has the effect of ignoring those errors and making them warnings
instead.