### PR TITLE
efi: prefer firmware db for shim image verification

### DIFF
--- a/efi/shim_load_handler.go
+++ b/efi/shim_load_handler.go
@@ -283,7 +283,7 @@ func (m *shimImageLoadMeasurer) measurePEImageDigest() error {
 func (m *shimImageLoadMeasurer) measureVerification() error {
 	sc := m.ShimContext()
 
-	authority, err := m.DetermineAuthority([]*secureBootDB{sc.VendorDb, m.FwContext().Db}, m.image)
+	authority, err := m.DetermineAuthority([]*secureBootDB{m.FwContext().Db, sc.VendorDb}, m.image)
 	if err != nil {
 		return err
 	}

--- a/efi/shim_load_handler_test.go
+++ b/efi/shim_load_handler_test.go
@@ -602,3 +602,47 @@ func (s *shimLoadHandlerSuite) TestMeasureImageLoadBootManagerCodeProfile2(c *C)
 		},
 	})
 }
+
+func (s *shimLoadHandlerSuite) TestMeasureImageLoadSecureBootPolicyProfile15_7PrefersDb(c *C) {
+	verificationDigest := testutil.DecodeHexString(
+		c,
+		"50ebc322b94d41ad0cff5544d532207ba652eefe8c5d8aa27c2186f152fade9e",
+	)
+
+	s.testMeasureImageLoad(c, &testShimMeasureImageLoadData{
+		alg:  tpm2.HashAlgorithmSHA256,
+		pcrs: MakePcrFlags(internal_efi.SecureBootPolicyPCR),
+
+		db: efi.SignatureDatabase{
+			efitest.NewSignatureListX509(c, canonicalCACert, efi.GUID{}),
+		},
+
+		shimFlags: ShimHasSbatVerification |
+			ShimFixVariableAuthorityEventsMatchSpec |
+			ShimVendorCertContainsDb |
+			ShimHasSbatRevocationManagement,
+
+		vendorDb: &SecureBootDB{
+			Name: efi.VariableDescriptor{
+				Name: "MokListRT",
+				GUID: ShimGuid,
+			},
+			Contents: efi.SignatureDatabase{
+				efitest.NewSignatureListX509(c, canonicalCACert, ShimGuid),
+			},
+		},
+
+		image: newMockImage().appendSignatures(
+			efitest.ReadWinCertificateAuthenticodeDetached(c, grubUbuntuSig3),
+		),
+
+		expectedEvents: []*mockPcrBranchEvent{
+			{
+				pcr:       7,
+				eventType: mockPcrBranchExtendEvent,
+				digest:    verificationDigest,
+			},
+		},
+		verificationDigest: verificationDigest,
+	})
+}


### PR DESCRIPTION
## Summary

Prefer the firmware Secure Boot `db` over shim's built-in vendor database
when determining the authority used to verify an image loaded by shim.

When an image is trusted by both databases, shim may verify it using the
firmware `db`. Modeling the vendor database first can therefore select a
different authority from the one actually measured by firmware/shim,
causing the generated PCR 7 profile to differ from the real boot
measurement.

## Fix

Change the authority lookup order from:

    shim vendor DB, firmware db

to:

    firmware db, shim vendor DB

This makes the modeled verification authority match systems where the
image is authorized by the firmware `db`.

## Regression test

Added
`TestMeasureImageLoadSecureBootPolicyProfile15_7PrefersDb`.

The test configures both the firmware `db` and shim vendor database with
certificates that can authorize the image and verifies that the PCR 7
authority event is derived from the firmware `db`.

Before the change the test fails because the shim vendor database is
selected first. With the change it passes.

## Hardware validation

This was also validated end-to-end on an Ubuntu 26.04 system using
TPM-backed full-disk encryption.

Before the change, the generated PCR 7 profile selected the shim
`MokListRT` authority and did not match the actual PCR 7 value observed
after boot.

With firmware `db` preferred, the generated PCR 7 profile matched the
actual PCR 7 measurement, and a clean hardware-backed encrypted
installation subsequently unlocked automatically on first boot without
requiring the recovery key.

## Tests

Targeted regression test:

    go test ./efi \
      -check.f TestMeasureImageLoadSecureBootPolicyProfile15_7PrefersDb \
      -count=1

passes.

Running the full `./efi` suite produced:

    390 passed, 1 failed

The single failure is unrelated to this change:
`TestAddPCRProfileLoadFailsFromLeafImage` expects exactly 10 hexadecimal
digits in a pointer value in its error regex, while this environment
produced an 11-digit pointer value.